### PR TITLE
fix bug-道中战斗失败撤退

### DIFF
--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -321,7 +321,7 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
         self.device.stuck_record_clear()
         self.device.click_record_clear()
         exp_info = False  # This is for the white screen bug in game
-        get_urgent_commission = False
+        withdraw_stable_timer = Timer(2)
 
         for _ in self.loop():
 
@@ -335,18 +335,21 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
             # Withdraw
             if self._withdraw:
                 if self.appear_then_click(FLEET_SWITCH_CONFIRM, offset=(30, 30)):
+                    self.fleet_alive_multiple = False
+                    self._withdraw = False
                     continue
+                
+                if self.appear(WITHDRAW, offset=(30, 30)):
+                    if not withdraw_stable_timer.reached():
+                        continue
                 if not self.appear(WITHDRAW, offset=(30, 30)):
+                    withdraw_stable_timer.reset()
                     continue
 
-                logger.info(f'fleet_alive_multiple: {self.fleet_alive_multiple}')
                 self._withdraw = False
                 if self.config.Campaign_DefeatWithdraw or not self.fleet_alive_multiple:
                     self.withdraw()
                     break
-                elif get_urgent_commission:
-                    self.fleet_alive_multiple = False
-                    continue
                 else:
                     while True:
                         self.device.screenshot()
@@ -367,7 +370,6 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
             if self.handle_popup_confirm('AUTO_SEARCH_COMBAT_STATUS'):
                 continue
             if self.handle_urgent_commission():
-                get_urgent_commission = True
                 continue
             if self.handle_story_skip():
                 continue


### PR DESCRIPTION
由于出现bug，将道中战斗失败撤退的代码修改回原pr的代码。
<img width="1280" height="720" alt="2026-05-16_14-08-17-912057" src="https://github.com/user-attachments/assets/2a40ff5a-d9e9-4486-bdb2-dccadf799d21" />
[log.txt](https://github.com/user-attachments/files/27851532/log.txt)

原代码中`if self.appear_then_click(FLEET_SWITCH_CONFIRM, offset=(30, 30)):`的功能等价于
`if self.handle_urgent_commission():`。
我没测试出我写的代码的bug，于是复原了我的代码，若有发现bug请告知一下。

## Summary by Sourcery

恢复并调整战斗中撤退处理逻辑，以解决基于战败触发的撤退行为问题。

Bug 修复：
- 通过恢复到之前类似“紧急委托”的确认处理方式，并稳定撤退画面检测逻辑，修复战斗失败后错误的撤退流程。

增强：
- 通过在执行撤退操作前加入短暂的稳定计时器，提高撤退画面检测的稳定性和可靠性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore and adjust in-battle withdrawal handling logic to address issues with defeat-based retreat behavior.

Bug Fixes:
- Fix incorrect withdrawal flow after combat failure by reverting to the previous urgent-commission–equivalent confirmation handling and stabilizing detection of the withdraw screen.

Enhancements:
- Improve robustness of withdraw screen detection by introducing a short stability timer before proceeding with retreat actions.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

恢复并调整战斗中撤退处理逻辑，以解决基于战败触发的撤退行为问题。

Bug 修复：
- 通过恢复到之前类似“紧急委托”的确认处理方式，并稳定撤退画面检测逻辑，修复战斗失败后错误的撤退流程。

增强：
- 通过在执行撤退操作前加入短暂的稳定计时器，提高撤退画面检测的稳定性和可靠性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore and adjust in-battle withdrawal handling logic to address issues with defeat-based retreat behavior.

Bug Fixes:
- Fix incorrect withdrawal flow after combat failure by reverting to the previous urgent-commission–equivalent confirmation handling and stabilizing detection of the withdraw screen.

Enhancements:
- Improve robustness of withdraw screen detection by introducing a short stability timer before proceeding with retreat actions.

</details>

</details>