### PR TITLE
修复行动力总量与虚拟资产统计错误采用当前剩余体力导致数据异常的问题

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,5 @@
+# Cursor Helper Version: 0.1.5
+# 保留 Cursor Helper 与 .cursor 目录
+!cursor-helper/
+!.cursor/rules/
+!.cursor/commands/

--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,34 @@ pyrightconfig.json
 /f
 /workers
 /debug_img
+
+# Cursor Helper Version: 0.1.5
+# Cursor Helper AI 相关文件
+# 忽略 .cursor/commands 目录（Cursor 命令文件）
+.cursor/commands/
+
+# cursor-helper 目录：只允许提交报告文件
+# 忽略所有 diff 目录（临时文件）
+cursor-helper/**/diff/
+
+# 忽略所有 docs 目录（PRD和技术方案文档）
+cursor-helper/**/docs/
+
+# 忽略 rule_improvements.md（临时规则优化建议文件）
+cursor-helper/**/rule_improvements.md
+
+# 忽略 fix 目录下的修复计划文件（临时文件）
+cursor-helper/**/fix/fix_plan.md
+
+# 忽略评审报告中的 files 目录（详细的文件评审报告，diff 报告）
+cursor-helper/**/review/reports/files/
+
+# 备份文件（.bak）
+# ⚠️ 重要提示：如果因为 Cursor 无法访问文件而通过文件操作命令修改文件时，可能会遗留 .bak 备份文件
+# 这些备份文件应该被忽略，请记得及时删除遗留的 .bak 文件
+*.bak
+
+# 保留所有报告文件：
+# - cursor-helper/**/review/reports/summary/** （总结性评审报告）
+# - cursor-helper/**/fix/fix_report.md （修复报告）
+# - cursor-helper/**/organize-rules/** （规则整理报告）

--- a/module/os/tasks/scheduling.py
+++ b/module/os/tasks/scheduling.py
@@ -1041,10 +1041,10 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
             - 数据来源: cache / dashboard / none
         """
         cached_ap = getattr(self, '_action_point_total', None)
-        if cached_ap is not None:
+        if cached_ap:
             try:
                 return int(cached_ap), 'cache'
-            except Exception:
+            except (TypeError, ValueError):
                 pass
 
         try:

--- a/module/os/tasks/scheduling.py
+++ b/module/os/tasks/scheduling.py
@@ -1040,20 +1040,19 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
             tuple[int, str]: (行动力数值, 数据来源)
             - 数据来源: cache / dashboard / none
         """
-        cached_ap = getattr(self, '_action_point_total', None)
-        if cached_ap:
+        if '_action_point_total' in self.__dict__:
             try:
-                return int(cached_ap), 'cache'
+                return int(self.__dict__['_action_point_total']), 'cache'
             except (TypeError, ValueError):
                 pass
 
         try:
             dashboard_ap = self.config.cross_get(
-                keys='Dashboard.ActionPoint.Total', default=0
+                keys='Dashboard.ActionPoint.Total', default=None
             )
-            if dashboard_ap:
+            if dashboard_ap is not None:
                 return int(dashboard_ap), 'dashboard'
-        except Exception:
+        except (TypeError, ValueError):
             pass
 
         return 0, 'none'

--- a/module/os/tasks/scheduling.py
+++ b/module/os/tasks/scheduling.py
@@ -1034,22 +1034,29 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
     # ========== 短猫提前开始计算 ==========
 
     def _get_current_action_point_value(self) -> tuple[int, str]:
-        """获取当前行动力，避免依赖统计模块。
+        """获取当前可用总体力，包含行动力箱子。
 
         Returns:
             tuple[int, str]: (行动力数值, 数据来源)
-            - 数据来源: realtime / cache / none
+            - 数据来源: cache / dashboard / none
         """
-        try:
-            return int(self.get_action_point()), 'realtime'
-        except Exception:
-            cached_ap = getattr(self, '_action_point_total', None)
-            if cached_ap is None:
-                return 0, 'none'
+        cached_ap = getattr(self, '_action_point_total', None)
+        if cached_ap is not None:
             try:
                 return int(cached_ap), 'cache'
             except Exception:
-                return 0, 'none'
+                pass
+
+        try:
+            dashboard_ap = self.config.cross_get(
+                keys='Dashboard.ActionPoint.Total', default=0
+            )
+            if dashboard_ap:
+                return int(dashboard_ap), 'dashboard'
+        except Exception:
+            pass
+
+        return 0, 'none'
 
     def _get_meow_avg_round_time_seconds(self) -> tuple[float, str]:
         """获取短猫平均每轮耗时（秒）。

--- a/module/statistics/cl1_database.py
+++ b/module/statistics/cl1_database.py
@@ -17,10 +17,12 @@ from module.logger import logger
 class Cl1Database:
     @staticmethod
     def _coerce_int(value: Any) -> int:
+        """严格转换为 int；无效输入由调用方按上下文捕获处理。"""
         return int(value)
 
     @staticmethod
     def _coerce_float(value: Any) -> float:
+        """严格转换为 float；无效输入由调用方按上下文捕获处理。"""
         return float(value)
 
     def _empty_siren_research_devices(self) -> dict:

--- a/module/statistics/cl1_database.py
+++ b/module/statistics/cl1_database.py
@@ -2,6 +2,7 @@
 import sqlite3
 import json
 import os
+from contextlib import suppress
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Tuple
@@ -14,6 +15,14 @@ from module.logger import logger
 
 
 class Cl1Database:
+    @staticmethod
+    def _coerce_int(value: Any) -> int:
+        return int(value)
+
+    @staticmethod
+    def _coerce_float(value: Any) -> float:
+        return float(value)
+
     def _empty_siren_research_devices(self) -> dict:
         return {"cl1": 0, "meow": {}}
 
@@ -44,11 +53,9 @@ class Cl1Database:
         devices = self._normalize_siren_research_devices(data)
         if source == "meow":
             if hazard_level is None:
