### PR TITLE
Fix dashboard resource change detection and timestamp updates in LogRes

### DIFF
--- a/module/log_res/log_res.py
+++ b/module/log_res/log_res.py
@@ -20,7 +20,6 @@ class LogRes:
     def __setattr__(self, key, value):
         if key in self.groups:
             _key_group = f'Dashboard.{key}'
-            _mod = False
             original = deep_get(self.config.data, keys=_key_group)
             if isinstance(value, int):
                 if original['Value'] != value:
@@ -37,11 +36,15 @@ class LogRes:
                         except Exception:
                             logger.exception('Failed to save yellow coin snapshot')
             elif isinstance(value, dict):
+                changed = False
                 for value_name, _value in value.items():
-                    if _value == original[value_name]:
+                    original_value = original.get(value_name) if isinstance(original, dict) else None
+                    if _value == original_value:
                         continue
                     _key = _key_group + f'.{value_name}'
                     self.config.modified[_key] = _value
+                    changed = True
+                if changed:
                     _key_time = _key_group + f'.Record'
                     _time = datetime.now().replace(microsecond=0)
                     self.config.modified[_key_time] = _time


### PR DESCRIPTION
### Motivation

- Ensure timestamp `Dashboard.<name>.Record` is only updated when a dashboard resource actually changes.
- Avoid potential errors when comparing incoming dict values against a missing or non-dict original dashboard entry.
- Clean up an unused local variable.

### Description

- Removed the unused `_mod` variable from `LogRes.__setattr__`.
- Use a safe lookup `original.get(value_name)` only when `original` is a dict to prevent KeyError during comparisons. 
- Introduced a `changed` flag to record whether any sub-values actually changed and only write the `Record` timestamp when `changed` is true.
- Kept existing behavior for integer-value updates and preserved the `YellowCoin` snapshot save with exception logging.

### Testing

- Ran the project's automated test suite with `pytest`, and all tests passed.
- Verified that updating dashboard dict fields now only writes the `Record` timestamp when values change by exercising the `LogRes.__setattr__` code paths under unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a144bd9783c83259cf1a84fd5283d18)

## Summary by Sourcery

调整仪表板日志资源更新方式，以避免不必要的记录时间戳写入，并安全地处理缺失的原始值。

Bug 修复：
- 在更新仪表板字典字段时，通过安全处理缺失或非字典类型的原始值，防止出现 `KeyError` 和错误比较。
- 仅在字典子值实际发生变化时才更新仪表板记录的时间戳，而不是在每次赋值时都更新。

增强：
- 从 LogRes 属性处理逻辑中移除未使用的局部变量，以简化代码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust dashboard logging resource updates to avoid unnecessary record timestamp writes and handle missing original values safely.

Bug Fixes:
- Prevent KeyError and miscomparisons when updating dashboard dict fields by safely handling missing or non-dict original values.
- Update dashboard record timestamps only when dict sub-values actually change instead of on every assignment.

Enhancements:
- Remove an unused local variable from LogRes attribute handling to simplify the code.

</details>