### PR TITLE
feat(os_handler): 新增处理指挥猫搜寻时退出海域的确认弹窗

### DIFF
--- a/module/os_handler/map_event.py
+++ b/module/os_handler/map_event.py
@@ -112,6 +112,12 @@ class MapEventHandler(EnemySearchingHandler):
         Returns:
             str: Event that handled
         """
+        # 优先处理阻塞性确认弹窗,避免卡住状态循环
+        # 处理指挥猫搜寻时退出海域的确认弹窗 (issue #100)
+        # 这类弹窗会阻止其他操作,必须优先处理
+        # handle_popup_confirm 的 name 参数仅用于日志记录,实际识别使用通用的 POPUP_CONFIRM 按钮
+        if self.handle_popup_confirm('DEPART_CONFIRM'):
+            return 'depart_confirm'
         if self.handle_map_get_items(drop=drop):
             return 'map_get_items'
         if self.handle_os_game_tips():
@@ -122,9 +128,6 @@ class MapEventHandler(EnemySearchingHandler):
             return 'guild_popup_cancel'
         if self.handle_ash_popup():
             return 'ash_popup'
-        # 处理指挥猫搜寻时退出海域的确认弹窗 (issue #100)
-        if self.handle_popup_confirm('DEPART_CONFIRM'):
-            return 'depart_confirm'
         if self.handle_urgent_commission(drop=drop):
             return 'urgent_commission'
         if self.handle_story_skip(drop=drop):

--- a/module/os_handler/map_event.py
+++ b/module/os_handler/map_event.py
@@ -122,6 +122,9 @@ class MapEventHandler(EnemySearchingHandler):
             return 'guild_popup_cancel'
         if self.handle_ash_popup():
             return 'ash_popup'
+        # 处理指挥猫搜寻时退出海域的确认弹窗 (issue #100)
+        if self.handle_popup_confirm('DEPART_CONFIRM'):
+            return 'depart_confirm'
         if self.handle_urgent_commission(drop=drop):
             return 'urgent_commission'
         if self.handle_story_skip(drop=drop):


### PR DESCRIPTION
修复issue #100中指挥猫搜寻阶段退出海域弹窗无法自动处理的问题

## Summary by Sourcery

错误修复：
- 在指挥官猫搜索阶段，自动处理离开海域确认弹窗（问题 #100）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Automatically process the exit sea-area confirmation popup during the commander cat search phase (issue #100).

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 在指挥官猫搜索阶段，自动处理离开海域确认弹窗（问题 #100）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Automatically process the exit sea-area confirmation popup during the commander cat search phase (issue #100).

</details>

</details>