-                return sum(
-                    int(value or 0) for value in devices.get("meow", {}).values()
-                )
-            return int(devices.get("meow", {}).get(str(int(hazard_level)), 0) or 0)
-        return int(devices.get("cl1", 0) or 0)
+                return sum(devices.get("meow", {}).values())
+            return devices.get("meow", {}).get(str(self._coerce_int(hazard_level)), 0)
+        return devices.get("cl1", 0)
 
     def add_siren_research_device(
         self, instance: str, source: str = "cl1", hazard_level: int = None
@@ -68,7 +75,7 @@ class Cl1Database:
             devices["cl1"] = devices.get("cl1", 0) + 1
         elif source == "meow":
             meow = devices.get("meow", {})
-            key = str(int(hazard_level or 0))
+            key = str(self._coerce_int(hazard_level or 0))
             meow[key] = int(meow.get(key, 0) or 0) + 1
             devices["meow"] = meow
         data["siren_research_devices"] = devices
@@ -79,7 +86,7 @@ class Cl1Database:
         entries.append({
             "ts": datetime.now().isoformat(),
             "source": source,
-            "hazard_level": int(hazard_level or 0) if source == "meow" else None,
+            "hazard_level": self._coerce_int(hazard_level or 0) if source == "meow" else None,
         })
         if len(entries) > 5000:
             entries = entries[-5000:]
@@ -163,8 +170,7 @@ class Cl1Database:
                 updated_rows = []
                 for instance, month, blob in rows:
                     # 1. 用旧密钥解密
-                    data = self._decrypt_with_key(blob, old_key)
-                    if data:
+                    if data := self._decrypt_with_key(blob, old_key):
                         # 2. 用新密钥重加密 (self._encrypt 使用的是当前 self._encryption_key)
                         new_blob = self._encrypt(data)
                         updated_rows.append((new_blob, instance, month))
@@ -180,17 +186,20 @@ class Cl1Database:
         except Exception as e:
             logger.error(f"Failed to migrate database to new device_id: {e}")
 
+    def _decrypt_payload(self, blob: bytes, key: bytes) -> Dict[str, Any]:
+        nonce = blob[:16]
+        tag = blob[16:32]
+        ciphertext = blob[32:]
+        cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+        plaintext = cipher.decrypt_and_verify(ciphertext, tag)
+        return json.loads(plaintext.decode("utf-8"))
+
     def _decrypt_with_key(self, blob: bytes, key: bytes) -> Optional[Dict[str, Any]]:
         """辅助方法：使用指定密钥进行解密"""
         if not blob or len(blob) < 32:
             return None
         try:
-            nonce = blob[:16]
-            tag = blob[16:32]
-            ciphertext = blob[32:]
-            cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
-            plaintext = cipher.decrypt_and_verify(ciphertext, tag)
-            return json.loads(plaintext.decode("utf-8"))
+            return self._decrypt_payload(blob, key)
         except Exception:
             return None
 
@@ -212,12 +221,7 @@ class Cl1Database:
         if not blob or len(blob) < 32:
             return None
         try:
-            nonce = blob[:16]
-            tag = blob[16:32]
-            ciphertext = blob[32:]
-            cipher = AES.new(self._encryption_key, AES.MODE_GCM, nonce=nonce)
-            plaintext = cipher.decrypt_and_verify(ciphertext, tag)
-            return json.loads(plaintext.decode("utf-8"))
+            return self._decrypt_payload(blob, self._encryption_key)
         except (ValueError, KeyError) as e:
             logger.error(f"Decryption failed (Tamper detected or Wrong key): {e}")
             return None
@@ -235,10 +239,8 @@ class Cl1Database:
                     (instance, month),
                 )
                 row = cursor.fetchone()
-                if row:
-                    data = self._decrypt(row[0])
-                    if data:
-                        return data
+                if row and (data := self._decrypt(row[0])):
+                    return data
         except Exception as e:
             logger.error(f"Failed to query stats for {instance} {month}: {e}")
 
@@ -289,11 +291,7 @@ class Cl1Database:
     @staticmethod
     def _get_meow_battles_per_round(hazard_level: Optional[int]) -> Optional[int]:
         """根据侵蚀等级返回每轮战斗次数。"""
