### PR TITLE
修复之前添加统计表格功能引发的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,4 @@ pyrightconfig.json
 /f
 /workers
 /debug_img
+.roomodes

--- a/module/statistics/cl1_database.py
+++ b/module/statistics/cl1_database.py
@@ -1002,15 +1002,15 @@ class Cl1Database:
         hazard_sample_total = 0
         hazard_round_samples: Dict[int, List[float]] = {3: [], 5: []}
         for entry in normalized_round_times:
-            hazard_level = entry.get("hazard_level")
-            if hazard_level in [2, 3, 4, 5, 6]:
+            entry_hazard_level = entry.get("hazard_level")
+            if entry_hazard_level in [2, 3, 4, 5, 6]:
                 hazard_sample_total += 1
-            if hazard_level in [3, 5]:
-                hazard_round_samples[hazard_level].append(entry["duration"])
+            if entry_hazard_level in [3, 5]:
+                hazard_round_samples[entry_hazard_level].append(entry["duration"])
 
         by_hazard: Dict[str, Dict[str, Any]] = {}
-        for hazard_level in [3, 5]:
-            key_name = str(hazard_level)
+        for target_hazard_level in [3, 5]:
+            key_name = str(target_hazard_level)
             bucket = hazard_stats.get(key_name, {})
 
             try:
@@ -1049,14 +1049,14 @@ class Cl1Database:
                     round(
                         battle_count
                         * (
-                            len(hazard_round_samples[hazard_level])
+                            len(hazard_round_samples[target_hazard_level])
                             / hazard_sample_total
                         )
                     )
                 )
                 estimated = True
 
-            battles_per_round = self._get_meow_battles_per_round(hazard_level) or 1
+            battles_per_round = self._get_meow_battles_per_round(target_hazard_level) or 1
             if hz_effective_rounds <= 0 and hz_battle_count > 0:
                 hz_effective_rounds = hz_battle_count / battles_per_round
                 estimated = True
@@ -1084,7 +1084,7 @@ class Cl1Database:
                 source = "none"
 
             by_hazard[key_name] = {
-                "hazard_level": hazard_level,
+                "hazard_level": target_hazard_level,
                 "battle_count": hz_battle_count,
                 "effective_rounds": round(hz_effective_rounds, 2),
                 "avg_round_time": hz_avg_round_time,

--- a/module/statistics/cl1_database.py
+++ b/module/statistics/cl1_database.py
@@ -594,7 +594,9 @@ class Cl1Database:
                 pass
 
         # 资产 = AP × 效率 + 黄币
-        asset = ap_current * cl5_efficiency + yellow_coin
+        # 优先使用 ap_total（含箱子），不存在时回退到 ap_current
+        ap_for_calc = ap_total if ap_total is not None and ap_total > 0 else ap_current
+        asset = ap_for_calc * cl5_efficiency + yellow_coin
         # 虚拟资产 = 资产 + 时间加成
         virtual_asset = asset + virtual_asset_added
 

--- a/module/statistics/cl1_database.py
+++ b/module/statistics/cl1_database.py
@@ -1032,7 +1032,7 @@ class Cl1Database:
                 float(v) for v in hz_round_times if isinstance(v, (int, float))
             ]
             if not hz_round_times:
-                hz_round_times = hazard_round_samples[hazard_level]
+                hz_round_times = hazard_round_samples[target_hazard_level]
 
             hz_battle_times = (
                 bucket.get("battle_times", [])

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -1617,7 +1617,7 @@ class AlasGUI(Frame):
 
                         ap_timeline = get_ap_timeline(instance_name=instance_name_stat)
                         current_ap = (
-                            int(ap_timeline[-1].get("ap", 0)) if ap_timeline else 0
+                            int(ap_timeline[-1].get("ap_total", ap_timeline[-1].get("ap", 0))) if ap_timeline else 0
                         )
 
                         meow_round_ap = 30

--- a/webapp/ap_chart.js
+++ b/webapp/ap_chart.js
@@ -301,7 +301,6 @@
             }
         }
 
