### PR TITLE
fixbug，修复运行海里检测时错误将行动力识别为0，过滤掉0数值

### DIFF
--- a/module/os/tasks/hazard_leveling.py
+++ b/module/os/tasks/hazard_leveling.py
@@ -952,6 +952,36 @@ class OpsiHazard1Leveling(CoinTaskMixin, OSMap):
                 self.config.task_delay(server_update=True)
                 self.config.task_stop()
 
+    def _get_current_ap(self):
+        """
+        获取当前行动力
+        
+        Returns:
+            int: 当前行动力，失败时返回0
+        """
+        try:
+            logger.info("进入行动力弹窗")
+            self.action_point_enter()
+            
+            logger.info("获取行动力数据")
+            self.action_point_safe_get()
+            
+            ap_current = getattr(self, '_action_point_current', 0)
+            logger.info(f"当前行动力: {ap_current}")
+            
+            logger.info("退出行动力弹窗")
+            self.action_point_quit()
+            
+            return ap_current
+            
+        except Exception as e:
+            logger.error(f"获取行动力失败: {e}")
+            try:
+                self.action_point_quit()
+            except Exception:
+                pass
+            return 0
+
     def detect_and_record_sea_miles(self):
         """
         检测并记录海里数
@@ -966,6 +996,11 @@ class OpsiHazard1Leveling(CoinTaskMixin, OSMap):
             if not self.is_in_map():
                 logger.info("当前不在大世界地图，返回大世界地图")
                 self.ui_back(check_button=self.is_in_map)
+            
+            # 获取当前行动力
+            logger.info("获取当前行动力")
+            ap_current = self._get_current_ap()
+            logger.info(f"当前行动力: {ap_current}")
             
             logger.info("进入情报页面")
             skip_first_screenshot = True
@@ -999,7 +1034,7 @@ class OpsiHazard1Leveling(CoinTaskMixin, OSMap):
             from module.statistics.opsi_runtime import record_ap_snapshot
             record_ap_snapshot(
                 config=self.config,
-                ap_current=0,
+                ap_current=ap_current,
                 source='sea_miles',
                 distance=sea_miles
             )

--- a/module/os/tasks/hazard_leveling.py
+++ b/module/os/tasks/hazard_leveling.py
@@ -952,36 +952,6 @@ class OpsiHazard1Leveling(CoinTaskMixin, OSMap):
                 self.config.task_delay(server_update=True)
                 self.config.task_stop()
 
-    def _get_current_ap(self):
-        """
-        获取当前行动力
-        
-        Returns:
-            int: 当前行动力，失败时返回0
-        """
-        try:
-            logger.info("进入行动力弹窗")
-            self.action_point_enter()
-            
-            logger.info("获取行动力数据")
-            self.action_point_safe_get()
-            
-            ap_current = getattr(self, '_action_point_current', 0)
-            logger.info(f"当前行动力: {ap_current}")
-            
-            logger.info("退出行动力弹窗")
-            self.action_point_quit()
-            
-            return ap_current
-            
-        except Exception as e:
-            logger.error(f"获取行动力失败: {e}")
-            try:
-                self.action_point_quit()
-            except Exception:
-                pass
-            return 0
-
     def detect_and_record_sea_miles(self):
         """
         检测并记录海里数
@@ -996,11 +966,6 @@ class OpsiHazard1Leveling(CoinTaskMixin, OSMap):
             if not self.is_in_map():
                 logger.info("当前不在大世界地图，返回大世界地图")
                 self.ui_back(check_button=self.is_in_map)
-            
-            # 获取当前行动力
-            logger.info("获取当前行动力")
-            ap_current = self._get_current_ap()
-            logger.info(f"当前行动力: {ap_current}")
             
             logger.info("进入情报页面")
             skip_first_screenshot = True
@@ -1034,7 +999,7 @@ class OpsiHazard1Leveling(CoinTaskMixin, OSMap):
             from module.statistics.opsi_runtime import record_ap_snapshot
             record_ap_snapshot(
                 config=self.config,
-                ap_current=ap_current,
+                ap_current=0,
                 source='sea_miles',
                 distance=sea_miles
             )

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -492,13 +492,16 @@ class AlasGUI(Frame):
                     dt = _dt.fromisoformat(ts_raw)
                 except Exception:
                     continue
-                raw_points.append(
-                    {
-                        "dt": dt,
-                        "ap": int(pt.get("ap", 0)),
-                        "source": pt.get("source", "-"),
-                    }
-                )
+                ap_value = int(pt.get("ap", 0))
+                # 过滤掉ap=0的数据点（海里数检测时的占位数据）
+                if ap_value > 0:
+                    raw_points.append(
+                        {
+                            "dt": dt,
+                            "ap": ap_value,
+                            "source": pt.get("source", "-"),
+                        }
+                    )
 
             if not raw_points:
                 with use_scope("ap_chart", clear=True):


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 忽略 AP 图表数据中 AP 值为 0 的条目，以防止在检测海里数时误将当前行动点识别为 0。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ignore AP chart data entries where the AP value is 0 to prevent misidentifying the current action points as zero during sea-mile detection.

</details>