-        if hazard_level in [2, 3]:
-            return 2
-        if hazard_level in [4, 5, 6]:
-            return 3
-        return None
+        return 2 if hazard_level in {2, 3} else 3 if hazard_level in {4, 5, 6} else None
 
     def _normalize_meow_hazard_stats(
         self, data: Dict[str, Any]
@@ -309,7 +307,7 @@ class Cl1Database:
                 hazard_level = int(hazard_key)
             except (TypeError, ValueError):
                 continue
-            if hazard_level not in [2, 3, 4, 5, 6] or not isinstance(bucket, dict):
+            if hazard_level not in {2, 3, 4, 5, 6} or not isinstance(bucket, dict):
                 continue
 
             round_times = bucket.get("round_times", [])
@@ -320,9 +318,9 @@ class Cl1Database:
                 if isinstance(entry, (int, float)):
                     normalized_round_times.append(float(entry))
                 elif isinstance(entry, dict) and isinstance(
-                    entry.get("duration"), (int, float)
+                    duration := entry.get("duration"), (int, float)
                 ):
-                    normalized_round_times.append(float(entry.get("duration")))
+                    normalized_round_times.append(float(duration))
 
             battle_times = bucket.get("battle_times", [])
             if not isinstance(battle_times, list):
@@ -332,9 +330,9 @@ class Cl1Database:
                 if isinstance(entry, (int, float)):
                     normalized_battle_times.append(float(entry))
                 elif isinstance(entry, dict) and isinstance(
-                    entry.get("duration"), (int, float)
+                    duration := entry.get("duration"), (int, float)
                 ):
-                    normalized_battle_times.append(float(entry.get("duration")))
+                    normalized_battle_times.append(float(duration))
 
             try:
                 battle_raw_count = int(bucket.get("battle_raw_count", 0) or 0)
@@ -384,7 +382,7 @@ class Cl1Database:
         for entry in round_times:
             if isinstance(entry, dict):
                 hazard_level = entry.get("hazard_level")
-                if hazard_level in [2, 3, 4, 5, 6]:
+                if hazard_level in {2, 3, 4, 5, 6}:
                     hazard_levels.append(hazard_level)
 
         if not hazard_levels:
@@ -432,10 +430,12 @@ class Cl1Database:
         by_battle_times = len(battle_times) if battle_times else 0
         should_save = False
 
-        need_backfill = raw_battle_count is None
-        if estimated_from_rounds is not None and current_raw > 0:
-            if current_raw < int(estimated_from_rounds * 0.85):
-                need_backfill = True
+        need_backfill = (
+            raw_battle_count is None
+            or estimated_from_rounds is not None
+            and current_raw > 0
+            and current_raw < int(estimated_from_rounds * 0.85)
+        )
 
         if need_backfill:
             candidates = [
@@ -443,25 +443,23 @@ class Cl1Database:
                 for candidate in [current_raw, estimated_from_rounds, by_battle_times]
                 if candidate is not None
             ]
-            raw_battle_count = (
-                max(candidates) if candidates else int(round(effective_rounds))
-            )
+            raw_battle_count = max(candidates, default=int(round(effective_rounds)))
             data["meow_battle_raw_count"] = int(raw_battle_count)
             should_save = True
 
-            if inferred_divisor in [2, 3] and effective_rounds > 0:
+            if inferred_divisor in {2, 3} and effective_rounds > 0:
                 data["meow_battle_count"] = round(
-                    int(raw_battle_count) / inferred_divisor, 2
+                    raw_battle_count / inferred_divisor, 2
                 )
                 effective_rounds = float(data["meow_battle_count"])
         else:
             raw_battle_count = current_raw
 
-        if int(raw_battle_count) > 0 and effective_rounds > 0:
-            ratio = float(raw_battle_count) / float(effective_rounds)
+        if raw_battle_count > 0 and effective_rounds > 0:
+            ratio = raw_battle_count / effective_rounds
             if ratio > 5:
-                divisor_for_fix = inferred_divisor if inferred_divisor in [2, 3] else 3
-                fixed_rounds = round(int(raw_battle_count) / divisor_for_fix, 2)
+                divisor_for_fix = inferred_divisor if inferred_divisor in {2, 3} else 3
+                fixed_rounds = round(raw_battle_count / divisor_for_fix, 2)
                 if abs(fixed_rounds - effective_rounds) > 0.01:
                     data["meow_battle_count"] = fixed_rounds
                     effective_rounds = float(fixed_rounds)
@@ -628,28 +626,30 @@ class Cl1Database:
         yellow_coin = 0
         yellow_coin_snapshots = data.get("yellow_coin_snapshots", [])
         if yellow_coin_snapshots:
-            try:
+            with suppress(Exception):
                 yellow_coin = int(yellow_coin_snapshots[-1].get("yellow_coin", 0))
-            except Exception:
-                pass
 
-        # 资产 = AP × 效率 + 黄币
-        asset = ap_current * cl5_efficiency + yellow_coin
+        # 资产按可用总体力计算，包含行动力箱子。
+        ap_current = self._coerce_int(ap_current)
+        if ap_total is not None:
+            ap_total = self._coerce_int(ap_total)
+        ap_for_asset = ap_total if ap_total is not None else ap_current
+        asset = ap_for_asset * cl5_efficiency + yellow_coin
         # 虚拟资产 = 资产 + 时间加成
         virtual_asset = asset + virtual_asset_added
 
         snapshot = {
             "ts": now.isoformat(),
-            "ap": int(ap_current),
-            "yellow_coin": int(yellow_coin),
+            "ap": ap_current,
+            "yellow_coin": yellow_coin,
             "asset": round(asset, 2),
             "virtual_asset": round(virtual_asset, 2),
             "source": source,
         }
         if distance is not None:
-            snapshot["distance"] = int(distance)
+            snapshot["distance"] = self._coerce_int(distance)
         if ap_total is not None:
-            snapshot["ap_total"] = int(ap_total)
+            snapshot["ap_total"] = ap_total
 
         snapshots = data.get("ap_snapshots", [])
         snapshots.append(snapshot)
@@ -681,7 +681,7 @@ class Cl1Database:
         data = self.get_stats(instance, month)
         data["last_ap_notification"] = {
             "ts": datetime.now().isoformat(),
-            "ap": int(ap_current),
+            "ap": self._coerce_int(ap_current),
         }
         self.save_stats(instance, month, data)
 
@@ -697,20 +697,19 @@ class Cl1Database:
         """
         month = datetime.now().strftime("%Y-%m")
         data = self.get_stats(instance, month)
+        yellow_coin = self._coerce_int(yellow_coin)
 
         snapshot = {
             "ts": datetime.now().isoformat(),
-            "yellow_coin": int(yellow_coin),
+            "yellow_coin": yellow_coin,
             "source": source,
         }
 
         snapshots = data.get("yellow_coin_snapshots", [])
         if snapshots:
-            try:
-                if int(snapshots[-1].get("yellow_coin", -1)) == int(yellow_coin):
+            with suppress(Exception):
+                if snapshots[-1].get("yellow_coin", -1) == yellow_coin:
                     return
-            except Exception:
-                pass
         snapshots.append(snapshot)
         data["yellow_coin_snapshots"] = snapshots
         self.save_stats(instance, month, data)
@@ -732,28 +731,26 @@ class Cl1Database:
         """
         month = datetime.now().strftime("%Y-%m")
         data = self.get_stats(instance, month)
+        yellow_coins = self._coerce_int(yellow_coins)
+        purple_coins = self._coerce_int(purple_coins) if purple_coins is not None else None
 
         snapshot = {
             "ts": datetime.now().isoformat(),
-            "yellow_coins": int(yellow_coins),
+            "yellow_coins": yellow_coins,
             "source": source,
         }
         if purple_coins is not None:
-            snapshot["purple_coins"] = int(purple_coins)
+            snapshot["purple_coins"] = purple_coins
 
         snapshots = data.get("coins_snapshots", [])
         if snapshots:
-            try:
+            with suppress(Exception):
                 last = snapshots[-1]
-                if int(last.get("yellow_coins", -1)) == int(yellow_coins):
-                    if purple_coins is not None and int(
-                        last.get("purple_coins", -1)
-                    ) == int(purple_coins):
+                if last.get("yellow_coins", -1) == yellow_coins:
+                    if purple_coins is not None and last.get("purple_coins", -1) == purple_coins:
                         return
                     if purple_coins is None and "purple_coins" not in last:
                         return
-            except Exception:
-                pass
         snapshots.append(snapshot)
         # 保留最近 500 条记录，避免数据过大
         if len(snapshots) > 500:
@@ -790,10 +787,11 @@ class Cl1Database:
 
             # JSON 格式比较杂乱，需要按月份归档
             # 格式可能是: {"2026-02": 10, "2026-02-akashi": 1, "2026-02-akashi-ap": 120, "2026-02-akashi-ap-entries": [...]}
-            months = set()
-            for key in old_data.keys():
-                if len(key) >= 7 and key[4] == "-":
-                    months.add(key[:7])
+            months = {
+                key[:7]
+                for key in old_data
+                if len(key) >= 7 and key[4] == "-"
+            }
 
             for month in months:
                 # 首先检查数据库是否已有数据，避免覆盖
@@ -879,10 +877,10 @@ class Cl1Database:
         if delta is not None:
             # 直接使用 delta，保持向后兼容
             try:
-                delta = float(delta)
+                delta = self._coerce_float(delta)
             except Exception:
                 delta = 1
-        elif hazard_level is not None and hazard_level in [2, 3, 4, 5, 6]:
+        elif hazard_level in {2, 3, 4, 5, 6}:
             battles_per_round = self._get_meow_battles_per_round(hazard_level)
             delta = (1 / battles_per_round) if battles_per_round else 1
         else:
@@ -893,13 +891,13 @@ class Cl1Database:
         data["meow_battle_raw_count"] = data.get("meow_battle_raw_count", 0) + 1
         data["meow_battle_count"] = data.get("meow_battle_count", 0) + delta
 
-        if hazard_level in [2, 3, 4, 5, 6]:
+        if hazard_level in {2, 3, 4, 5, 6}:
             hazard_stats = self._normalize_meow_hazard_stats(data)
             bucket = self._ensure_meow_hazard_bucket(hazard_stats, hazard_level)
             bucket["battle_raw_count"] = int(bucket.get("battle_raw_count", 0) or 0) + 1
             bucket["effective_rounds"] = float(
                 bucket.get("effective_rounds", 0) or 0
-            ) + float(delta)
+            ) + delta
             data["meow_hazard_stats"] = hazard_stats
 
         self.save_stats(instance, month, data)
