### PR TITLE
修复全资源变化趋势图图例键名错误，修改折线的显示，使其更加靠近图表中心

### DIFF
--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -1212,18 +1212,18 @@ class AlasGUI(Frame):
 
             labels = []
             series_map = {
-                "Oil": {"name": t("Dashboard.Oil.name"), "color": "#ff8a65", "data": []},
-                "Coin": {"name": t("Dashboard.Coin.name"), "color": "#ffd54f", "data": []},
-                "Gem": {"name": t("Dashboard.Gem.name"), "color": "#ef5350", "data": []},
-                "Pt": {"name": t("Dashboard.Pt.name"), "color": "#4fc3f7", "data": []},
-                "Cube": {"name": t("Dashboard.Cube.name"), "color": "#4dd0e1", "data": []},
-                "Core": {"name": t("Dashboard.Core.name"), "color": "#b0bec5", "data": []},
-                "Medal": {"name": t("Dashboard.Medal.name"), "color": "#ffd740", "data": []},
-                "Merit": {"name": t("Dashboard.Merit.name"), "color": "#ffab00", "data": []},
-                "GuildCoin": {"name": t("Dashboard.GuildCoin.name"), "color": "#a1887f", "data": []},
-                "ActionPoint": {"name": t("Dashboard.ActionPoint.name"), "color": "#64b5f6", "data": []},
-                "YellowCoin": {"name": t("Dashboard.YellowCoin.name"), "color": "#ffa726", "data": []},
-                "PurpleCoin": {"name": t("Dashboard.PurpleCoin.name"), "color": "#ce93d8", "data": []},
+                "Oil": {"name": t("Gui.Dashboard.Oil"), "color": "#ff8a65", "data": []},
+                "Coin": {"name": t("Gui.Dashboard.Coin"), "color": "#ffd54f", "data": []},
+                "Gem": {"name": t("Gui.Dashboard.Gem"), "color": "#ef5350", "data": []},
+                "Pt": {"name": t("Gui.Dashboard.Pt"), "color": "#4fc3f7", "data": []},
+                "Cube": {"name": t("Gui.Dashboard.Cube"), "color": "#4dd0e1", "data": []},
+                "Core": {"name": t("Gui.Dashboard.Core"), "color": "#b0bec5", "data": []},
+                "Medal": {"name": t("Gui.Dashboard.Medal"), "color": "#ffd740", "data": []},
+                "Merit": {"name": t("Gui.Dashboard.Merit"), "color": "#ffab00", "data": []},
+                "GuildCoin": {"name": t("Gui.Dashboard.GuildCoin"), "color": "#a1887f", "data": []},
+                "ActionPoint": {"name": t("Gui.Dashboard.ActionPoint"), "color": "#64b5f6", "data": []},
+                "YellowCoin": {"name": t("Gui.Dashboard.YellowCoin"), "color": "#ffa726", "data": []},
+                "PurpleCoin": {"name": t("Gui.Dashboard.PurpleCoin"), "color": "#ce93d8", "data": []},
             }
 
             key_map = {

--- a/webapp/resource_chart.js
+++ b/webapp/resource_chart.js
@@ -170,8 +170,9 @@
                 if (mn === Infinity) { mn = 0; mx = 100; }
                 if (mx === mn) { mx = mn + 100; }
                 var rng = mx - mn;
-                mn -= rng * 0.08;
-                mx += rng * 0.08;
+                var extra = Math.max(rng * 0.2, mn * 0.2, mx * 0.1);
+                mn -= extra;
+                mx += extra;
                 mn = Math.max(0, mn);
                 if (mn < gridMin) gridMin = mn;
                 if (mx > gridMax) gridMax = mx;
@@ -187,8 +188,9 @@
         })();
         if (gridMin === Infinity) { gridMin = 0; gridMax = 100; }
         var gridRng = gridMax - gridMin;
-        gridMin -= gridRng * 0.08;
-        gridMax += gridRng * 0.08;
+        var gridExtra = Math.max(gridRng * 0.1, gridMin * 0.08);
+        gridMin -= gridExtra;
+        gridMax += gridExtra;
         gridMin = Math.max(0, gridMin);
 
         function yOfGrid(v) {
@@ -420,8 +422,9 @@
                 if (mn === Infinity) { mn = 0; mx = 100; }
                 if (mx === mn) { mx = mn + 100; }
                 var rng = mx - mn;
-                mn -= rng * 0.08;
-                mx += rng * 0.08;
+                var extra = Math.max(rng * 0.2, mn * 0.2, mx * 0.1);
+                mn -= extra;
+                mx += extra;
                 mn = Math.max(0, mn);
                 if (mn < gridMin) gridMin = mn;
                 if (mx > gridMax) gridMax = mx;
@@ -437,8 +440,9 @@
         })();
         if (gridMin === Infinity) { gridMin = 0; gridMax = 100; }
         var gridRng = gridMax - gridMin;
-        gridMin -= gridRng * 0.08;
-        gridMax += gridRng * 0.08;
+        var gridExtra = Math.max(gridRng * 0.1, gridMin * 0.08);
+        gridMin -= gridExtra;
+        gridMax += gridExtra;
         gridMin = Math.max(0, gridMin);
 
         var ctx = cv.getContext("2d");


### PR DESCRIPTION
修复全资源变化趋势图例键名错误
修改折线的显示，当数值变化不大时，使其更加靠近图表中心，而不是紧靠在图表最底下

## Summary by Sourcery

错误修复：
- 修复用于完整资源趋势图图例标签的不正确 i18n 键，以便显示正确的本地化名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect i18n keys used for full resource trend chart legend labels so they display the proper localized names.

</details>