-        // ---- 绘制系列线（紫币独立 Y 轴，黄币/虚拟资产/资产共用组合 Y 轴） ----
         function drawSeriesLine(xOf, start, end) {
             for (var ci = 0; ci < SERIES_DRAW.length; ci++) {
                 var sd = SERIES_DRAW[ci];
@@ -315,11 +314,43 @@
                 ctx.beginPath();
                 var started = false;
 
-                for (var i = start; i < end && i < sd.data.length; i++) {
-                    if (sd.data[i] === null || sd.data[i] === undefined) { started = false; continue; }
-                    var x = xOf(i), y = sd.yFn(sd.data[i]);
-                    if (!started) { ctx.moveTo(x, y); started = true; }
-                    else { ctx.lineTo(x, y); }
+                if (sd.ts && sd.ts.length > 0) {
+                    var tsMap = {};
+                    for (var k = start; k < end && k < apTs.length; k++) {
+                        tsMap[apTs[k]] = k;
+                    }
+                    
+                    for (var j = 0; j < sd.data.length; j++) {
+                        if (sd.data[j] === null || sd.data[j] === undefined) { started = false; continue; }
+                        
+                        var dataTs = sd.ts[j];
+                        var closestIdx = -1;
+                        var minDiff = Infinity;
+                        
+                        for (var k = start; k < end && k < apTs.length; k++) {
+                            var diff = Math.abs(apTs[k] - dataTs);
+                            if (diff < minDiff) {
+                                minDiff = diff;
+                                closestIdx = k;
+                            }
+                            if (diff === 0) break;
+                        }
+                        
+                        if (closestIdx !== -1 && minDiff < 600000) {
+                            var x = xOf(closestIdx), y = sd.yFn(sd.data[j]);
+                            if (!started) { ctx.moveTo(x, y); started = true; }
+                            else { ctx.lineTo(x, y); }
+                        } else {
+                            started = false;
+                        }
+                    }
+                } else {
+                    for (var i = start; i < end && i < sd.data.length; i++) {
+                        if (sd.data[i] === null || sd.data[i] === undefined) { started = false; continue; }
+                        var x = xOf(i), y = sd.yFn(sd.data[i]);
+                        if (!started) { ctx.moveTo(x, y); started = true; }
+                        else { ctx.lineTo(x, y); }
+                    }
                 }
                 ctx.stroke();
             }
@@ -530,22 +561,24 @@
                 if (hasYellowCoins && idx < yellowCoinsLen && yellowCoins[idx] !== null && yellowCoins[idx] !== undefined && seriesVisible[2])
                     drawBead(yellowCoins[idx], "#ffd54f", yOfCombined);
 
-                if (seriesVisible[3] && hasVirtualAssetSeries) {
-                    var closestIdx_va = -1, closestDist_va = 600000;
+                if (seriesVisible[3] && hasVirtualAssetSeries && idx < apTs.length) {
+                    var currentTs = apTs[idx];
+                    var closestIdx_va = -1, closestDist_va = Infinity;
                     for (var j = 0; j < lineVirtualAssetTs.length; j++) {
-                        var dist = Math.abs(idx - j);
+                        var dist = Math.abs(currentTs - lineVirtualAssetTs[j]);
                         if (dist < closestDist_va) { closestDist_va = dist; closestIdx_va = j; }
                     }
-                    if (closestIdx_va !== -1 && closestDist_va < 5)
+                    if (closestIdx_va !== -1 && closestDist_va < 600000)
                         drawBead(lineVirtualAsset[closestIdx_va], "#4fc3f7", yOfVirtualAsset);
                 }
-                if (seriesVisible[4] && hasAssetSeries) {
-                    var closestIdx_a = -1, closestDist_a = 600000;
+                if (seriesVisible[4] && hasAssetSeries && idx < apTs.length) {
+                    var currentTs = apTs[idx];
+                    var closestIdx_a = -1, closestDist_a = Infinity;
                     for (var j = 0; j < lineAssetTs.length; j++) {
-                        var dist = Math.abs(idx - j);
+                        var dist = Math.abs(currentTs - lineAssetTs[j]);
                         if (dist < closestDist_a) { closestDist_a = dist; closestIdx_a = j; }
                     }
-                    if (closestIdx_a !== -1 && closestDist_a < 5)
+                    if (closestIdx_a !== -1 && closestDist_a < 600000)
                         drawBead(lineAsset[closestIdx_a], "#81c784", yOfAsset);
                 }
 
@@ -592,25 +625,27 @@
                 }
 
                 // 虚拟资产 tooltip
-                if (seriesVisible[3] && hasVirtualAssetSeries) {
+                if (seriesVisible[3] && hasVirtualAssetSeries && idx < apTs.length) {
+                    var currentTs = apTs[idx];
                     var closestIdx = -1, closestDist = 600000;
                     for (var j = 0; j < lineVirtualAssetTs.length; j++) {
-                        var dist = Math.abs(idx - j);
+                        var dist = Math.abs(currentTs - lineVirtualAssetTs[j]);
                         if (dist < closestDist) { closestDist = dist; closestIdx = j; }
                     }
-                    if (closestIdx !== -1 && closestDist < 5) {
+                    if (closestIdx !== -1 && closestDist < 600000) {
                         tooltipRows.push({ parts: [{ type: 'text', value: "虚拟资产: " }, { type: 'bold', value: lineVirtualAsset[closestIdx].toFixed(1), style: { color: "#4fc3f7" } }] });
                     }
                 }
 
                 // 资产 tooltip
-                if (seriesVisible[4] && hasAssetSeries) {
+                if (seriesVisible[4] && hasAssetSeries && idx < apTs.length) {
+                    var currentTs = apTs[idx];
                     var closestIdx = -1, closestDist = 600000;
                     for (var j = 0; j < lineAssetTs.length; j++) {
-                        var dist = Math.abs(idx - j);
+                        var dist = Math.abs(currentTs - lineAssetTs[j]);
                         if (dist < closestDist) { closestDist = dist; closestIdx = j; }
                     }
-                    if (closestIdx !== -1 && closestDist < 5) {
+                    if (closestIdx !== -1 && closestDist < 600000) {
                         tooltipRows.push({ parts: [{ type: 'text', value: "资产: " }, { type: 'bold', value: lineAsset[closestIdx].toFixed(1), style: { color: "#81c784" } }] });
                     }
                 }

--- a/webapp/ap_chart.js
+++ b/webapp/ap_chart.js
@@ -201,26 +201,32 @@
         }
         
         // ---- 虚拟资产独立范围（用于左侧刻度） ----
-        var virtualAssetMin = 0, virtualAssetMax = -Infinity;
+        var virtualAssetMin = Infinity, virtualAssetMax = -Infinity;
         if (hasVirtualAssetSeries) {
             for (var i = 0; i < lineVirtualAsset.length; i++) {
                 if (lineVirtualAsset[i] === null || lineVirtualAsset[i] === undefined) continue;
+                if (lineVirtualAsset[i] < virtualAssetMin) virtualAssetMin = lineVirtualAsset[i];
                 if (lineVirtualAsset[i] > virtualAssetMax) virtualAssetMax = lineVirtualAsset[i];
             }
+            if (virtualAssetMin === Infinity) virtualAssetMin = 0;
             if (virtualAssetMax === -Infinity) virtualAssetMax = 1000;
             var virtualAssetRng = virtualAssetMax - virtualAssetMin || 1;
+            virtualAssetMin -= virtualAssetRng * 0.08;
             virtualAssetMax += virtualAssetRng * 0.08;
         }
         
         // ---- 资产独立范围（用于左侧刻度） ----
-        var assetMin = 0, assetMax = -Infinity;
+        var assetMin = Infinity, assetMax = -Infinity;
         if (hasAssetSeries) {
             for (var i = 0; i < lineAsset.length; i++) {
                 if (lineAsset[i] === null || lineAsset[i] === undefined) continue;
+                if (lineAsset[i] < assetMin) assetMin = lineAsset[i];
                 if (lineAsset[i] > assetMax) assetMax = lineAsset[i];
             }
+            if (assetMin === Infinity) assetMin = 0;
             if (assetMax === -Infinity) assetMax = 1000;
             var assetRng = assetMax - assetMin || 1;
+            assetMin -= assetRng * 0.08;
             assetMax += assetRng * 0.08;
         }
 

--- a/webapp/ap_chart.js
+++ b/webapp/ap_chart.js
@@ -182,8 +182,8 @@
 
         // ---- 紫币独立轴 ----
         var hasPurpleAxis = showCoins && chartType === 'line' && hasPurpleCoins;
-        // ---- 组合轴（黄币 + 虚拟资产 + 资产共用） ----
-        var hasCombined = showCoins && chartType === 'line' && (hasYellowCoins || hasVirtualAssetSeries || hasAssetSeries);
+        // ---- 组合轴（仅黄币使用，虚拟资产和资产已独立） ----
+        var hasCombined = showCoins && chartType === 'line' && hasYellowCoins;
         // ---- 海里数独立轴 ----
         var hasDistanceAxis = showCoins && chartType === 'line' && hasDistanceSeries;
         var hasExtra = hasPurpleAxis || hasCombined || hasDistanceAxis;
@@ -195,9 +195,8 @@
             }
         }
         if (hasCombined) {
+            // 只扫描黄币数据，虚拟资产和资产已使用独立Y轴
             if (hasYellowCoins) scanRange(yellowCoins);
-            if (hasVirtualAssetSeries) scanRange(lineVirtualAsset);
-            if (hasAssetSeries) scanRange(lineAsset);
             if (combinedMax === -Infinity) combinedMax = 1000;
             var combinedRng = combinedMax - combinedMin || 1;
             combinedMax += combinedRng * 0.08;
@@ -283,17 +282,19 @@
                 var mainVal = mainMin + (mainMax - mainMin) * (i / TICK_CONFIG.count);
                 var y = yOfMain(mainVal);
                 
-                // 绘制虚拟资产刻度（使用独立Y轴的数值）
+                // 绘制虚拟资产刻度（使用独立Y轴的数值，在行动力刻度下方）
                 if (hasVirtualAssetSeries) {
                     var vaVal = virtualAssetMin + (virtualAssetMax - virtualAssetMin) * (i / TICK_CONFIG.count);
                     ctx.fillStyle = "#06b6d4";
+                    // 使用与右侧刻度相同的间距配置，确保不重叠
                     ctx.fillText(Math.round(vaVal), pad.l - TICK_CONFIG.x, y + TICK_CONFIG.baseline + TICK_CONFIG.stackGap);
                 }
                 
-                // 绘制资产刻度（使用独立Y轴的数值）
+                // 绘制资产刻度（使用独立Y轴的数值，在虚拟资产刻度下方）
                 if (hasAssetSeries) {
                     var aVal = assetMin + (assetMax - assetMin) * (i / TICK_CONFIG.count);
                     ctx.fillStyle = "#81c784";
+                    // 如果有虚拟资产，资产刻度在虚拟资产下方；否则直接在行动力下方
                     var offsetY = hasVirtualAssetSeries ? TICK_CONFIG.stackGap * 2 : TICK_CONFIG.stackGap;
                     ctx.fillText(Math.round(aVal), pad.l - TICK_CONFIG.x, y + TICK_CONFIG.baseline + offsetY);
                 }

--- a/webapp/ap_chart.js
+++ b/webapp/ap_chart.js
@@ -315,11 +315,6 @@
                 var started = false;
 
                 if (sd.ts && sd.ts.length > 0) {
-                    var tsMap = {};
-                    for (var k = start; k < end && k < apTs.length; k++) {
-                        tsMap[apTs[k]] = k;
-                    }
-                    
                     for (var j = 0; j < sd.data.length; j++) {
                         if (sd.data[j] === null || sd.data[j] === undefined) { started = false; continue; }
                         

--- a/webapp/ap_chart.js
+++ b/webapp/ap_chart.js
@@ -186,15 +186,42 @@
         }
         
         // ---- 海里数独立范围 ----
-        var distanceMin = 0, distanceMax = -Infinity;
+        var distanceMin = Infinity, distanceMax = -Infinity;
         if (hasDistanceAxis) {
             for (var i = 0; i < lineDistance.length; i++) {
                 if (lineDistance[i] === null || lineDistance[i] === undefined) continue;
+                if (lineDistance[i] < distanceMin) distanceMin = lineDistance[i];
                 if (lineDistance[i] > distanceMax) distanceMax = lineDistance[i];
             }
+            if (distanceMin === Infinity) distanceMin = 0;
             if (distanceMax === -Infinity) distanceMax = 1000;
             var distanceRng = distanceMax - distanceMin || 1;
+            distanceMin -= distanceRng * 0.08;
             distanceMax += distanceRng * 0.08;
+        }
+        
+        // ---- 虚拟资产独立范围（用于左侧刻度） ----
+        var virtualAssetMin = 0, virtualAssetMax = -Infinity;
+        if (hasVirtualAssetSeries) {
+            for (var i = 0; i < lineVirtualAsset.length; i++) {
+                if (lineVirtualAsset[i] === null || lineVirtualAsset[i] === undefined) continue;
+                if (lineVirtualAsset[i] > virtualAssetMax) virtualAssetMax = lineVirtualAsset[i];
+            }
+            if (virtualAssetMax === -Infinity) virtualAssetMax = 1000;
+            var virtualAssetRng = virtualAssetMax - virtualAssetMin || 1;
+            virtualAssetMax += virtualAssetRng * 0.08;
+        }
+        
+        // ---- 资产独立范围（用于左侧刻度） ----
+        var assetMin = 0, assetMax = -Infinity;
+        if (hasAssetSeries) {
+            for (var i = 0; i < lineAsset.length; i++) {
+                if (lineAsset[i] === null || lineAsset[i] === undefined) continue;
+                if (lineAsset[i] > assetMax) assetMax = lineAsset[i];
+            }
+            if (assetMax === -Infinity) assetMax = 1000;
+            var assetRng = assetMax - assetMin || 1;
+            assetMax += assetRng * 0.08;
         }
 
         // 刻度配置（右侧标签）：第1行紫币独立，第2行黄币代表合并轴，第3行海里数独立
@@ -248,38 +275,31 @@
             }
         }
 
-        // 绘制左侧资产刻度标签（虚拟资产和资产）
-        function drawLeftAssetTicks(ctx, yFn, dataMin, dataMax) {
+        // 绘制左侧资产刻度标签（虚拟资产和资产都在行动力刻度下方垂直紧贴排列）
+        function drawLeftAssetTicks(ctx, yOfMain, mainMin, mainMax) {
             if (!hasLeftAssets) return;
             ctx.font = "10px -apple-system, sans-serif";
             ctx.textAlign = "right";
-            var leftAssetConfigs = [];
-            var leftOffset = 0;
             
-            // 虚拟资产配置
-            if (hasVirtualAssetSeries) {
-                leftAssetConfigs.push({
-                    color: "#06b6d4",
-                    offsetY: leftOffset
-                });
-                leftOffset += LEFT_ASSET_TICK_STACK_GAP;
-            }
-            
-            // 资产配置
-            if (hasAssetSeries) {
-                leftAssetConfigs.push({
-                    color: "#22d3ee",
-                    offsetY: leftOffset
-                });
-            }
-            
+            // 使用体力轴的Y坐标，与体力刻度对齐
             for (var i = 0; i <= 5; i++) {
-                var val = dataMin + (dataMax - dataMin) * (i / 5);
-                var y = yFn(val);
-                for (var ci = 0; ci < leftAssetConfigs.length; ci++) {
-                    var cfg = leftAssetConfigs[ci];
-                    ctx.fillStyle = cfg.color;
-                    ctx.fillText(Math.round(val), pad.l - LEFT_ASSET_TICK_X, y + LEFT_ASSET_TICK_BASELINE + cfg.offsetY);
+                // 使用体力轴计算统一的Y坐标
+                var mainVal = mainMin + (mainMax - mainMin) * (i / 5);
+                var y = yOfMain(mainVal);
+                
+                // 绘制虚拟资产刻度（在体力刻度下方第一行）
+                if (hasVirtualAssetSeries) {
+                    var vaVal = virtualAssetMin + (virtualAssetMax - virtualAssetMin) * (i / 5);
+                    ctx.fillStyle = "#06b6d4";
+                    ctx.fillText(Math.round(vaVal), pad.l - LEFT_ASSET_TICK_X, y + LEFT_ASSET_TICK_BASELINE + LEFT_ASSET_TICK_STACK_GAP);
+                }
+                
+                // 绘制资产刻度（在体力刻度下方第二行，虚拟资产下方）
+                if (hasAssetSeries) {
+                    var aVal = assetMin + (assetMax - assetMin) * (i / 5);
+                    ctx.fillStyle = "#81c784";
+                    var offsetY = hasVirtualAssetSeries ? LEFT_ASSET_TICK_STACK_GAP * 2 : LEFT_ASSET_TICK_STACK_GAP;
+                    ctx.fillText(Math.round(aVal), pad.l - LEFT_ASSET_TICK_X, y + LEFT_ASSET_TICK_BASELINE + offsetY);
                 }
             }
         }
@@ -331,7 +351,7 @@
         }
 
         drawAssetTicks(ctx, yOf, allMin, allMax);
-        drawLeftAssetTicks(ctx, yOfCombined, combinedMin, combinedMax);
+        drawLeftAssetTicks(ctx, yOf, allMin, allMax);
 
         var avgY = yOf(avg);
         ctx.save();
@@ -764,10 +784,8 @@
 
                 drawAssetTicks(ctx, dyOf, dMin, dMax);
                 
-                // 绘制左侧资产刻度（使用组合轴的范围）
-                if (hasLeftAssets && hasCombined) {
-                    drawLeftAssetTicks(ctx, yOfCombined, combinedMin, combinedMax);
-                }
+                // 绘制左侧资产刻度
+                drawLeftAssetTicks(ctx, dyOf, dMin, dMax);
 
                 // Ap 线
                 if (seriesVisible[0]) {

--- a/webapp/ap_chart.js
+++ b/webapp/ap_chart.js
@@ -99,20 +99,28 @@
         ctx.scale(dpr, dpr);
         var oc = ovCv.getContext("2d");
 
-        // 硬币刻度标签布局常量
-        var COIN_TICK_X = 8;
-        var COIN_TICK_BASELINE = 4;
-        var COIN_TICK_STACK_GAP = 11;
-
-        // 左侧资产刻度标签布局常量
-        var LEFT_ASSET_TICK_X = 8;
-        var LEFT_ASSET_TICK_BASELINE = 4;
-        var LEFT_ASSET_TICK_STACK_GAP = 11;
+        // 刻度标签布局常量（统一管理，左右两侧保持一致）
+        var TICK_CONFIG = {
+            x: 8,                    // 刻度标签距离边界的水平距离
+            baseline: 4,             // 刻度标签的垂直基线偏移
+            stackGap: 11,            // 多行刻度标签之间的垂直间距
+            count: 5,                // 刻度数量（0-5共6个刻度）
+            padding: 0.08            // 数据范围两端的留白比例
+        };
+        
+        // 边距配置常量
+        var PADDING_CONFIG = {
+            base: 52,                // 基础边距
+            extended: 110,           // 扩展边距（有额外刻度时）
+            top: 20,
+            bottom: 52
+        };
 
         // 根据是否有资产数据动态调整左侧边距
         var hasLeftAssets = hasVirtualAssetSeries || hasAssetSeries;
-        var leftPadding = hasLeftAssets ? 110 : 52;
-        pad = { t: 20, r: showCoins ? 110 : 20, b: 52, l: leftPadding };
+        var leftPadding = hasLeftAssets ? PADDING_CONFIG.extended : PADDING_CONFIG.base;
+        var rightPadding = showCoins ? PADDING_CONFIG.extended : PADDING_CONFIG.base;
+        pad = { t: PADDING_CONFIG.top, r: rightPadding, b: PADDING_CONFIG.bottom, l: leftPadding };
         gW = W - pad.l - pad.r;
         gH = H - pad.t - pad.b;
 
@@ -131,36 +139,46 @@
         var allRng = allMax - allMin || 1;
         allMax += allRng * 0.08;
 
-        // ---- 黄币独立范围 ----
-        var yellowMin = Infinity, yellowMax = -Infinity;
-        var yellowCoinsLen = yellowCoins ? yellowCoins.length : 0;
-        var hasYellowCoins = showCoins && chartType === 'line' && yellowCoinsLen > 0;
-        if (hasYellowCoins) {
-            for (var i = 0; i < yellowCoinsLen; i++) {
-                if (yellowCoins[i] === null || yellowCoins[i] === undefined) continue;
-                if (yellowCoins[i] < yellowMin) yellowMin = yellowCoins[i];
-                if (yellowCoins[i] > yellowMax) yellowMax = yellowCoins[i];
+        // 通用范围计算辅助函数
+        function computeRangeWithPadding(dataArray, options) {
+            options = options || {};
+            var fixMinToZero = options.fixMinToZero || false;
+            var defaultMin = options.defaultMin !== undefined ? options.defaultMin : 0;
+            var defaultMax = options.defaultMax !== undefined ? options.defaultMax : 1000;
+            var paddingRatio = options.paddingRatio !== undefined ? options.paddingRatio : TICK_CONFIG.padding;
+            
+            var min = fixMinToZero ? 0 : Infinity;
+            var max = -Infinity;
+            
+            for (var i = 0; i < dataArray.length; i++) {
+                if (dataArray[i] === null || dataArray[i] === undefined) continue;
+                if (!fixMinToZero && dataArray[i] < min) min = dataArray[i];
+                if (dataArray[i] > max) max = dataArray[i];
             }
-            if (yellowMin === Infinity) yellowMin = 0;
-            if (yellowMax === -Infinity) yellowMax = 1000;
-            var yellowRng = yellowMax - yellowMin || 1;
-            yellowMin -= yellowRng * 0.08;
-            yellowMax += yellowRng * 0.08;
+            
+            if (!fixMinToZero && min === Infinity) min = defaultMin;
+            if (max === -Infinity) max = defaultMax;
+            
+            var range = max - min || 1;
+            if (!fixMinToZero) min -= range * paddingRatio;
+            max += range * paddingRatio;
+            
+            return { min: min, max: max };
         }
 
+        // ---- 黄币独立范围 ----
+        var yellowCoinsLen = yellowCoins ? yellowCoins.length : 0;
+        var hasYellowCoins = showCoins && chartType === 'line' && yellowCoinsLen > 0;
+        var yellowRange = hasYellowCoins ? computeRangeWithPadding(yellowCoins) : { min: 0, max: 1000 };
+        var yellowMin = yellowRange.min;
+        var yellowMax = yellowRange.max;
+
         // ---- 紫币独立范围（最小值固定 0） ----
-        var purpleMin = 0, purpleMax = -Infinity;
         var purpleCoinsLen = purpleCoins ? purpleCoins.length : 0;
         var hasPurpleCoins = showCoins && chartType === 'line' && purpleCoinsLen > 0;
-        if (hasPurpleCoins) {
-            for (var i = 0; i < purpleCoinsLen; i++) {
-                if (purpleCoins[i] === null || purpleCoins[i] === undefined) continue;
-                if (purpleCoins[i] > purpleMax) purpleMax = purpleCoins[i];
-            }
-            if (purpleMax === -Infinity) purpleMax = 1000;
-            var purpleRng = purpleMax - purpleMin || 1;
-            purpleMax += purpleRng * 0.08;
-        }
+        var purpleRange = hasPurpleCoins ? computeRangeWithPadding(purpleCoins, { fixMinToZero: true }) : { min: 0, max: 1000 };
+        var purpleMin = purpleRange.min;
+        var purpleMax = purpleRange.max;
 
         // ---- 紫币独立轴 ----
         var hasPurpleAxis = showCoins && chartType === 'line' && hasPurpleCoins;
@@ -186,49 +204,19 @@
         }
         
         // ---- 海里数独立范围 ----
-        var distanceMin = Infinity, distanceMax = -Infinity;
-        if (hasDistanceAxis) {
-            for (var i = 0; i < lineDistance.length; i++) {
-                if (lineDistance[i] === null || lineDistance[i] === undefined) continue;
-                if (lineDistance[i] < distanceMin) distanceMin = lineDistance[i];
-                if (lineDistance[i] > distanceMax) distanceMax = lineDistance[i];
-            }
-            if (distanceMin === Infinity) distanceMin = 0;
-            if (distanceMax === -Infinity) distanceMax = 1000;
-            var distanceRng = distanceMax - distanceMin || 1;
-            distanceMin -= distanceRng * 0.08;
-            distanceMax += distanceRng * 0.08;
-        }
+        var distanceRange = hasDistanceAxis ? computeRangeWithPadding(lineDistance) : { min: 0, max: 1000 };
+        var distanceMin = distanceRange.min;
+        var distanceMax = distanceRange.max;
         
         // ---- 虚拟资产独立范围（用于左侧刻度） ----
-        var virtualAssetMin = Infinity, virtualAssetMax = -Infinity;
-        if (hasVirtualAssetSeries) {
-            for (var i = 0; i < lineVirtualAsset.length; i++) {
-                if (lineVirtualAsset[i] === null || lineVirtualAsset[i] === undefined) continue;
-                if (lineVirtualAsset[i] < virtualAssetMin) virtualAssetMin = lineVirtualAsset[i];
-                if (lineVirtualAsset[i] > virtualAssetMax) virtualAssetMax = lineVirtualAsset[i];
-            }
-            if (virtualAssetMin === Infinity) virtualAssetMin = 0;
-            if (virtualAssetMax === -Infinity) virtualAssetMax = 1000;
-            var virtualAssetRng = virtualAssetMax - virtualAssetMin || 1;
-            virtualAssetMin -= virtualAssetRng * 0.08;
-            virtualAssetMax += virtualAssetRng * 0.08;
-        }
+        var virtualAssetRange = hasVirtualAssetSeries ? computeRangeWithPadding(lineVirtualAsset) : { min: 0, max: 1000 };
+        var virtualAssetMin = virtualAssetRange.min;
+        var virtualAssetMax = virtualAssetRange.max;
         
         // ---- 资产独立范围（用于左侧刻度） ----
-        var assetMin = Infinity, assetMax = -Infinity;
-        if (hasAssetSeries) {
-            for (var i = 0; i < lineAsset.length; i++) {
-                if (lineAsset[i] === null || lineAsset[i] === undefined) continue;
-                if (lineAsset[i] < assetMin) assetMin = lineAsset[i];
-                if (lineAsset[i] > assetMax) assetMax = lineAsset[i];
-            }
-            if (assetMin === Infinity) assetMin = 0;
-            if (assetMax === -Infinity) assetMax = 1000;
-            var assetRng = assetMax - assetMin || 1;
-            assetMin -= assetRng * 0.08;
-            assetMax += assetRng * 0.08;
-        }
+        var assetRange = hasAssetSeries ? computeRangeWithPadding(lineAsset) : { min: 0, max: 1000 };
+        var assetMin = assetRange.min;
+        var assetMax = assetRange.max;
 
         // 刻度配置（右侧标签）：第1行紫币独立，第2行黄币代表合并轴，第3行海里数独立
         var EXTRA_SERIES_CONFIGS = [];
@@ -236,18 +224,18 @@
         function addCfg(has, color, dataMin, dataMax) {
             if (!has) return;
             EXTRA_SERIES_CONFIGS.push({ color: color, dataMin: dataMin, dataMax: dataMax, offsetY: cfgOffset });
-            cfgOffset += COIN_TICK_STACK_GAP;
+            cfgOffset += TICK_CONFIG.stackGap;
         }
         addCfg(hasPurpleCoins, "#ce93d8", purpleMin, purpleMax);
         addCfg(hasCombined, "#ffd54f", combinedMin, combinedMax);
         addCfg(hasDistanceAxis, "#1565c0", distanceMin, distanceMax);
 
-        // 系列绘制配置（所有线都要画，虚拟/资产用时间戳）
+        // 系列绘制配置（所有线都要画，虚拟/资产用时间戳和独立Y轴）
         var SERIES_DRAW = [
             { has: hasPurpleCoins, data: purpleCoins, yFn: yOfPurple, dash: [] },
             { has: hasYellowCoins, data: yellowCoins, yFn: yOfCombined, dash: [] },
-            { has: hasVirtualAssetSeries, data: lineVirtualAsset, ts: lineVirtualAssetTs, yFn: yOfCombined, dash: [] },
-            { has: hasAssetSeries, data: lineAsset, ts: lineAssetTs, yFn: yOfCombined, dash: [] },
+            { has: hasVirtualAssetSeries, data: lineVirtualAsset, ts: lineVirtualAssetTs, yFn: yOfVirtualAsset, dash: [] },
+            { has: hasAssetSeries, data: lineAsset, ts: lineAssetTs, yFn: yOfAsset, dash: [] },
             { has: hasDistanceSeries, data: lineDistance, yFn: yOfDistance, dash: [] },
         ];
 
@@ -259,6 +247,8 @@
         function yOfPurple(v) { return yScale(v, purpleMin, purpleMax); }
         function yOfCombined(v) { return yScale(v, combinedMin, combinedMax); }
         function yOfDistance(v) { return yScale(v, distanceMin, distanceMax); }
+        function yOfVirtualAsset(v) { return yScale(v, virtualAssetMin, virtualAssetMax); }
+        function yOfAsset(v) { return yScale(v, assetMin, assetMax); }
 
         // 时间感知的 x 坐标映射
         function xOfLine(i) {
@@ -269,43 +259,43 @@
             if (!hasExtra) return;
             ctx.font = "10px -apple-system, sans-serif";
             ctx.textAlign = "left";
-            for (var i = 0; i <= 5; i++) {
-                var mainVal = mainMin + (mainMax - mainMin) * (i / 5);
+            for (var i = 0; i <= TICK_CONFIG.count; i++) {
+                var mainVal = mainMin + (mainMax - mainMin) * (i / TICK_CONFIG.count);
                 var y = yOfMain(mainVal);
                 for (var ci = 0; ci < EXTRA_SERIES_CONFIGS.length; ci++) {
                     var cfg = EXTRA_SERIES_CONFIGS[ci];
-                    var val = cfg.dataMin + (cfg.dataMax - cfg.dataMin) * (i / 5);
+                    var val = cfg.dataMin + (cfg.dataMax - cfg.dataMin) * (i / TICK_CONFIG.count);
                     ctx.fillStyle = cfg.color;
-                    ctx.fillText(Math.round(val), W - pad.r + COIN_TICK_X, y + COIN_TICK_BASELINE + cfg.offsetY);
+                    ctx.fillText(Math.round(val), W - pad.r + TICK_CONFIG.x, y + TICK_CONFIG.baseline + cfg.offsetY);
                 }
             }
         }
 
         // 绘制左侧资产刻度标签（虚拟资产和资产都在行动力刻度下方垂直紧贴排列）
+        // 虚拟资产和资产使用各自独立的Y轴，显示各自的数值范围
         function drawLeftAssetTicks(ctx, yOfMain, mainMin, mainMax) {
             if (!hasLeftAssets) return;
             ctx.font = "10px -apple-system, sans-serif";
             ctx.textAlign = "right";
             
             // 使用体力轴的Y坐标，与体力刻度对齐
-            for (var i = 0; i <= 5; i++) {
-                // 使用体力轴计算统一的Y坐标
-                var mainVal = mainMin + (mainMax - mainMin) * (i / 5);
+            for (var i = 0; i <= TICK_CONFIG.count; i++) {
+                var mainVal = mainMin + (mainMax - mainMin) * (i / TICK_CONFIG.count);
                 var y = yOfMain(mainVal);
                 
-                // 绘制虚拟资产刻度（在体力刻度下方第一行）
+                // 绘制虚拟资产刻度（使用独立Y轴的数值）
                 if (hasVirtualAssetSeries) {
-                    var vaVal = virtualAssetMin + (virtualAssetMax - virtualAssetMin) * (i / 5);
+                    var vaVal = virtualAssetMin + (virtualAssetMax - virtualAssetMin) * (i / TICK_CONFIG.count);
                     ctx.fillStyle = "#06b6d4";
-                    ctx.fillText(Math.round(vaVal), pad.l - LEFT_ASSET_TICK_X, y + LEFT_ASSET_TICK_BASELINE + LEFT_ASSET_TICK_STACK_GAP);
+                    ctx.fillText(Math.round(vaVal), pad.l - TICK_CONFIG.x, y + TICK_CONFIG.baseline + TICK_CONFIG.stackGap);
                 }
                 
-                // 绘制资产刻度（在体力刻度下方第二行，虚拟资产下方）
+                // 绘制资产刻度（使用独立Y轴的数值）
                 if (hasAssetSeries) {
-                    var aVal = assetMin + (assetMax - assetMin) * (i / 5);
+                    var aVal = assetMin + (assetMax - assetMin) * (i / TICK_CONFIG.count);
                     ctx.fillStyle = "#81c784";
-                    var offsetY = hasVirtualAssetSeries ? LEFT_ASSET_TICK_STACK_GAP * 2 : LEFT_ASSET_TICK_STACK_GAP;
-                    ctx.fillText(Math.round(aVal), pad.l - LEFT_ASSET_TICK_X, y + LEFT_ASSET_TICK_BASELINE + offsetY);
+                    var offsetY = hasVirtualAssetSeries ? TICK_CONFIG.stackGap * 2 : TICK_CONFIG.stackGap;
+                    ctx.fillText(Math.round(aVal), pad.l - TICK_CONFIG.x, y + TICK_CONFIG.baseline + offsetY);
                 }
             }
         }
@@ -349,8 +339,8 @@
         ctx.font = "11px -apple-system, sans-serif";
         ctx.textAlign = "right";
         ctx.textBaseline = "middle";
-        for (var i = 0; i <= 5; i++) {
-            var v = allMin + (allMax - allMin) * (i / 5);
+        for (var i = 0; i <= TICK_CONFIG.count; i++) {
+            var v = allMin + (allMax - allMin) * (i / TICK_CONFIG.count);
             var y = yOf(v);
             ctx.beginPath(); ctx.moveTo(pad.l, y); ctx.lineTo(W - pad.r, y); ctx.stroke();
             ctx.fillText(Math.round(v), pad.l - 8, y);
@@ -546,7 +536,7 @@
                         if (dist < closestDist_va) { closestDist_va = dist; closestIdx_va = j; }
                     }
                     if (closestIdx_va !== -1 && closestDist_va < 5)
-                        drawBead(lineVirtualAsset[closestIdx_va], "#4fc3f7", yOfCombined);
+                        drawBead(lineVirtualAsset[closestIdx_va], "#4fc3f7", yOfVirtualAsset);
                 }
                 if (seriesVisible[4] && hasAssetSeries) {
                     var closestIdx_a = -1, closestDist_a = 600000;
@@ -555,7 +545,7 @@
                         if (dist < closestDist_a) { closestDist_a = dist; closestIdx_a = j; }
                     }
                     if (closestIdx_a !== -1 && closestDist_a < 5)
-                        drawBead(lineAsset[closestIdx_a], "#81c784", yOfCombined);
+                        drawBead(lineAsset[closestIdx_a], "#81c784", yOfAsset);
                 }
 
                 // 海里数 bead（使用独立轴）
@@ -775,8 +765,8 @@
                 ctx.font = "11px -apple-system, sans-serif";
                 ctx.textAlign = "right";
                 ctx.textBaseline = "middle";
-                for (var i = 0; i <= 5; i++) {
-                    var v = dMin + (dMax - dMin) * (i / 5);
+                for (var i = 0; i <= TICK_CONFIG.count; i++) {
+                    var v = dMin + (dMax - dMin) * (i / TICK_CONFIG.count);
                     var y = yScale(v, dMin, dMax);
                     ctx.beginPath(); ctx.moveTo(pad.l, y); ctx.lineTo(W - pad.r, y); ctx.stroke();
                     ctx.fillText(Math.round(v), pad.l - 8, y);

--- a/webapp/ap_chart.js
+++ b/webapp/ap_chart.js
@@ -104,7 +104,15 @@
         var COIN_TICK_BASELINE = 4;
         var COIN_TICK_STACK_GAP = 11;
 
-        pad = { t: 20, r: showCoins ? 110 : 20, b: 52, l: 52 };
+        // 左侧资产刻度标签布局常量
+        var LEFT_ASSET_TICK_X = 8;
+        var LEFT_ASSET_TICK_BASELINE = 4;
+        var LEFT_ASSET_TICK_STACK_GAP = 11;
+
+        // 根据是否有资产数据动态调整左侧边距
+        var hasLeftAssets = hasVirtualAssetSeries || hasAssetSeries;
+        var leftPadding = hasLeftAssets ? 110 : 52;
+        pad = { t: 20, r: showCoins ? 110 : 20, b: 52, l: leftPadding };
         gW = W - pad.l - pad.r;
         gH = H - pad.t - pad.b;
 
@@ -157,8 +165,10 @@
         // ---- 紫币独立轴 ----
         var hasPurpleAxis = showCoins && chartType === 'line' && hasPurpleCoins;
         // ---- 组合轴（黄币 + 虚拟资产 + 资产共用） ----
-        var hasCombined = showCoins && chartType === 'line' && (hasYellowCoins || hasVirtualAssetSeries || hasAssetSeries || hasDistanceSeries);
-        var hasExtra = hasPurpleAxis || hasCombined;
+        var hasCombined = showCoins && chartType === 'line' && (hasYellowCoins || hasVirtualAssetSeries || hasAssetSeries);
+        // ---- 海里数独立轴 ----
+        var hasDistanceAxis = showCoins && chartType === 'line' && hasDistanceSeries;
+        var hasExtra = hasPurpleAxis || hasCombined || hasDistanceAxis;
         var combinedMin = 0, combinedMax = -Infinity;
         function scanRange(arr) {
             for (var i = 0; i < arr.length; i++) {
@@ -170,13 +180,24 @@
             if (hasYellowCoins) scanRange(yellowCoins);
             if (hasVirtualAssetSeries) scanRange(lineVirtualAsset);
             if (hasAssetSeries) scanRange(lineAsset);
-            if (hasDistanceSeries) scanRange(lineDistance);
             if (combinedMax === -Infinity) combinedMax = 1000;
             var combinedRng = combinedMax - combinedMin || 1;
             combinedMax += combinedRng * 0.08;
         }
+        
+        // ---- 海里数独立范围 ----
+        var distanceMin = 0, distanceMax = -Infinity;
+        if (hasDistanceAxis) {
+            for (var i = 0; i < lineDistance.length; i++) {
+                if (lineDistance[i] === null || lineDistance[i] === undefined) continue;
+                if (lineDistance[i] > distanceMax) distanceMax = lineDistance[i];
+            }
+            if (distanceMax === -Infinity) distanceMax = 1000;
+            var distanceRng = distanceMax - distanceMin || 1;
+            distanceMax += distanceRng * 0.08;
+        }
 
-        // 刻度配置（右侧标签）：第1行紫币独立，第2行黄币代表合并轴
+        // 刻度配置（右侧标签）：第1行紫币独立，第2行黄币代表合并轴，第3行海里数独立
         var EXTRA_SERIES_CONFIGS = [];
         var cfgOffset = 0;
         function addCfg(has, color, dataMin, dataMax) {
@@ -186,6 +207,7 @@
         }
         addCfg(hasPurpleCoins, "#ce93d8", purpleMin, purpleMax);
         addCfg(hasCombined, "#ffd54f", combinedMin, combinedMax);
+        addCfg(hasDistanceAxis, "#1565c0", distanceMin, distanceMax);
 
         // 系列绘制配置（所有线都要画，虚拟/资产用时间戳）
         var SERIES_DRAW = [
@@ -193,7 +215,7 @@
             { has: hasYellowCoins, data: yellowCoins, yFn: yOfCombined, dash: [] },
             { has: hasVirtualAssetSeries, data: lineVirtualAsset, ts: lineVirtualAssetTs, yFn: yOfCombined, dash: [] },
             { has: hasAssetSeries, data: lineAsset, ts: lineAssetTs, yFn: yOfCombined, dash: [] },
-            { has: hasDistanceSeries, data: lineDistance, yFn: yOfCombined, dash: [] },
+            { has: hasDistanceSeries, data: lineDistance, yFn: yOfDistance, dash: [] },
         ];
 
         // Y 坐标映射
@@ -203,6 +225,7 @@
         function yOf(v) { return yScale(v, allMin, allMax); }
         function yOfPurple(v) { return yScale(v, purpleMin, purpleMax); }
         function yOfCombined(v) { return yScale(v, combinedMin, combinedMax); }
+        function yOfDistance(v) { return yScale(v, distanceMin, distanceMax); }
 
         // 时间感知的 x 坐标映射
         function xOfLine(i) {
@@ -221,6 +244,42 @@
                     var val = cfg.dataMin + (cfg.dataMax - cfg.dataMin) * (i / 5);
                     ctx.fillStyle = cfg.color;
                     ctx.fillText(Math.round(val), W - pad.r + COIN_TICK_X, y + COIN_TICK_BASELINE + cfg.offsetY);
+                }
+            }
+        }
+
+        // 绘制左侧资产刻度标签（虚拟资产和资产）
+        function drawLeftAssetTicks(ctx, yFn, dataMin, dataMax) {
+            if (!hasLeftAssets) return;
+            ctx.font = "10px -apple-system, sans-serif";
+            ctx.textAlign = "right";
+            var leftAssetConfigs = [];
+            var leftOffset = 0;
+            
+            // 虚拟资产配置
+            if (hasVirtualAssetSeries) {
+                leftAssetConfigs.push({
+                    color: "#06b6d4",
+                    offsetY: leftOffset
+                });
+                leftOffset += LEFT_ASSET_TICK_STACK_GAP;
+            }
+            
+            // 资产配置
+            if (hasAssetSeries) {
+                leftAssetConfigs.push({
+                    color: "#22d3ee",
+                    offsetY: leftOffset
+                });
+            }
+            
+            for (var i = 0; i <= 5; i++) {
+                var val = dataMin + (dataMax - dataMin) * (i / 5);
+                var y = yFn(val);
+                for (var ci = 0; ci < leftAssetConfigs.length; ci++) {
+                    var cfg = leftAssetConfigs[ci];
+                    ctx.fillStyle = cfg.color;
+                    ctx.fillText(Math.round(val), pad.l - LEFT_ASSET_TICK_X, y + LEFT_ASSET_TICK_BASELINE + cfg.offsetY);
                 }
             }
         }
@@ -272,6 +331,7 @@
         }
 
         drawAssetTicks(ctx, yOf, allMin, allMax);
+        drawLeftAssetTicks(ctx, yOfCombined, combinedMin, combinedMax);
 
         var avgY = yOf(avg);
         ctx.save();
@@ -472,9 +532,9 @@
                         drawBead(lineAsset[closestIdx_a], "#81c784", yOfCombined);
                 }
 
-                // 海里数 bead
+                // 海里数 bead（使用独立轴）
                 if (hasDistanceSeries && idx < lineDistance.length && lineDistance[idx] !== null && lineDistance[idx] !== undefined && seriesVisible[5])
-                    drawBead(lineDistance[idx], "#1565c0", yOfCombined);
+                    drawBead(lineDistance[idx], "#1565c0", yOfDistance);
 
                 oc.setTransform(1, 0, 0, 1, 0, 0);
 
@@ -703,6 +763,11 @@
                 function dyOf(v) { return yScale(v, dMin, dMax); }
 
                 drawAssetTicks(ctx, dyOf, dMin, dMax);
+                
+                // 绘制左侧资产刻度（使用组合轴的范围）
+                if (hasLeftAssets && hasCombined) {
+                    drawLeftAssetTicks(ctx, yOfCombined, combinedMin, combinedMax);
+                }
 
                 // Ap 线
                 if (seriesVisible[0]) {


### PR DESCRIPTION
现在两个循环使用不同的变量名，不会相互覆盖，确保每个侵蚀等级的统计数据都能正确计算。这个bug是在提交 8e71f88 时引入的，当时重构代码时添加了两个循环但使用了相同的变量名。

## Summary by Sourcery

Bug Fixes:
- 通过在收集和汇总 hazard 回合样本时使用不同的循环变量，防止 hazard 级别统计数据被覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent hazard-level statistics from being overwritten by using distinct loop variables when collecting and summarizing hazard round samples.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 通过在收集和汇总 hazard 回合样本时使用不同的循环变量，防止 hazard 级别统计数据被覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent hazard-level statistics from being overwritten by using distinct loop variables when collecting and summarizing hazard round samples.

</details>

</details>