@@ -915,7 +913,7 @@ class Cl1Database:
             hazard_level: 侵蚀等级，用于计算出击轮次（2-6）
         """
         # 验证 hazard_level 是否在有效范围内
-        if hazard_level is not None and hazard_level not in [2, 3, 4, 5, 6]:
+        if hazard_level is not None and hazard_level not in {2, 3, 4, 5, 6}:
             logger.debug(f"Invalid hazard_level {hazard_level}, ignoring")
             hazard_level = None
 
@@ -936,7 +934,7 @@ class Cl1Database:
 
         data["meow_round_times"] = normalized_times
 
-        if hazard_level in [2, 3, 4, 5, 6]:
+        if hazard_level in {2, 3, 4, 5, 6}:
             hazard_stats = self._normalize_meow_hazard_stats(data)
             bucket = self._ensure_meow_hazard_bucket(hazard_stats, hazard_level)
             round_times = bucket.get("round_times", [])
@@ -958,7 +956,7 @@ class Cl1Database:
             duration: 战斗耗时（秒）
             hazard_level: 侵蚀等级（2-6），用于分级统计
         """
-        if hazard_level is not None and hazard_level not in [2, 3, 4, 5, 6]:
+        if hazard_level is not None and hazard_level not in {2, 3, 4, 5, 6}:
             logger.debug(f"Invalid hazard_level {hazard_level}, ignoring")
             hazard_level = None
 
@@ -977,7 +975,7 @@ class Cl1Database:
 
         data["meow_battle_times"] = times
 
-        if hazard_level in [2, 3, 4, 5, 6]:
+        if hazard_level in {2, 3, 4, 5, 6}:
             hazard_stats = self._normalize_meow_hazard_stats(data)
             bucket = self._ensure_meow_hazard_bucket(hazard_stats, hazard_level)
             battle_times = bucket.get("battle_times", [])
@@ -1045,13 +1043,13 @@ class Cl1Database:
         hazard_round_samples: Dict[int, List[float]] = {3: [], 5: []}
         for entry in normalized_round_times:
             hl = entry.get("hazard_level")
-            if hl in [2, 3, 4, 5, 6]:
+            if hl in {2, 3, 4, 5, 6}:
                 hazard_sample_total += 1
-            if hl in [3, 5]:
+            if hl in {3, 5}:
                 hazard_round_samples[hl].append(entry["duration"])
 
         by_hazard: Dict[str, Dict[str, Any]] = {}
-        for hl in [3, 5]:
+        for hl in (3, 5):
             key_name = str(hl)
             bucket = hazard_stats.get(key_name, {})
 
@@ -1073,8 +1071,7 @@ class Cl1Database:
             hz_round_times = [
                 float(v) for v in hz_round_times if isinstance(v, (int, float))
             ]
-            if not hz_round_times:
-                hz_round_times = hazard_round_samples[hl]
+            hz_round_times = hz_round_times or hazard_round_samples[hl]
 
             hz_battle_times = (
                 bucket.get("battle_times", [])
@@ -1162,14 +1159,11 @@ class Cl1Database:
         }
 
         # 请求指定侵蚀等级时，将该等级数据提升到顶层
-        if hazard_level is not None:
-            hl_key = str(hazard_level)
-            if hl_key in by_hazard:
-                hl_data = by_hazard[hl_key]
-                result["battle_count"] = hl_data["battle_count"]
-                result["effective_rounds"] = hl_data["effective_rounds"]
-                result["avg_round_time"] = hl_data["avg_round_time"]
-                result["avg_battle_time"] = hl_data["avg_battle_time"]
+        if hazard_level is not None and (hl_data := by_hazard.get(str(hazard_level))):
+            result["battle_count"] = hl_data["battle_count"]
+            result["effective_rounds"] = hl_data["effective_rounds"]
+            result["avg_round_time"] = hl_data["avg_round_time"]
+            result["avg_battle_time"] = hl_data["avg_battle_time"]
 
         return result
 
@@ -1281,10 +1275,11 @@ class Cl1Database:
         month = datetime.now().strftime("%Y-%m")
         data = self.get_stats(instance, month)
 
+        commission_count = self._coerce_int(commission_count)
         entry = {
             "ts": datetime.now().isoformat(),
-            "items": {k: int(v) for k, v in items.items() if v > 0},
-            "commission_count": int(commission_count),
+            "items": {k: self._coerce_int(v) for k, v in items.items() if v > 0},
+            "commission_count": commission_count,
         }
 
         entries = data.get("commission_income_entries", [])
