### PR TITLE
style: 将运行中区域高度优化为单行，减少空白占用

### DIFF
--- a/assets/gui/css/alas-pc.css
+++ b/assets/gui/css/alas-pc.css
@@ -21,7 +21,7 @@
 
 #pywebio-scope-schedulers {
     grid-auto-flow: row;
-    grid-template-rows: auto auto minmax(7.75rem, 1fr) minmax(7.75rem, 1fr) minmax(7.75rem, 1fr);
+    grid-template-rows: auto auto auto minmax(7.75rem, 1fr) minmax(7.75rem, 1fr);
     height: 100%;
     overflow-y: auto;
 }


### PR DESCRIPTION
This pull request makes a small adjustment to the CSS grid layout in the `alas-pc.css` file, modifying the row structure of the `#pywebio-scope-schedulers` element. This change slightly alters the layout by adding an additional `auto` row, which may affect how content is displayed within this section.
调整"运行中"ui的高度，使其为正常的一行高度，而不是原先的三行，以节省空间。
<img width="403" height="407" alt="image" src="https://github.com/user-attachments/assets/0d4b8c5e-3ed7-4bb4-bdb6-25815adf7dcf" />

## Summary by Sourcery

Enhancements:
- 简化 `#pywebio-scope-schedulers` CSS 网格行结构，以减少运行部分中未使用的垂直空白。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Simplify the #pywebio-scope-schedulers CSS grid row structure to reduce unused vertical whitespace in the running section.

</details>