### PR TITLE
活动每日sp如果已经打完则延时

### DIFF
--- a/module/event/campaign_sp.py
+++ b/module/event/campaign_sp.py
@@ -2,6 +2,7 @@ import os
 
 from module.config.config import TaskEnd
 from module.event.base import EventBase
+from module.exception import RequestHumanTakeover
 from module.logger import logger
 
 
@@ -18,7 +19,21 @@ class CampaignSP(EventBase):
         except TaskEnd:
             # Catch task switch
             pass
+        except RequestHumanTakeover:
+            # Daily SP already completed, delay to next day
+            logger.info('Daily SP already completed or unable to enter')
+            logger.info('Delaying task to next day')
+            self.config.task_delay(server_update=True)
+            return
+        
+        # Check if SP was successfully executed
         if self.run_count > 0:
+            # SP completed successfully, delay to next day
+            logger.info(f'SP completed successfully, run_count={self.run_count}')
             self.config.task_delay(server_update=True)
         else:
-            self.config.task_stop()
+            # SP failed to execute (possibly already completed today)
+            # Delay task to next day instead of stopping
+            logger.info('SP failed to execute, possibly already completed today')
+            logger.info('Delaying task to next day')
+            self.config.task_delay(server_update=True)


### PR DESCRIPTION
现在5次重试后会报错停止alas，改成了会延时然后运行其他任务

## Summary by Sourcery

Bug Fixes:
- 防止每日活动 SP 任务在多次尝试失败后因错误而中止：当 SP 已经完成或无法进入时，将其延迟到下一天再执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the daily campaign SP task from stopping with an error after multiple failed attempts by delaying it to the next day when SP is already completed or cannot be entered.

</details>