@@ -1309,10 +1304,8 @@ class Cl1Database:
         """
         if year is None or month is None:
             now = datetime.now()
-            if year is None:
-                year = now.year
-            if month is None:
-                month = now.month
+            year = year or now.year
+            month = month or now.month
 
         month_key = f"{year:04d}-{month:02d}"
         data = self.get_stats(instance, month_key)

--- a/module/statistics/cl1_database.py
+++ b/module/statistics/cl1_database.py
@@ -53,9 +53,14 @@ class Cl1Database:
         devices = self._normalize_siren_research_devices(data)
         if source == "meow":
             if hazard_level is None:
-                return sum(devices.get("meow", {}).values())
-            return devices.get("meow", {}).get(str(self._coerce_int(hazard_level)), 0)
-        return devices.get("cl1", 0)
+                return sum(
+                    self._coerce_int(value or 0)
+                    for value in devices.get("meow", {}).values()
+                )
+            return self._coerce_int(
+                devices.get("meow", {}).get(str(self._coerce_int(hazard_level)), 0) or 0
+            )
+        return self._coerce_int(devices.get("cl1", 0) or 0)
 
     def add_siren_research_device(
         self, instance: str, source: str = "cl1", hazard_level: int = None
@@ -626,7 +631,7 @@ class Cl1Database:
         yellow_coin = 0
         yellow_coin_snapshots = data.get("yellow_coin_snapshots", [])
         if yellow_coin_snapshots:
-            with suppress(Exception):
+            with suppress(ValueError, TypeError, IndexError, KeyError):
                 yellow_coin = int(yellow_coin_snapshots[-1].get("yellow_coin", 0))
 
         # 资产按可用总体力计算，包含行动力箱子。
@@ -707,8 +712,8 @@ class Cl1Database:
 
         snapshots = data.get("yellow_coin_snapshots", [])
         if snapshots:
-            with suppress(Exception):
-                if snapshots[-1].get("yellow_coin", -1) == yellow_coin:
+            with suppress(ValueError, TypeError, IndexError, KeyError):
+                if self._coerce_int(snapshots[-1].get("yellow_coin", -1)) == yellow_coin:
                     return
         snapshots.append(snapshot)
         data["yellow_coin_snapshots"] = snapshots
@@ -744,10 +749,13 @@ class Cl1Database:
 
         snapshots = data.get("coins_snapshots", [])
         if snapshots:
-            with suppress(Exception):
+            with suppress(ValueError, TypeError, IndexError, KeyError):
                 last = snapshots[-1]
-                if last.get("yellow_coins", -1) == yellow_coins:
-                    if purple_coins is not None and last.get("purple_coins", -1) == purple_coins:
+                if self._coerce_int(last.get("yellow_coins", -1)) == yellow_coins:
+                    if (
+                        purple_coins is not None
+                        and self._coerce_int(last.get("purple_coins", -1)) == purple_coins
+                    ):
                         return
                     if purple_coins is None and "purple_coins" not in last:
                         return

--- a/module/statistics/opsi_month.py
+++ b/module/statistics/opsi_month.py
@@ -224,9 +224,11 @@ def get_virtual_asset_timeline(
     year: int | None = None, month: int | None = None, instance_name: str | None = None
 ) -> list:
     """
-    Get virtual asset timeline from ap_snapshots that contain virtual_asset data.
+    Get virtual asset timeline from AP snapshots.
 
