### PR TITLE
修复岛屿产物列表滚动后无法选择可见产物的问题

### DIFF
--- a/module/island/project.py
+++ b/module/island/project.py
@@ -220,6 +220,76 @@ class ProductItem:
     # 当前页面所有物品的按钮网格
     item_buttons: ButtonGrid
 
+    @staticmethod
+    def _normalize_product_text(text):
+        text = str(text or '').lower()
+        return re.sub(r'[\W_]+', '', text)
+
+    @classmethod
+    def resolve_product_name(cls, detected, known_names):
+        normalized = cls._normalize_product_text(detected)
+        if not normalized:
+            return None
+        for name in known_names:
+            product = cls._normalize_product_text(name)
+            if normalized == product:
+                return name
+            if len(product) >= 2 and product in normalized:
+                return name
+        return None
+
+    @classmethod
+    def empty(cls, image, parent_project_id):
+        item = cls.__new__(cls)
+        item.image = image
+        item.y = []
+        item.valid = True
+        item.name = None
+        item.button = None
+        item.parent_project_id = parent_project_id
+        item.items = []
+        item.item_buttons = None
+        return item
+
+    @classmethod
+    def from_ocr_results(cls, image, parent_project_id, product_order):
+        item = cls.empty(image, parent_project_id)
+        detector = AlOcr(name='zhcn' if server.server == 'cn' else 'en')
+        try:
+            det_results = detector.det(image)
+        except Exception as e:
+            logger.warning(f'Product OCR fallback failed: {e}')
+            det_results = []
+
+        left, top, right, bottom = ISLAND_PRODUCT_ITEMS.area
+        seen = set()
+        for txt, box, score in det_results:
+            xs = [point[0] for point in box]
+            ys = [point[1] for point in box]
+            cx = sum(xs) / len(xs)
+            cy = sum(ys) / len(ys)
+            if not (left <= cx <= right and top <= cy <= bottom):
+                continue
+            resolved = cls.resolve_product_name(txt, product_order)
+            if not resolved:
+                continue
+            normalized = cls._normalize_product_text(resolved)
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            y1 = int(max(top, cy - 65))
+            y2 = int(min(bottom, cy + 65))
+            area = (left + 20, y1, right - 20, y2)
+            row = cls.empty(image, parent_project_id)
+            row.y = (y1, y2)
+            row.name = resolved
+            row.button = Button(area=area, color=(), button=area, name=f'ISLAND_ITEM_{resolved}')
+            item.items.append(row)
+
+        if item.items:
+            logger.info(f'Product OCR fallback rows: {[row.name for row in item.items]}')
+        return item
+
     def __init__(self, image, y, parent_project_id, get_button=True):
         """
         初始化产品物品对象。
@@ -733,7 +803,13 @@ class IslandProjectRun(IslandUI):
         }
         peaks, _ = signal.find_peaks(line, **parameters)
         peaks = np.array(peaks) + y_top
-        return ProductItem(self.device.image, peaks, project_id)
+        product_order = list(items_data.get(project_id, {}).values())
+        if len(peaks) < 2:
+            return ProductItem.from_ocr_results(self.device.image, project_id, product_order)
+        current = ProductItem(self.device.image, peaks, project_id)
+        if not any(item.valid and item.name for item in current.items):
+            return ProductItem.from_ocr_results(self.device.image, project_id, product_order)
+        return current
 
     def product_select(self, option, project_id, trial=2):
         """
@@ -771,6 +847,9 @@ class IslandProjectRun(IslandUI):
                         self.device.click(item.button)
                         self.device.sleep(0.2)
                         click_interval.reset()
+                        # OCR fallback rows cannot report the selected item; the confirm step validates the click.
+                        if not current.name:
+                            return True
                     drag = False
             
             if bottom_item == current.items[-1]:


### PR DESCRIPTION
## 概要

修复岛屿产物选择列表滚动后，明明产物仍然可见，但程序无法识别并选择的问题。

## 问题原因

`get_current_product()` 依赖蓝色分隔线峰值来解析产物行。岛屿产物列表滚动后，这个分隔线检测可能失败，即使 `铁矿` 等产物仍然清楚显示在列表中，程序也会认为产物列表为空，从而选择失败。

## 修改内容

- 增加产物名称归一化，用于兜底匹配。
- 当原有分隔线检测失败或没有可用产物行时，使用 OCR 文本框检测扫描产物列表区域。
- 从检测到的产物名称文本框生成点击区域。
- 兜底逻辑只匹配当前生产地已知产物，避免误点无关文本。
- 兜底点击后交给后续 `product_select_confirm()` 验证生产界面。

## 验证

- 运行 `python -m py_compile module/island/project.py`。
- 使用滚动后可见 `铜矿`、`铝矿`、`铁矿`、`硫矿` 的截图进行测试。
- 确认兜底 OCR 能识别 `['铜矿', '铝矿', '铁矿', '硫矿']`，并为 `铁矿` 生成点击区域。

## 风险

较低。新的 OCR 兜底只会在原有分隔线检测失败或没有可用产物行时启用，并且只匹配当前生产地的已知产物。

## 由 Sourcery 提供的摘要

在基于分隔符的行检测失败或未找到有效商品时，增加一个基于 OCR 的后备方案，用于检测并选择岛屿产品。

Bug 修复：
- 当产品仍然可见但分隔符峰值检测失败时，确保在滚动之后岛屿产品选择依然可用。

增强功能：
- 规范化检测到的产品名称，并将基于 OCR 的匹配限制在当前项目的已知产品范围内，以避免误点击。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an OCR-based fallback to detect and select island products when the separator-based row detection fails or yields no valid items.

Bug Fixes:
- Ensure island product selection still works after scrolling when products remain visible but separator peak detection fails.

Enhancements:
- Normalize detected product names and restrict OCR-based matches to known products for the current project to avoid incorrect clicks.

</details>