### PR TITLE
fix: 修复紧急委托部分情况下战斗结算界面误识别的问题

### DIFF
--- a/module/campaign/gems_farming.py
+++ b/module/campaign/gems_farming.py
@@ -105,13 +105,13 @@ class GemsCampaignOverride(CampaignBase):
             return False
         if super().handle_exp_info():
             return True
-        if self.appear_then_click(EXP_INFO_C):
+        if self.appear_then_click(EXP_INFO_C, threshold=10):
             self.device.sleep((0.25, 0.5))
             return True
         if self.appear_then_click(EXP_INFO_D):
             self.device.sleep((0.25, 0.5))
             return True
-        if self.appear_then_click(OPTS_INFO_D):
+        if self.appear_then_click(OPTS_INFO_D, offset=True, similarity=0.9):
             self.device.sleep((0.25, 0.5))
             return True
         return False


### PR DESCRIPTION
## Summary by Sourcery

调整宝石刷取活动中经验信息和选项信息的点击检测阈值，以减少在某些紧急委托情况下对战斗结算界面的误识别。

Bug Fixes:
- 提高 `EXP_INFO_C` 检测的阈值，从而在战斗结算界面上避免误报。
- 使用偏移量和相似度参数优化 `OPTS_INFO_D` 检测，以正确区分紧急委托战斗结算界面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust experience and options info click detection thresholds in gems farming campaign to reduce misrecognition of battle result screens in certain emergency commission cases.

Bug Fixes:
- Tighten EXP_INFO_C detection with a higher threshold to avoid false positives on battle result screens.
- Refine OPTS_INFO_D detection using offset and similarity parameters to correctly distinguish emergency commission battle settlement interfaces.

</details>