-    Returns sorted list of snapshots with 'ts' and 'virtual_asset' fields.
+    Existing asset/virtual_asset snapshot fields are the display source of truth.
+    Older snapshots without these fields are still returned so the WebUI can
+    reconstruct them for display.
     """
     now = datetime.now()
     if year is None:
@@ -237,6 +239,4 @@ def get_virtual_asset_timeline(
 
     data = cl1_db.get_stats(instance_name or "default", key_prefix)
     snapshots = data.get("ap_snapshots", [])
-    return sorted(
-        [s for s in snapshots if "virtual_asset" in s], key=lambda e: e.get("ts", "")
-    )
+    return sorted([s for s in snapshots if s.get("ts")], key=lambda e: e.get("ts", ""))

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -774,20 +774,34 @@ class AlasGUI(Frame):
 
             # Process virtual asset timeline
             if virtual_asset_timeline and current_view in ("line", "detail"):
+                from calendar import monthrange as _monthrange
+
                 for pt in virtual_asset_timeline:
                     ts_raw = pt.get("ts", "")
                     va_val = pt.get("virtual_asset")
                     a_val = pt.get("asset")
                     if ts_raw and va_val is not None:
                         try:
-                            va_val = float(va_val)
                             va_dt = _dt.fromisoformat(ts_raw)
-                            virtual_asset_list.append(va_val)
+                            ap_for_asset = int(pt.get("ap_total", pt.get("ap", 0)) or 0)
+                            yellow_coin_for_asset = int(pt.get("yellow_coin", 0) or 0)
+                            cl5_efficiency = 1700.0 / 30.0
+                            asset_value = ap_for_asset * cl5_efficiency + yellow_coin_for_asset
+                            month_end = va_dt.replace(
+                                day=_monthrange(va_dt.year, va_dt.month)[1],
+                                hour=23,
+                                minute=59,
+                                second=59,
+                                microsecond=0,
+                            )
+                            virtual_asset_value = asset_value + max(
+                                0,
+                                (month_end - va_dt).total_seconds(),
+                            ) / 600.0 * cl5_efficiency
+                            virtual_asset_list.append(virtual_asset_value)
                             virtual_asset_ts_list.append(int(va_dt.timestamp() * 1000))
-                            # 从同一条快照中提取 asset
-                            if a_val is not None:
-                                asset_list.append(float(a_val))
-                                asset_ts_list.append(int(va_dt.timestamp() * 1000))
+                            asset_list.append(asset_value)
+                            asset_ts_list.append(int(va_dt.timestamp() * 1000))
                         except (TypeError, ValueError, Exception):
                             continue
 
@@ -1617,7 +1631,9 @@ class AlasGUI(Frame):
 
                         ap_timeline = get_ap_timeline(instance_name=instance_name_stat)
                         current_ap = (
-                            int(ap_timeline[-1].get("ap", 0)) if ap_timeline else 0
+                            int(ap_timeline[-1].get("ap_total", ap_timeline[-1].get("ap", 0)))
+                            if ap_timeline
+                            else 0
                         )
 
                         meow_round_ap = 30

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -801,7 +801,7 @@ class AlasGUI(Frame):
 
                 for pt in virtual_asset_timeline:
                     ts_raw = pt.get("ts", "")
-                    if ts_raw and pt.get("virtual_asset") is not None:
+                    if ts_raw:
                         try:
                             va_dt = _dt.fromisoformat(ts_raw)
                             asset_value = _snapshot_float(pt, "asset")

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -485,6 +485,29 @@ class AlasGUI(Frame):
             from datetime import datetime as _dt
             import json as _json
 
+            def _get_cl5_efficiency():
+                default = 1700.0 / 30.0
+                try:
+                    config = getattr(self, "alas_config", None)
+                    if config is None or not hasattr(config, "cross_get"):
+                        return default
+                    meow5_coin = config.cross_get(
+                        "OpsiSimulator.OpsiSimulatorParameters.Meow5Coin"
+                    )
+                    if meow5_coin is not None:
+                        meow5_coin_float = float(meow5_coin)
+                        if meow5_coin_float > 0:
+                            return meow5_coin_float / 30.0
+                except (AttributeError, TypeError, ValueError):
+                    pass
+                return default
+
+            def _snapshot_float(point, key):
+                value = point.get(key)
+                if value is None:
+                    return None
+                return float(value)
+
             raw_points = []
             for pt in timeline:
                 ts_raw = pt.get("ts", "")
@@ -778,31 +801,35 @@ class AlasGUI(Frame):
 
                 for pt in virtual_asset_timeline:
                     ts_raw = pt.get("ts", "")
-                    va_val = pt.get("virtual_asset")
-                    a_val = pt.get("asset")
-                    if ts_raw and va_val is not None:
+                    if ts_raw and pt.get("virtual_asset") is not None:
                         try:
                             va_dt = _dt.fromisoformat(ts_raw)
-                            ap_for_asset = int(pt.get("ap_total", pt.get("ap", 0)) or 0)
-                            yellow_coin_for_asset = int(pt.get("yellow_coin", 0) or 0)
-                            cl5_efficiency = 1700.0 / 30.0
-                            asset_value = ap_for_asset * cl5_efficiency + yellow_coin_for_asset
-                            month_end = va_dt.replace(
-                                day=_monthrange(va_dt.year, va_dt.month)[1],
-                                hour=23,
-                                minute=59,
-                                second=59,
-                                microsecond=0,
-                            )
-                            virtual_asset_value = asset_value + max(
-                                0,
-                                (month_end - va_dt).total_seconds(),
-                            ) / 600.0 * cl5_efficiency
+                            asset_value = _snapshot_float(pt, "asset")
+                            virtual_asset_value = _snapshot_float(pt, "virtual_asset")
+                            if asset_value is None:
+                                ap_for_asset = int(pt.get("ap_total", pt.get("ap", 0)) or 0)
+                                yellow_coin_for_asset = int(pt.get("yellow_coin", 0) or 0)
+                                asset_value = (
+                                    ap_for_asset * _get_cl5_efficiency()
+                                    + yellow_coin_for_asset
+                                )
+                            if virtual_asset_value is None:
+                                month_end = va_dt.replace(
+                                    day=_monthrange(va_dt.year, va_dt.month)[1],
+                                    hour=23,
+                                    minute=59,
+                                    second=59,
+                                    microsecond=0,
+                                )
+                                virtual_asset_value = asset_value + max(
+                                    0,
+                                    (month_end - va_dt).total_seconds(),
+                                ) / 600.0 * _get_cl5_efficiency()
                             virtual_asset_list.append(virtual_asset_value)
                             virtual_asset_ts_list.append(int(va_dt.timestamp() * 1000))
                             asset_list.append(asset_value)
                             asset_ts_list.append(int(va_dt.timestamp() * 1000))
-                        except (TypeError, ValueError, Exception):
+                        except (TypeError, ValueError):
                             continue
 
                 if virtual_asset_list:


### PR DESCRIPTION
使用包含行动力箱子的总体力作为短猫调度和统计展示依据，重新计算资产与虚拟资产时间线，避免沿用旧快照值导致展示偏差。

同时整理 CL1 统计数据库中的类型转换、解密复用和短猫统计兼容逻辑，并补充 Cursor Helper 相关忽略规则。

## Summary by Sourcery

将基于行动点（AP）的资产计算和 meow 统计与「总可用 AP」（包括 AP 盒子）统一对齐，同时收紧 CL1 统计类型处理和 Web UI 时间线，并更新调度逻辑以使用缓存/仪表盘的 AP 数据源。

Bug Fixes（错误修复）:
- 将基础资产和虚拟资产快照改为基于「总可用行动点」（包括 AP 盒子），而不是当前 AP，以修复报告数值不准确的问题。
- 规范 meow 危险等级的战斗与回合统计及回填逻辑，确保各危险等级之间的计数与比例保持一致。
- 通过在比较前先规范化数值并跳过未变化的条目，避免黄色金币和金币快照的重复记录。
- 将 AES-GCM 负载解密逻辑集中管理，以减少解密失败，并确保始终能从加密数据中读取统计信息。
- 确保 meow 农场及相关功能从快照或缓存/仪表盘中的最新「总 AP」取值，而不是使用易变的当前 AP。

Enhancements（功能增强）:
- 引入共享的整数与浮点数类型转换辅助方法，以在整个 CL1 统计中统一数值处理方式。
- 使用基于集合的成员检查和更清晰的控制流，细化 meow 危险等级的检查、采样和聚合逻辑，使统计更加稳健。
- 在 Web UI 中从 AP 总量和黄色金币快照导出资产与虚拟资产时间序列，并重建缺失字段，以保证时间线的一致性。
- 通过规范化物品数量并简化默认年/月解析逻辑，精简佣金收入的聚合流程。
- 更新 short-meow 调度逻辑，优先使用缓存的总 AP 和仪表盘配置，而不是直接实时查询行动点。

Chores（日常维护）:
- 新增 .cursorignore 文件，使其与仓库的忽略规则保持一致，以支持编辑器工具链。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align action point–based asset calculations and meow statistics with total available AP (including boxes), while tightening CL1 stats type handling and web UI timelines, and updating scheduling to use cached/dashboard AP sources.

Bug Fixes:
- Base asset and virtual asset snapshots on total available action points (including AP boxes) instead of current AP to fix misreported values.
- Normalize meow hazard-level battle and round statistics and backfill logic to keep counts and ratios consistent across hazard levels.
- Avoid duplicate yellow coin and coin snapshots by normalizing values before comparison and skipping unchanged entries.
- Centralize AES-GCM payload decryption to reduce failures and ensure stats can always be read from encrypted blobs.
- Ensure meow farming and related features derive AP from the latest total value in snapshots or cached/dashboard sources instead of transient current AP.

Enhancements:
- Introduce shared integer and float coercion helpers to standardize numeric handling throughout CL1 statistics.
- Refine meow hazard-level checks, sampling, and aggregation using set-based membership and clearer control flow for more robust stats.
- Derive asset and virtual asset series in the Web UI from AP totals and yellow coin snapshots, reconstructing missing fields for a consistent timeline.
- Simplify commission income aggregation by normalizing item counts and streamlining default year/month resolution.
- Update short-meow scheduling to prefer cached total AP and dashboard configuration over direct real-time queries for action points.

Chores:
- Add a .cursorignore file aligned with repository ignore rules for editor tooling.

</details>

Bug 修复：
- 修复资产和虚拟资产统计，使其基于可用行动点总量（包括 AP 箱子），而不是当前剩余 AP。
- 确保 meow 战斗和回合统计在不同 hazard 等级之间正确推断数量和比例，并避免不一致的回填行为。
- 通过在比较前规范化数值并跳过未变化的条目，防止重复记录 yellow coin 与 coin 快照。
- 通过集中化 AES-GCM 负载处理并在各代码路径中复用，避免解密失败和统计读取遗漏。
- 确保 meow farming 在调度计算中使用快照中的最新 AP 总量，而不是仅使用当前 AP。

功能增强：
- 引入共享的整数和浮点数类型转换辅助函数，以在 CL1 统计流程中规范化数值输入。
- 重构 meow hazard 等级检查与集合处理逻辑，使用基于 set 的成员测试和海象运算符，提高清晰度和健壮性。
- 在 Web UI 图表中，从 AP 总量和 yellow coin 快照推导资产与虚拟资产数值，从而获得不依赖存储快照字段的一致时间线。
- 通过规范化计数与条目，并简化默认月份解析逻辑，改进佣金收入聚合。
- 调整短 meow 调度的行动点获取逻辑，使其优先使用缓存总量和 dashboard 配置，而不是直接实时查询。

杂项：
- 添加 `.cursorignore` 文件，使编辑器工具与仓库忽略规则保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将基于行动点（AP）的资产计算和 meow 统计与「总可用 AP」（包括 AP 盒子）统一对齐，同时收紧 CL1 统计类型处理和 Web UI 时间线，并更新调度逻辑以使用缓存/仪表盘的 AP 数据源。

Bug Fixes（错误修复）:
- 将基础资产和虚拟资产快照改为基于「总可用行动点」（包括 AP 盒子），而不是当前 AP，以修复报告数值不准确的问题。
- 规范 meow 危险等级的战斗与回合统计及回填逻辑，确保各危险等级之间的计数与比例保持一致。
- 通过在比较前先规范化数值并跳过未变化的条目，避免黄色金币和金币快照的重复记录。
- 将 AES-GCM 负载解密逻辑集中管理，以减少解密失败，并确保始终能从加密数据中读取统计信息。
- 确保 meow 农场及相关功能从快照或缓存/仪表盘中的最新「总 AP」取值，而不是使用易变的当前 AP。

Enhancements（功能增强）:
- 引入共享的整数与浮点数类型转换辅助方法，以在整个 CL1 统计中统一数值处理方式。
- 使用基于集合的成员检查和更清晰的控制流，细化 meow 危险等级的检查、采样和聚合逻辑，使统计更加稳健。
- 在 Web UI 中从 AP 总量和黄色金币快照导出资产与虚拟资产时间序列，并重建缺失字段，以保证时间线的一致性。
- 通过规范化物品数量并简化默认年/月解析逻辑，精简佣金收入的聚合流程。
- 更新 short-meow 调度逻辑，优先使用缓存的总 AP 和仪表盘配置，而不是直接实时查询行动点。

Chores（日常维护）:
- 新增 .cursorignore 文件，使其与仓库的忽略规则保持一致，以支持编辑器工具链。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align action point–based asset calculations and meow statistics with total available AP (including boxes), while tightening CL1 stats type handling and web UI timelines, and updating scheduling to use cached/dashboard AP sources.

Bug Fixes:
- Base asset and virtual asset snapshots on total available action points (including AP boxes) instead of current AP to fix misreported values.
- Normalize meow hazard-level battle and round statistics and backfill logic to keep counts and ratios consistent across hazard levels.
- Avoid duplicate yellow coin and coin snapshots by normalizing values before comparison and skipping unchanged entries.
- Centralize AES-GCM payload decryption to reduce failures and ensure stats can always be read from encrypted blobs.
- Ensure meow farming and related features derive AP from the latest total value in snapshots or cached/dashboard sources instead of transient current AP.

Enhancements:
- Introduce shared integer and float coercion helpers to standardize numeric handling throughout CL1 statistics.
- Refine meow hazard-level checks, sampling, and aggregation using set-based membership and clearer control flow for more robust stats.
- Derive asset and virtual asset series in the Web UI from AP totals and yellow coin snapshots, reconstructing missing fields for a consistent timeline.
- Simplify commission income aggregation by normalizing item counts and streamlining default year/month resolution.
- Update short-meow scheduling to prefer cached total AP and dashboard configuration over direct real-time queries for action points.

Chores:
- Add a .cursorignore file aligned with repository ignore rules for editor tooling.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将基于行动点（AP）的资产计算和 meow 统计与「总可用 AP」（包括 AP 盒子）统一对齐，同时收紧 CL1 统计类型处理和 Web UI 时间线，并更新调度逻辑以使用缓存/仪表盘的 AP 数据源。

Bug Fixes（错误修复）:
- 将基础资产和虚拟资产快照改为基于「总可用行动点」（包括 AP 盒子），而不是当前 AP，以修复报告数值不准确的问题。
- 规范 meow 危险等级的战斗与回合统计及回填逻辑，确保各危险等级之间的计数与比例保持一致。
- 通过在比较前先规范化数值并跳过未变化的条目，避免黄色金币和金币快照的重复记录。
- 将 AES-GCM 负载解密逻辑集中管理，以减少解密失败，并确保始终能从加密数据中读取统计信息。
- 确保 meow 农场及相关功能从快照或缓存/仪表盘中的最新「总 AP」取值，而不是使用易变的当前 AP。

Enhancements（功能增强）:
- 引入共享的整数与浮点数类型转换辅助方法，以在整个 CL1 统计中统一数值处理方式。
- 使用基于集合的成员检查和更清晰的控制流，细化 meow 危险等级的检查、采样和聚合逻辑，使统计更加稳健。
- 在 Web UI 中从 AP 总量和黄色金币快照导出资产与虚拟资产时间序列，并重建缺失字段，以保证时间线的一致性。
- 通过规范化物品数量并简化默认年/月解析逻辑，精简佣金收入的聚合流程。
- 更新 short-meow 调度逻辑，优先使用缓存的总 AP 和仪表盘配置，而不是直接实时查询行动点。

Chores（日常维护）:
- 新增 .cursorignore 文件，使其与仓库的忽略规则保持一致，以支持编辑器工具链。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align action point–based asset calculations and meow statistics with total available AP (including boxes), while tightening CL1 stats type handling and web UI timelines, and updating scheduling to use cached/dashboard AP sources.

Bug Fixes:
- Base asset and virtual asset snapshots on total available action points (including AP boxes) instead of current AP to fix misreported values.
- Normalize meow hazard-level battle and round statistics and backfill logic to keep counts and ratios consistent across hazard levels.
- Avoid duplicate yellow coin and coin snapshots by normalizing values before comparison and skipping unchanged entries.
- Centralize AES-GCM payload decryption to reduce failures and ensure stats can always be read from encrypted blobs.
- Ensure meow farming and related features derive AP from the latest total value in snapshots or cached/dashboard sources instead of transient current AP.

Enhancements:
- Introduce shared integer and float coercion helpers to standardize numeric handling throughout CL1 statistics.
- Refine meow hazard-level checks, sampling, and aggregation using set-based membership and clearer control flow for more robust stats.
- Derive asset and virtual asset series in the Web UI from AP totals and yellow coin snapshots, reconstructing missing fields for a consistent timeline.
- Simplify commission income aggregation by normalizing item counts and streamlining default year/month resolution.
- Update short-meow scheduling to prefer cached total AP and dashboard configuration over direct real-time queries for action points.

Chores:
- Add a .cursorignore file aligned with repository ignore rules for editor tooling.

</details>

Bug 修复：
- 修复资产和虚拟资产统计，使其基于可用行动点总量（包括 AP 箱子），而不是当前剩余 AP。
- 确保 meow 战斗和回合统计在不同 hazard 等级之间正确推断数量和比例，并避免不一致的回填行为。
- 通过在比较前规范化数值并跳过未变化的条目，防止重复记录 yellow coin 与 coin 快照。
- 通过集中化 AES-GCM 负载处理并在各代码路径中复用，避免解密失败和统计读取遗漏。
- 确保 meow farming 在调度计算中使用快照中的最新 AP 总量，而不是仅使用当前 AP。

功能增强：
- 引入共享的整数和浮点数类型转换辅助函数，以在 CL1 统计流程中规范化数值输入。
- 重构 meow hazard 等级检查与集合处理逻辑，使用基于 set 的成员测试和海象运算符，提高清晰度和健壮性。
- 在 Web UI 图表中，从 AP 总量和 yellow coin 快照推导资产与虚拟资产数值，从而获得不依赖存储快照字段的一致时间线。
- 通过规范化计数与条目，并简化默认月份解析逻辑，改进佣金收入聚合。
- 调整短 meow 调度的行动点获取逻辑，使其优先使用缓存总量和 dashboard 配置，而不是直接实时查询。

杂项：
- 添加 `.cursorignore` 文件，使编辑器工具与仓库忽略规则保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将基于行动点（AP）的资产计算和 meow 统计与「总可用 AP」（包括 AP 盒子）统一对齐，同时收紧 CL1 统计类型处理和 Web UI 时间线，并更新调度逻辑以使用缓存/仪表盘的 AP 数据源。

Bug Fixes（错误修复）:
- 将基础资产和虚拟资产快照改为基于「总可用行动点」（包括 AP 盒子），而不是当前 AP，以修复报告数值不准确的问题。
- 规范 meow 危险等级的战斗与回合统计及回填逻辑，确保各危险等级之间的计数与比例保持一致。
- 通过在比较前先规范化数值并跳过未变化的条目，避免黄色金币和金币快照的重复记录。
- 将 AES-GCM 负载解密逻辑集中管理，以减少解密失败，并确保始终能从加密数据中读取统计信息。
- 确保 meow 农场及相关功能从快照或缓存/仪表盘中的最新「总 AP」取值，而不是使用易变的当前 AP。

Enhancements（功能增强）:
- 引入共享的整数与浮点数类型转换辅助方法，以在整个 CL1 统计中统一数值处理方式。
- 使用基于集合的成员检查和更清晰的控制流，细化 meow 危险等级的检查、采样和聚合逻辑，使统计更加稳健。
- 在 Web UI 中从 AP 总量和黄色金币快照导出资产与虚拟资产时间序列，并重建缺失字段，以保证时间线的一致性。
- 通过规范化物品数量并简化默认年/月解析逻辑，精简佣金收入的聚合流程。
- 更新 short-meow 调度逻辑，优先使用缓存的总 AP 和仪表盘配置，而不是直接实时查询行动点。

Chores（日常维护）:
- 新增 .cursorignore 文件，使其与仓库的忽略规则保持一致，以支持编辑器工具链。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align action point–based asset calculations and meow statistics with total available AP (including boxes), while tightening CL1 stats type handling and web UI timelines, and updating scheduling to use cached/dashboard AP sources.

Bug Fixes:
- Base asset and virtual asset snapshots on total available action points (including AP boxes) instead of current AP to fix misreported values.
- Normalize meow hazard-level battle and round statistics and backfill logic to keep counts and ratios consistent across hazard levels.
- Avoid duplicate yellow coin and coin snapshots by normalizing values before comparison and skipping unchanged entries.
- Centralize AES-GCM payload decryption to reduce failures and ensure stats can always be read from encrypted blobs.
- Ensure meow farming and related features derive AP from the latest total value in snapshots or cached/dashboard sources instead of transient current AP.

Enhancements:
- Introduce shared integer and float coercion helpers to standardize numeric handling throughout CL1 statistics.
- Refine meow hazard-level checks, sampling, and aggregation using set-based membership and clearer control flow for more robust stats.
- Derive asset and virtual asset series in the Web UI from AP totals and yellow coin snapshots, reconstructing missing fields for a consistent timeline.
- Simplify commission income aggregation by normalizing item counts and streamlining default year/month resolution.
- Update short-meow scheduling to prefer cached total AP and dashboard configuration over direct real-time queries for action points.

Chores:
- Add a .cursorignore file aligned with repository ignore rules for editor tooling.

</details>

</details>

</details>