### PR TITLE
feat: 支持岛屿计划多候选产物和角色

### DIFF
--- a/module/island/project.py
+++ b/module/island/project.py
@@ -196,7 +196,9 @@ class ItemNameOcr(Ocr):
     def after_process(self, result):
         result = super().after_process(result)
         if server.server == 'cn':
-            result = result.replace('蛮', '蜜').replace('汗', '汁').replace('纠', '组').replace('离', '禽').replace('莱', '菜').replace('内', '肉').replace('克', '苋').replace('蛟', '鲛')
+            result = result.replace('蛮', '蜜').replace('汗', '汁').replace('纠', '组') \
+                .replace('离', '禽').replace('莱', '菜').replace('内', '肉') \
+                .replace('克', '苋').replace('蛟', '鲛')
             result = re.sub(r'[^\u4e00-\u9fff]', '', result)
             if '冰咖' in result:
                 result = '冰咖啡'
@@ -204,13 +206,13 @@ class ItemNameOcr(Ocr):
                 result = '莓果香橙甜点组'
             elif '莉精油' in result:
                 result = '茉莉精油'
-            elif '胡萝下' == result:
+            elif result == '胡萝下':
                 result = '胡萝卜'
-            elif '草莓奶缘' == result:
+            elif result == '草莓奶缘':
                 result = '草莓奶绿'
-            elif '红鱼' == result:
+            elif result == '红鱼':
                 result = '红鲷鱼'
-            elif '黑鱼' == result:
+            elif result == '黑鱼':
                 result = '黑鲷鱼'
         elif server.server == 'en':
             result = re.sub(r"[\s'-]+", "", result)
@@ -219,6 +221,12 @@ class ItemNameOcr(Ocr):
 
 
 class ProductItem:
+    PRODUCT_ROW_NAME_TO_CENTER_Y = 36
+    PRODUCT_ROW_HALF_HEIGHT = 65
+    PRODUCT_SELECTED_COLOR = (57, 189, 255)
+    PRODUCT_SELECTED_THRESHOLD = 221
+    PRODUCT_SELECTED_BORDER_WIDTH = 14
+    PRODUCT_SELECTED_BORDER_COUNT = 160
     # OCR 识别结果（物品名称）
     name: str
     # 是否成功解析物品名称
@@ -257,11 +265,35 @@ class ProductItem:
         item.parent_project_id = parent_project_id
         item.items = []
         item.item_buttons = None
+        item.is_fallback = False
         return item
+
+    @classmethod
+    def row_area_from_name_center(cls, cy):
+        left, top, right, bottom = ISLAND_PRODUCT_ITEMS.area
+        center = cy + cls.PRODUCT_ROW_NAME_TO_CENTER_Y
+        y1 = int(max(top, center - cls.PRODUCT_ROW_HALF_HEIGHT))
+        y2 = int(min(bottom, center + cls.PRODUCT_ROW_HALF_HEIGHT))
+        return left + 20, y1, right - 20, y2
+
+    @classmethod
+    def row_is_selected(cls, image, area):
+        left, y1, right, y2 = area
+        border = cls.PRODUCT_SELECTED_BORDER_WIDTH
+        top = crop(image, (left - 20, y1, right + 20, min(y1 + border, y2)), copy=False)
+        bottom = crop(image, (left - 20, max(y1, y2 - border), right + 20, y2), copy=False)
+        top_similarity = color_similarity_2d(top, color=cls.PRODUCT_SELECTED_COLOR)
+        bottom_similarity = color_similarity_2d(bottom, color=cls.PRODUCT_SELECTED_COLOR)
+        selected_pixels = (
+            np.count_nonzero(top_similarity > cls.PRODUCT_SELECTED_THRESHOLD)
+            + np.count_nonzero(bottom_similarity > cls.PRODUCT_SELECTED_THRESHOLD)
+        )
+        return selected_pixels >= cls.PRODUCT_SELECTED_BORDER_COUNT
 
     @classmethod
     def from_ocr_results(cls, image, parent_project_id, product_order):
         item = cls.empty(image, parent_project_id)
+        item.is_fallback = True
         detector = AlOcr(name='zhcn' if server.server == 'cn' else 'en')
         try:
             det_results = detector.det(image)
@@ -285,17 +317,18 @@ class ProductItem:
             if normalized in seen:
                 continue
             seen.add(normalized)
-            y1 = int(max(top, cy - 65))
-            y2 = int(min(bottom, cy + 65))
-            area = (left + 20, y1, right - 20, y2)
+            area = cls.row_area_from_name_center(cy)
+            _, y1, _, y2 = area
             row = cls.empty(image, parent_project_id)
             row.y = (y1, y2)
             row.name = resolved
             row.button = Button(area=area, color=(), button=area, name=f'ISLAND_ITEM_{resolved}')
+            if cls.row_is_selected(image, area):
+                item.name = resolved
             item.items.append(row)
 
         if item.items:
-            logger.info(f'Product OCR fallback rows: {[row.name for row in item.items]}')
+            logger.info(f'Product OCR fallback rows: {[row.name for row in item.items]}, selected={item.name}')
         return item
 
     def __init__(self, image, y, parent_project_id, get_button=True):
@@ -424,10 +457,208 @@ class ProductItem:
 
 class IslandProjectRun(IslandUI):
     DEBUG_ISLAND_PROJECT = False
+    LIST_SPLIT = re.compile(r'[,，;；/、\n]+')
+    RANCH_PROJECT_ID = 2
+    PRODUCT_CURSOR_PATH = 'Island.Storage.Storage.ProductCursor'
+    ROLE_CARD_ORIGIN = (58, 140)
+    ROLE_CARD_DELTA = (140, 181)
+    ROLE_CARD_SIZE = (120, 160)
+    ROLE_CARD_GRID = (6, 2)
+    ROLE_CARD_NAME_OFFSET = (-4, 103, 120, 136)
+    ROLE_CARD_STAMINA_OFFSET = (2, 130, 92, 150)
+    ROLE_DETAIL_NAME_AREA = (940, 96, 1150, 132)
     project = SelectedGrids([])
     projects_dirty = False
     total = SelectedGrids([])
     character: str
+    _island_product_cursor: dict
+    _island_product_cursor_dirty: bool
+
+    @classmethod
+    def parse_config_list(cls, value):
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [part.strip() for part in cls.LIST_SPLIT.split(value) if part.strip()]
+        if isinstance(value, (list, tuple, set)):
+            out = []
+            for item in value:
+                out.extend(cls.parse_config_list(item))
+            return out
+        return [value]
+
+    @classmethod
+    def option_is_empty(cls, option):
+        if option is None or option == 0:
+            return True
+        if isinstance(option, str):
+            option = option.strip()
+            return not option or option == '0' or option == '不生产'
+        return False
+
+    @staticmethod
+    def normalize_character_text(text):
+        text = str(text or '').casefold()
+        return re.sub(r'[\W_]+', '', text)
+
+    @classmethod
+    def resolve_character_key(cls, character):
+        text = str(character or '').strip()
+        if not text:
+            return None
+        normalized = cls.normalize_character_text(text)
+        if not normalized:
+            return None
+
+        for key, names in CHARACTER_NAME_MAP.items():
+            if normalized == cls.normalize_character_text(key):
+                return key
+            for name in names.values():
+                if normalized == cls.normalize_character_text(name):
+                    return key
+        return text
+
+    @classmethod
+    def parse_character_candidates(cls, value):
+        candidates = []
+        seen = set()
+        for item in cls.parse_config_list(value):
+            character = cls.resolve_character_key(item)
+            if not character or character in seen:
+                continue
+            seen.add(character)
+            candidates.append(character)
+        return candidates
+
+    @classmethod
+    def character_target_names(cls, character):
+        names = [character]
+        names.extend(CHARACTER_NAME_MAP.get(character, {}).values())
+        out = []
+        seen = set()
+        for name in names:
+            normalized = cls.normalize_character_text(name)
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            out.append(normalized)
+        return out
+
+    @classmethod
+    def character_name_match(cls, detected, character):
+        detected = cls.normalize_character_text(detected)
+        if not detected:
+            return False
+        targets = cls.character_target_names(character)
+        if detected in targets:
+            return True
+        for target in targets:
+            if len(target) >= 3 and len(detected) >= 3 and (target in detected or detected in target):
+                return True
+        return False
+
+    @classmethod
+    def character_detail_name_match(cls, detected, character):
+        detected = cls.normalize_character_text(detected)
+        if not detected:
+            return False
+        for target in cls.character_target_names(character):
+            if detected == target or detected.startswith(target):
+                return True
+        return False
+
+    @staticmethod
+    def readable_character_name(character):
+        return CHARACTER_NAME_MAP.get(character, {}).get(
+            server.server,
+            CHARACTER_NAME_MAP.get(character, {}).get('cn', character),
+        )
+
+    @staticmethod
+    def product_cursor_key(project_id, slot):
+        return f'{project_id}:{slot}'
+
+    def reset_island_storage_cache(self):
+        cursor = self.config.cross_get(keys=self.PRODUCT_CURSOR_PATH, default={})
+        if not isinstance(cursor, dict):
+            cursor = {}
+        self._island_product_cursor = dict(cursor)
+        self._island_product_cursor_dirty = False
+
+    @staticmethod
+    def product_option_signature(candidates):
+        return [str(option) for option in candidates]
+
+    def get_product_cursor(self, project_id, slot, signature=None):
+        key = self.product_cursor_key(project_id, slot)
+        record = self._island_product_cursor.get(key, 0)
+        if isinstance(record, dict):
+            if signature is not None and record.get('signature') != signature:
+                logger.info(f'Product list changed for {key}, reset cursor')
+                return 0
+            record = record.get('cursor', 0)
+        elif signature is not None:
+            logger.info(f'Product cursor for {key} has no signature, reset cursor')
+            return 0
+
+        try:
+            cursor = int(record)
+        except (TypeError, ValueError):
+            cursor = 0
+        return max(cursor, 0)
+
+    def advance_product_cursor(self, option_info):
+        if not option_info or not option_info['rotates']:
+            return
+        self._island_product_cursor[option_info['cursor_key']] = {
+            'cursor': option_info['cursor_after'],
+            'signature': option_info.get('signature', self.product_option_signature(option_info['candidates'])),
+        }
+        self._island_product_cursor_dirty = True
+
+    def save_island_storage(self):
+        if not self._island_product_cursor_dirty:
+            return
+        self.config.cross_set(keys=self.PRODUCT_CURSOR_PATH, value=self._island_product_cursor)
+        self._island_product_cursor_dirty = False
+
+    @staticmethod
+    def resolve_product_option(project_id, option):
+        if isinstance(option, int):
+            return deep_get(items_data, [project_id, option])
+        if isinstance(option, str):
+            return option.strip()
+        return option
+
+    @staticmethod
+    def dedupe_options(options):
+        out = []
+        seen = set()
+        for option in options:
+            key = str(option)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(option)
+        return out
+
+    @staticmethod
+    def product_candidate_sequence(option_info):
+        candidates = option_info['candidates']
+        if not option_info['rotates']:
+            return [option_info]
+
+        cursor_before = option_info['cursor_before']
+        start = cursor_before % len(candidates)
+        sequence = []
+        for offset in range(len(candidates)):
+            index = (start + offset) % len(candidates)
+            current = dict(option_info)
+            current['option'] = candidates[index]
+            current['cursor_after'] = cursor_before + offset + 1
+            current['candidate_index'] = index
+            sequence.append(current)
+        return sequence
 
     def project_detect(self, image):
         """
@@ -584,116 +815,496 @@ class IslandProjectRun(IslandUI):
         """
         为岛屿项目选择指定角色。
 
-        点击角色按钮，等待确认，如果确认按钮未出现则重新点击。
-
-        Args:
-            click_button (Button): 角色按钮
-            check_button: 未使用，保留兼容性
+        点击角色按钮后，若提供了角色校验按钮，则先确认选中头像正确，再点击确认。
         """
         click_timeout = Timer(1.5).start()
         confirm_clicked = False
         self.device.click(click_button)
-        self.device.sleep(0.5)  # 等待 UI 稳定
 
-        for _ in self.loop():
-            self.device.screenshot()  # 强制获取新截图
-            # 结束条件
+        for _ in self.loop(skip_first=False, timeout=6):
             if self.appear(ISLAND_AMOUNT_MAX, offset=(20, 20)):
                 return True
             # 游戏 bug：点击 ROLE_SELECT_CONFIRM 后页面可能返回到 ISLAND_MANAGEMENT_CHECK
             if self.island_in_management():
                 return False
 
-            if self.appear(ROLE_SELECT_CONFIRM, offset=(20, 20)):
-                if not confirm_clicked:
-                    self.device.sleep(0.3)
+            confirm_visible = self.appear(ROLE_SELECT_CONFIRM, offset=(20, 20))
+            if confirm_clicked and not confirm_visible:
+                return True
+
+            if confirm_visible:
+                if check_button is not None and not self.appear(check_button, offset=(20, 20)):
+                    if click_timeout.reached():
+                        logger.info('Character check mismatch, re-clicking character')
+                        self.device.click(click_button)
+                        confirm_clicked = False
+                        click_timeout.reset()
+                    continue
+                if not confirm_clicked or click_timeout.reached():
+                    if confirm_clicked:
+                        logger.info('ROLE_SELECT_CONFIRM still appeared, re-clicking confirm')
                     self.device.click(ROLE_SELECT_CONFIRM)
                     confirm_clicked = True
+                    click_timeout.reset()
                     self.interval_clear(ISLAND_MANAGEMENT_CHECK)
                 continue
 
             if not confirm_clicked and click_timeout.reached():
                 logger.info('ROLE_SELECT_CONFIRM not appeared, re-clicking character')
                 self.device.click(click_button)
-                self.device.sleep(0.5)
                 click_timeout.reset()
                 continue
 
+        logger.warning('Island select role verification timeout')
+        return False
+
     def project_character_select(self, character='manjuu'):
         """
-        选择生产角色。
-
-        Args:
-            character (str): 角色名称
+        选择生产角色，支持按配置顺序尝试候选角色。
 
         Returns:
-            bool: 是否成功选择
+            str|None: 成功时返回选中的规范角色 key，失败时返回 None。
         """
-        logger.info('Island select role')
-        timeout = Timer(8, count=7).start()
+        candidates = self.parse_character_candidates(character)
+        if not candidates:
+            candidates = ['manjuu']
+        if 'manjuu' not in candidates:
+            candidates.append('manjuu')
+
+        logger.info(f'Island select role candidates: {candidates}')
+        self.project_character_reset_position()
+
+        unavailable = set()
+        timeout = Timer(5, count=3).start()
         swipe_count = 0
-        target_name = CHARACTER_NAME_MAP.get(character, {}).get(server.server,
-                       CHARACTER_NAME_MAP.get(character, {}).get('cn', character))
-        target_name_orig = target_name
+        swipe_limit = 5
         det_ocr = AlOcr(name='zhcn' if server.server == 'cn' else 'en')
-        for _ in self.loop():
+        for _ in self.loop(skip_first=False):
             if timeout.reached():
-                self.ui_ensure_management_page()
-                return False
+                break
 
             image = self.image_crop((0, 0, 910, 720), copy=False)
             det_results = det_ocr.det(image)
             if det_results:
-                # 将识别结果分组为角色卡片以识别"工作中"状态
+                # 将识别结果分组为角色卡片以识别“工作中”和体力状态。
                 cards = self._group_character_cards(det_results)
+                grid_checked = False
+                grid_cards = []
 
-                # 检查调试开关
                 if self.DEBUG_ISLAND_PROJECT:
                     self._save_island_debug(image, cards)
 
-                found_busy = False
-                for card in cards:
-                    if target_name in card['name'] or (card['name'] in target_name and len(card['name']) > 1):
-                        if card['working']:
-                            logger.info(f'Character {card["name"]} is working')
-                            found_busy = True
-                            continue
-                        stamina = card.get('stamina')
-                        if stamina is not None and stamina < 40:
-                            logger.info(f'Character {card["name"]} stamina {stamina} < 40')
-                            found_busy = True
-                            continue
+                for candidate in candidates:
+                    if candidate in unavailable:
+                        continue
+                    logger.debug(f'Checking character candidate: {self.readable_character_name(candidate)}')
+                    result = self._project_character_select_from_cards(
+                        candidate, image, cards, grid_checked=grid_checked
+                    )
+                    if result in ['needs_grid', 'not_found'] and not grid_checked:
+                        cards, grid_cards = self._append_character_grid_cards(
+                            image, cards, det_results, det_ocr, candidates, unavailable
+                        )
+                        grid_checked = True
+                        result = self._project_character_select_from_cards(
+                            candidate, image, cards, grid_checked=True
+                        )
+                    if result == 'not_found' and grid_checked:
+                        result = self._project_character_probe_grid_cards(candidate, grid_cards, det_ocr)
+                    if result == 'not_found':
+                        logger.debug(f'Character {self.readable_character_name(candidate)} not found on current page')
+                    if result == 'selected':
+                        return candidate
+                    if result == 'unavailable':
+                        unavailable.add(candidate)
+                        logger.info(f'Character {self.readable_character_name(candidate)} unavailable')
 
-                        box = card['name_box']
-                        cx = int(sum(p[0] for p in box) / len(box))
-                        cy = int(sum(p[1] for p in box) / len(box))
-                        click_button = Button(area=(cx, cy, cx, cy), color=(), button=(cx, cy, cx, cy), name=f'CHAR_{character}')
-                        return self._project_character_select(click_button)
+            remain = [candidate for candidate in candidates if candidate not in unavailable]
+            if not remain:
+                break
 
-            if swipe_count < 5 and not found_busy:
-                logger.info(f'No character {target_name_orig} found, swiping down ({swipe_count + 1}/5)')
+            names = ', '.join(self.readable_character_name(candidate) for candidate in remain)
+            if swipe_count < swipe_limit:
+                logger.info(f'No available character {names} found, swiping down ({swipe_count + 1}/{swipe_limit})')
                 self.drag_page((0, -250), (200, 300, 700, 550), 0.6)
-                self.device.sleep(0.5)
                 swipe_count += 1
             else:
-                if found_busy:
-                    logger.info(f'{target_name_orig} unavailable, use manjuu')
-                else:
-                    logger.info(f'No character {target_name_orig} was found, use manjuu')
-                character = 'manjuu'
-                target_name = CHARACTER_NAME_MAP.get(character, {}).get(server.server,
-                               CHARACTER_NAME_MAP.get(character, {}).get('cn', character))
-                self.drag_page((0, -300), (200, 300, 700, 550), 0.3)
-                self.device.sleep(0.5)
-            continue
+                logger.info(f'No available character {names} was found')
+                break
+        return None
+
+    def project_character_reset_position(self):
+        for _ in range(5):
+            self.drag_page((0, 300), (200, 300, 700, 550), 0.2)
+        self.device.click_record_remove('DRAG')
+
+    def _project_character_select_from_cards(self, character, image, cards, grid_checked=False):
+        """
+        从当前页面的角色卡片中按候选选择角色。
+
+        普通角色在列表中唯一；一旦检测到工作中或体力不足，直接判定该候选不可用。
+        工作啾可能有多个，因此只跳过当前不可用卡片并继续寻找其他工作啾。
+        """
+        matched = False
+        found_unavailable = False
+        for card in cards:
+            if not self.character_name_match(card['name'], character):
+                continue
+            matched = True
+            if card['working']:
+                logger.info(f'Character {card["name"]} is working')
+                found_unavailable = True
+                if character != 'manjuu':
+                    return 'unavailable'
+                continue
+            stamina = card.get('stamina')
+            if stamina is not None and stamina < 40:
+                logger.info(f'Character {card["name"]} stamina {stamina} < 40')
+                found_unavailable = True
+                if character != 'manjuu':
+                    return 'unavailable'
+                continue
+            if stamina is None and character != 'manjuu' and not grid_checked:
+                return 'needs_grid'
+
+            click_button = self._project_character_click_button(character, image, card)
+            check_button = self.get_character_check_button(character)
+            return 'selected' if self._project_character_select(click_button, check_button=check_button) else 'unavailable'
+
+        if matched and found_unavailable:
+            return 'unavailable'
+        return 'not_found'
+
+    @classmethod
+    def _character_grid_area(cls, column, row, offset):
+        ox, oy = cls.ROLE_CARD_ORIGIN
+        dx, dy = cls.ROLE_CARD_DELTA
+        x1 = ox + dx * column + offset[0]
+        y1 = oy + dy * row + offset[1]
+        x2 = ox + dx * column + offset[2]
+        y2 = oy + dy * row + offset[3]
+        return x1, y1, x2, y2
+
+    @staticmethod
+    def _box_from_area(area):
+        x1, y1, x2, y2 = area
+        return [[x1, y1], [x2, y1], [x2, y2], [x1, y2]]
+
+    @staticmethod
+    def _crop_area(image, area):
+        height, width = image.shape[:2]
+        x1, y1, x2, y2 = area
+        x1 = max(0, min(width, int(x1)))
+        x2 = max(0, min(width, int(x2)))
+        y1 = max(0, min(height, int(y1)))
+        y2 = max(0, min(height, int(y2)))
+        return image[y1:y2, x1:x2]
+
+    @staticmethod
+    def _parse_character_stamina(text):
+        m = re.search(r'(\d+)\s*/\s*\d+', str(text or ''))
+        if not m:
+            return None
+        return int(m.group(1))
+
+    @staticmethod
+    def _box_center(box):
+        center = np.mean(box, axis=0)
+        return float(center[0]), float(center[1])
+
+    @classmethod
+    def _known_character_card(cls, card):
+        return any(cls.character_name_match(card['name'], character) for character in CHARACTER_NAME_MAP)
+
+    @classmethod
+    def _area_contains_box_center(cls, area, box, margin=10):
+        x1, y1, x2, y2 = area
+        cx, cy = cls._box_center(box)
+        return x1 - margin <= cx <= x2 + margin and y1 - margin <= cy <= y2 + margin
+
+    def _slot_has_detected_known_character(self, cards, card_area):
+        return any(
+            self._known_character_card(card)
+            and self._area_contains_box_center(card_area, card['name_box'])
+            for card in cards
+        )
+
+    def _character_grid_slots(self, cards):
+        known = [card for card in cards if self._known_character_card(card)]
+        slots = []
+        seen = set()
+
+        rows = []
+        for card in sorted(known, key=lambda c: self._box_center(c['name_box'])[1]):
+            _, y = self._box_center(card['name_box'])
+            for row in rows:
+                if abs(row['y'] - y) < 45:
+                    row['cards'].append(card)
+                    row['y'] = float(np.mean([self._box_center(item['name_box'])[1] for item in row['cards']]))
+                    break
+            else:
+                rows.append({'y': y, 'cards': [card]})
+
+        for row in rows:
+            if len(row['cards']) < 2:
+                continue
+            centers = sorted(self._box_center(card['name_box']) for card in row['cards'])
+            xs = [center[0] for center in centers]
+            deltas = [
+                b - a for a, b in zip(xs, xs[1:])
+                if 80 <= b - a <= 180
+            ]
+            if deltas:
+                delta = float(np.median(deltas))
+            else:
+                delta = float(self.ROLE_CARD_DELTA[0])
+
+            x = min(xs)
+            while x - delta > 40:
+                x -= delta
+            while x < 900:
+                key = (round(x / 8), round(row['y'] / 8))
+                if key not in seen:
+                    seen.add(key)
+                    slots.append(self._character_slot_area_from_name_center(x, row['y']))
+                x += delta
+
+        if slots:
+            return slots
+
+        columns, rows = self.ROLE_CARD_GRID
+        for row in range(rows):
+            for column in range(columns):
+                name_area = self._character_grid_area(column, row, self.ROLE_CARD_NAME_OFFSET)
+                stamina_area = self._character_grid_area(column, row, self.ROLE_CARD_STAMINA_OFFSET)
+                card_area = self._character_grid_area(column, row, (0, 0, *self.ROLE_CARD_SIZE))
+                slots.append((name_area, stamina_area, card_area))
+        return slots
+
+    @classmethod
+    def _character_slot_area_from_name_center(cls, x, y):
+        name_area = (x - 64, y - 18, x + 64, y + 18)
+        stamina_area = (x - 42, y + 10, x + 98, y + 38)
+        card_area = (x - 64, y - 112, x + 64, y + 52)
+        return name_area, stamina_area, card_area
+
+    def _read_character_grid_cards(self, image, cards, det_results, det_ocr):
+        slots = self._character_grid_slots(cards)
+        name_images = [self._crop_area(image, name_area) for name_area, _, _ in slots]
+        stamina_images = [self._crop_area(image, stamina_area) for _, stamina_area, _ in slots]
+
+        names = det_ocr.ocr_for_single_lines(name_images)
+        stamina_texts = det_ocr.ocr_for_single_lines(stamina_images)
+        logger.debug(f'Character grid OCR: {[name for name in names if name]}')
+        grid_cards = []
+        for (name_area, stamina_area, card_area), name, stamina_text in zip(slots, names, stamina_texts):
+            working, stamina = self._character_grid_status(det_results, card_area)
+            stamina = stamina if stamina is not None else self._parse_character_stamina(stamina_text)
+            grid_cards.append({
+                'name': name,
+                'name_box': self._box_from_area(name_area),
+                'card_box': self._box_from_area(card_area),
+                'working': working,
+                'stamina': stamina,
+                'detected_known': self._slot_has_detected_known_character(cards, card_area),
+            })
+        return grid_cards
+
+    def _append_character_grid_cards(self, image, cards, det_results, det_ocr, candidates, unavailable):
+        """
+        补充卡片网格区域的单行 OCR 结果。
+
+        通用 OCR 有时会漏掉短名称或把个别字识别错。这里按当前页面已知卡片推断网格，
+        再补读每个槽位的名称和体力，供候选匹配和后续详情页校验使用。
+        """
+        active_candidates = [candidate for candidate in candidates if candidate not in unavailable]
+        if not active_candidates:
+            return cards, []
+
+        grid_cards = self._read_character_grid_cards(image, cards, det_results, det_ocr)
+        for grid_card in grid_cards:
+            name = grid_card['name']
+            candidate = next((
+                candidate for candidate in active_candidates
+                if self.character_name_match(name, candidate)
+            ), None)
+            if candidate is None:
+                continue
+
+            existing = next((
+                card for card in cards
+                if self.character_name_match(card['name'], candidate)
+            ), None)
+            if existing is not None:
+                if grid_card['working']:
+                    existing['working'] = True
+                if existing.get('stamina') is None and grid_card['stamina'] is not None:
+                    existing['stamina'] = grid_card['stamina']
+                    logger.info(f'Character grid OCR stamina: {name}, stamina={grid_card["stamina"]}')
+                continue
+
+            logger.info(f'Character grid OCR fallback: {name}, stamina={grid_card["stamina"]}')
+            cards.append(grid_card)
+        return cards, grid_cards
+
+    def _selected_character_detail_name(self, det_ocr):
+        image = self.device.image
+        if image is None:
+            return ''
+        area = self.ROLE_DETAIL_NAME_AREA
+        text = det_ocr.ocr_for_single_lines([self._crop_area(image, area)])[0]
+        logger.debug(f'Character detail OCR: {text}')
+        return text
+
+    def _project_character_probe_select(self, character, click_button, det_ocr):
+        click_timeout = Timer(1.5).start()
+        mismatch_timeout = Timer(0.5, count=1).start()
+        confirm_clicked = False
+        self.device.click(click_button)
+
+        for _ in self.loop(skip_first=False, timeout=6):
+            if self.appear(ISLAND_AMOUNT_MAX, offset=(20, 20)):
+                return 'selected'
+            if self.island_in_management():
+                return 'mismatch'
+
+            confirm_visible = self.appear(ROLE_SELECT_CONFIRM, offset=(20, 20))
+            if confirm_clicked and not confirm_visible:
+                return 'selected'
+
+            if confirm_visible:
+                detail_name = self._selected_character_detail_name(det_ocr)
+                if not detail_name:
+                    continue
+                if not self.character_detail_name_match(detail_name, character):
+                    if not mismatch_timeout.reached():
+                        continue
+                    logger.debug(
+                        f'Character detail mismatch: {detail_name} != '
+                        f'{self.readable_character_name(character)}'
+                    )
+                    return 'mismatch'
+                if not confirm_clicked:
+                    logger.info(f'Character detail matched: {detail_name}')
+                if not confirm_clicked or click_timeout.reached():
+                    if confirm_clicked:
+                        logger.info('ROLE_SELECT_CONFIRM still appeared, re-clicking confirm')
+                    self.device.click(ROLE_SELECT_CONFIRM)
+                    confirm_clicked = True
+                    click_timeout.reset()
+                    self.interval_clear(ISLAND_MANAGEMENT_CHECK)
+                continue
+
+            if not confirm_clicked and click_timeout.reached():
+                self.device.click(click_button)
+                click_timeout.reset()
+                mismatch_timeout.reset()
+                continue
+
+        logger.warning('Island select role detail verification timeout')
+        return 'timeout'
+
+    def _project_character_probe_grid_cards(self, character, grid_cards, det_ocr):
+        if not grid_cards:
+            return 'not_found'
+
+        logger.info(f'Verify ambiguous cards for {self.readable_character_name(character)}')
+        for card in grid_cards:
+            if self.character_name_match(card['name'], character):
+                continue
+            if card.get('detected_known'):
+                continue
+            if self._known_character_card(card):
+                continue
+            if card['working']:
+                continue
+            stamina = card.get('stamina')
+            if stamina is None or stamina < 40:
+                continue
+
+            click_button = self._project_character_click_button(character, self.device.image, card)
+            result = self._project_character_probe_select(character, click_button, det_ocr)
+            if result == 'selected':
+                return 'selected'
+            if result == 'timeout':
+                return 'unavailable'
+        return 'not_found'
+
+    @classmethod
+    def _character_grid_status(cls, det_results, card_area):
+        x1, y1, x2, y2 = card_area
+        working = False
+        stamina = None
+        for txt, box, _ in det_results:
+            cx, cy = np.mean(box, axis=0)
+            if not (x1 - 10 <= cx <= x2 + 10 and y1 - 10 <= cy <= y2 + 10):
+                continue
+            if '工作中' in txt:
+                working = True
+            if stamina is None:
+                stamina = cls._parse_character_stamina(txt)
+        return working, stamina
+
+    def project_character_select_one(self, character):
+        """
+        选择单个角色候选。
+        """
+        timeout = Timer(5, count=3).start()
+        swipe_count = 0
+        det_ocr = AlOcr(name='zhcn' if server.server == 'cn' else 'en')
+        for _ in self.loop(skip_first=False):
+            if timeout.reached():
+                return False
+
+            image = self.image_crop((0, 0, 910, 1280), copy=False)
+            det_results = det_ocr.det(image)
+            if det_results:
+                # 将识别结果分组为角色卡片以识别“工作中”和体力状态。
+                cards = self._group_character_cards(det_results)
+
+                if self.DEBUG_ISLAND_PROJECT:
+                    self._save_island_debug(image, cards)
+
+                for card in cards:
+                    if not self.character_name_match(card['name'], character):
+                        continue
+                    if card['working']:
+                        logger.info(f'Character {card["name"]} is working')
+                        continue
+                    stamina = card.get('stamina')
+                    if stamina is not None and stamina < 40:
+                        logger.info(f'Character {card["name"]} stamina {stamina} < 40')
+                        if character != 'manjuu':
+                            return False
+                        continue
+
+                    click_button = self._project_character_click_button(character, image, card)
+                    check_button = self.get_character_check_button(character)
+                    return self._project_character_select(click_button, check_button=check_button)
+
+            name = self.readable_character_name(character)
+            if swipe_count < 5:
+                logger.info(f'No character {name} found, swiping down ({swipe_count + 1}/5)')
+                self.drag_page((0, -250), (200, 300, 700, 550), 0.6)
+                swipe_count += 1
+            else:
+                logger.info(f'No character {name} was found')
+                return False
 
     @staticmethod
     def get_character_template(character):
-        return globals().get(f'TEMPLATE_{character.upper()}', TEMPLATE_MANJUU)
+        return globals().get(f'TEMPLATE_{character.upper()}')
 
     @staticmethod
     def get_character_check_button(character):
-        return globals().get(f'PROJECT_{character.upper()}_CHECK', PRODUCT_MANJUU_CHECK)
+        return globals().get(f'PROJECT_{character.upper()}_CHECK')
+
+    def _project_character_click_button(self, character, image, card):
+        # OCR 已经确认了目标卡片，点击角色名区域比头像模板更不容易误中相似立绘。
+        box = card['name_box']
+        cx = int(sum(p[0] for p in box) / len(box))
+        cy = int(sum(p[1] for p in box) / len(box))
+        return Button(area=(cx, cy, cx, cy), color=(), button=(cx, cy, cx, cy), name=f'CHAR_{character}')
 
     def _group_character_cards(self, det_results):
         working_label = '工作中'
@@ -731,9 +1342,9 @@ class IslandProjectRun(IslandUI):
                 if i in used_stamina: continue
                 sc = np.mean(sbox, axis=0)
                 if abs(sc[0] - bc[0]) < 100 and abs(sc[1] - bc[1]) < 80:
-                    m = re.search(r'(\d+)/(\d+)', stxt)
-                    if m:
-                        stamina = int(m.group(1))
+                    value = self._parse_character_stamina(stxt)
+                    if value is not None:
+                        stamina = value
                         used_stamina.add(i)
                         break
 
@@ -748,30 +1359,6 @@ class IslandProjectRun(IslandUI):
                 x_max, y_max = np.max(box, axis=0)
                 card_box = [[x_min - 10, y_min - 100], [x_max + 10, y_min - 100], [x_max + 10, y_max + 10], [x_min - 10, y_max + 10]]
                 working = False
-
-            if server.server == 'cn':
-                txt = txt.rstrip(".…:!iI·;")
-                if len(txt) > 3 and txt[2] == '者':
-                    # 探索者艾/探索者一艾
-                    txt = txt[:3]
-                if txt == '工': # 阻止技能等级C误匹配到工作啾
-                    txt = 'C'
-                elif txt == 'C作啾':
-                    txt = '工作啾'
-                elif txt == '飞会' or txt == '飞去' or txt == '3去' or txt == 'K云':
-                    txt = '飞云'
-                elif stamina is not None and (txt == 'Z' or txt == '3Z' or txt == 'SZ' or txt == '会'):
-                    txt = '飞云'
-                elif txt == '恶喜' or txt == '恶善':
-                    txt = '恶毒'
-                elif stamina is not None and txt == '恶':
-                    txt = '恶毒'
-                elif txt.startswith('海伦'):
-                    txt = '海伦娜'
-                elif txt.startswith('领航品'):
-                    txt = '领航员'
-                elif txt.startswith('独角'):
-                    txt = '独角兽'
 
             cards.append({
                 'name': txt,
@@ -856,6 +1443,8 @@ class IslandProjectRun(IslandUI):
         bottom_item = None
         retry = trial
         click_interval = Timer(1)
+        select_timeout = Timer(2, count=3)
+        pending_option = None
         for _ in self.loop():
             current = self.get_current_product(project_id)
             if trial > 0 and not len(current.items):
@@ -866,8 +1455,23 @@ class IslandProjectRun(IslandUI):
                 return False
 
             if option == current.name:
+                if getattr(current, 'is_fallback', False) and pending_option != option:
+                    target = next((item for item in current.items if item.name == option), None)
+                    if target is not None and click_interval.reached():
+                        logger.info(f'Fallback selected item {option}, click to verify')
+                        self.device.click(target.button)
+                        self.device.sleep(0.2)
+                        click_interval.reset()
+                        select_timeout.reset()
+                        pending_option = option
+                        continue
                 logger.info(f'Selected item {option}')
                 return True
+
+            if pending_option == option and select_timeout.reached():
+                logger.warning(f'Product {option} click did not become selected')
+                self.ui_ensure_management_page()
+                return False
 
             drag = True
             for item in current.items:
@@ -876,9 +1480,9 @@ class IslandProjectRun(IslandUI):
                         self.device.click(item.button)
                         self.device.sleep(0.2)
                         click_interval.reset()
-                        # OCR fallback rows cannot report the selected item; the confirm step validates the click.
-                        if not current.name:
-                            return True
+                        if pending_option != option:
+                            select_timeout.reset()
+                        pending_option = option
                     drag = False
             
             if bottom_item == current.items[-1]:
@@ -905,7 +1509,7 @@ class IslandProjectRun(IslandUI):
         产品选择确认后启动生产。
 
         Returns:
-            bool: 是否成功启动
+            str: 启动状态
         """
         logger.info('Island product confirm')
         last = None
@@ -917,13 +1521,9 @@ class IslandProjectRun(IslandUI):
 
             if not success:
                 if self.image_color_count(PROJECT_START, color=(151, 155, 155), threshold=221, count=200):
-                    if self.appear(PRODUCT_MANJUU_CHECK, offset=(20, 20)):
-                        self.ui_ensure_management_page()
-                        return True
-                    else:
-                        logger.warning('Product requirement is not satisfied, quitting and retrying')
-                        self.ui_ensure_management_page()
-                        return False
+                    logger.warning('Product requirement is not satisfied, quitting and retrying')
+                    self.ui_ensure_management_page()
+                    return 'requirement_unsatisfied'
 
                 if self.appear_then_click(ISLAND_AMOUNT_MAX, offset=(5, 5), interval=2):
                     timeout.reset()
@@ -948,36 +1548,44 @@ class IslandProjectRun(IslandUI):
 
                 if self.info_bar_count():
                     self.ui_ensure_management_page()
-                    return True
+                    return 'started'
                 if self.island_in_management():
-                    return True
+                    return 'started'
 
-    def project_receive_and_start(self, proj, button, character, option, project_id, ensure=True):
+        logger.warning('Island product confirm timeout')
+        self.ui_ensure_management_page()
+        return 'confirm_timeout'
+
+    def project_receive_and_start(self, proj, button, character_info, option_info, ensure=True):
         """
         领取并启动当前页面上的项目。
 
         Args:
             proj (IslandProject): 项目对象
             button (Button): 项目按钮
-            character (str): 角色名称
-            option (str): 产品选项
+            character_info (dict): 当前槽位的角色候选信息
+            option_info (dict): 当前槽位的产品候选信息
             ensure (bool): 启动后是否调用 ensure_project()
         """
         if not self.project_receive(button):
-            return True
-        if not self.project_character_select(character):
-            logger.warning('Island select role failed due to game bug, retrying')
-            return False
-        if not self.product_select(option, project_id):
-            return True
-        if not self.product_select_confirm():
-            self.character = 'manjuu'
+            return 'slot_skipped'
+        selected = self.project_character_select(character_info['candidates'])
+        if selected is None:
+            logger.warning('Island select role failed, skip this slot')
+            self.ui_ensure_management_page()
+            return 'character_unavailable'
+        if not self.product_select(option_info['option'], proj.id):
+            return 'product_select_failed'
+
+        status = self.product_select_confirm()
+        if status != 'started':
             self.ensure_project(proj)
-            return False
+            return status
         self.ui_ensure_management_page()
         if ensure:
             self.ensure_project(proj)
-        return True
+        logger.info(f'Island project started with {selected}: {option_info["option"]}')
+        return 'started'
 
     def island_project_character(self, project: IslandProject):
         """
@@ -987,11 +1595,18 @@ class IslandProjectRun(IslandUI):
             project (IslandProject): 项目对象
 
         Returns:
-            list[str]: 各槽位的角色名称列表
+            list[dict]: 各槽位的角色候选信息
         """
         proj_id = project.id
-        return [self.config.__getattribute__(f'Island{proj_id}_Character{proj_slot}')
-                for proj_slot in range(1, project.slot + 1)]
+        out = []
+        for proj_slot in range(1, project.slot + 1):
+            raw = self.config.__getattribute__(f'Island{proj_id}_Character{proj_slot}')
+            out.append({
+                'slot': proj_slot,
+                'raw': raw,
+                'candidates': self.parse_character_candidates(raw),
+            })
+        return out
 
     def island_project_option(self, project: IslandProject):
         """
@@ -1001,19 +1616,53 @@ class IslandProjectRun(IslandUI):
             project (IslandProject): 项目对象
 
         Returns:
-            list[str]: 各槽位的产品名称列表
+            list[dict|None]: 各槽位的产品候选信息
         """
         slot_option = []
         proj_id = project.id
         for proj_slot in range(1, project.slot + 1):
-            option = self.config.__getattribute__(f'Island{proj_id}_Option{proj_slot}')
-            if not option or option == 0 or option == '不生产':
+            raw = self.config.__getattribute__(f'Island{proj_id}_Option{proj_slot}')
+            if self.option_is_empty(raw):
                 slot_option.append(None)
                 continue
-            if isinstance(option, int):
-                slot_option.append(deep_get(items_data, [proj_id, option]))
+
+            if proj_id == self.RANCH_PROJECT_ID:
+                raw_candidates = self.parse_config_list(raw)
+                fixed_raw = raw_candidates[0] if raw_candidates else raw
+                candidates = [self.resolve_product_option(proj_id, fixed_raw)]
+                cursor_key = None
+                cursor_before = 0
+                cursor_after = 0
+                rotates = False
             else:
-                slot_option.append(option)
+                candidates = [
+                    self.resolve_product_option(proj_id, option)
+                    for option in self.parse_config_list(raw)
+                    if not self.option_is_empty(option)
+                ]
+                candidates = [option for option in candidates if option]
+                candidates = self.dedupe_options(candidates)
+                cursor_key = self.product_cursor_key(proj_id, proj_slot)
+                signature = self.product_option_signature(candidates)
+                cursor_before = self.get_product_cursor(proj_id, proj_slot, signature=signature)
+                cursor_after = cursor_before + 1
+                rotates = len(candidates) > 1
+
+            if not candidates:
+                slot_option.append(None)
+                continue
+            option = candidates[cursor_before % len(candidates)]
+            slot_option.append({
+                'slot': proj_slot,
+                'raw': raw,
+                'candidates': candidates,
+                'option': option,
+                'cursor_key': cursor_key,
+                'cursor_before': cursor_before,
+                'cursor_after': cursor_after,
+                'rotates': rotates,
+                'signature': self.product_option_signature(candidates),
+            })
         return slot_option
 
     def island_project_run(self, names, trial=2):
@@ -1028,6 +1677,9 @@ class IslandProjectRun(IslandUI):
             list[timedelta]: 未来完成时间列表
         """
         logger.hr('Island Project Run', level=1)
+        self.project = SelectedGrids([])
+        self.total = SelectedGrids([])
+        self.reset_island_storage_cache()
         self.ensure_project(names[0])
         end = False
         timeout = Timer(3, count=3).start()
@@ -1053,18 +1705,50 @@ class IslandProjectRun(IslandUI):
                 character_config = self.island_project_character(proj)
                 option_config = self.island_project_option(proj)
                 option_num = len(option_config)
-                for button, character, option, index in zip(
+                for button, character_info, option_info, index in zip(
                         proj.slot_buttons.buttons, character_config, option_config, range(option_num)):
-                    if option is None:
+                    if option_info is None:
                         continue
-                    self.character = character
-                    # retry 3 times because of a game bug
-                    for _ in range(3):
-                        ensure = not end or index != option_num - 1
-                        if self.project_receive_and_start(proj, button, self.character, option, proj.id, ensure):
-                            break
+                    self.character = ', '.join(character_info['candidates']) or str(character_info['raw'])
+                    logger.attr('Character', self.character)
+                    slot_started = False
+                    for current_option in self.product_candidate_sequence(option_info):
+                        logger.attr('Product', current_option['option'])
+                        last_status = None
+                        attempt_count = 0
+                        # retry 3 times because of a game bug or temporary OCR/confirm failure
+                        for _ in range(3):
+                            attempt_count += 1
+                            ensure = not end or index != option_num - 1
+                            status = self.project_receive_and_start(
+                                proj, button, character_info, current_option, ensure
+                            )
+                            last_status = status
+                            if self.projects_dirty:
+                                break
+                            if status == 'started':
+                                self.advance_product_cursor(current_option)
+                                self.save_island_storage()
+                                slot_started = True
+                                break
+                            if status in ['slot_skipped', 'character_unavailable', 'requirement_unsatisfied']:
+                                break
                         if self.projects_dirty:
                             break
+                        if slot_started or last_status in ['slot_skipped', 'character_unavailable']:
+                            break
+                        if last_status == 'requirement_unsatisfied':
+                            logger.warning(
+                                f'Product {current_option["option"]} requirement is not satisfied, '
+                                'try next candidate'
+                            )
+                        else:
+                            logger.warning(
+                                f'Product {current_option["option"]} failed after {attempt_count} attempts: '
+                                f'{last_status}, try next candidate'
+                            )
+                    if self.projects_dirty:
+                        break
                 timeout.reset()
                 if self.projects_dirty:
                     break
@@ -1074,6 +1758,8 @@ class IslandProjectRun(IslandUI):
             if end:
                 break
             self.drag_page((0, -500), ISLAND_PROJECT_SWIPE.area, 0.6)
+
+        self.save_island_storage()
 
         # task delay
         future_finish = sorted([f for f in self.total.get('finish_time') if f is not None])

--- a/module/island/project.py
+++ b/module/island/project.py
@@ -1629,7 +1629,8 @@ class IslandProjectRun(IslandUI):
             if proj_id == self.RANCH_PROJECT_ID:
                 raw_candidates = self.parse_config_list(raw)
                 fixed_raw = raw_candidates[0] if raw_candidates else raw
-                candidates = [self.resolve_product_option(proj_id, fixed_raw)]
+                resolved = self.resolve_product_option(proj_id, fixed_raw)
+                candidates = [resolved] if resolved else []
                 cursor_key = None
                 cursor_before = 0
                 cursor_after = 0

--- a/module/island/project.py
+++ b/module/island/project.py
@@ -811,7 +811,7 @@ class IslandProjectRun(IslandUI):
 
         return success
 
-    def _project_character_select(self, click_button, check_button=None):
+    def _project_character_select(self, click_button=None, check_button=None):
         """
         为岛屿项目选择指定角色。
 
@@ -819,7 +819,8 @@ class IslandProjectRun(IslandUI):
         """
         click_timeout = Timer(1.5).start()
         confirm_clicked = False
-        self.device.click(click_button)
+        if click_button is not None:
+            self.device.click(click_button)
 
         for _ in self.loop(skip_first=False, timeout=6):
             if self.appear(ISLAND_AMOUNT_MAX, offset=(20, 20)):
@@ -834,6 +835,8 @@ class IslandProjectRun(IslandUI):
 
             if confirm_visible:
                 if check_button is not None and not self.appear(check_button, offset=(20, 20)):
+                    if click_button is None:
+                        return False
                     if click_timeout.reached():
                         logger.info('Character check mismatch, re-clicking character')
                         self.device.click(click_button)
@@ -850,6 +853,9 @@ class IslandProjectRun(IslandUI):
                 continue
 
             if not confirm_clicked and click_timeout.reached():
+                if click_button is None:
+                    logger.warning('ROLE_SELECT_CONFIRM not appeared for selected character')
+                    return False
                 logger.info('ROLE_SELECT_CONFIRM not appeared, re-clicking character')
                 self.device.click(click_button)
                 click_timeout.reset()
@@ -857,6 +863,18 @@ class IslandProjectRun(IslandUI):
 
         logger.warning('Island select role verification timeout')
         return False
+
+    def _project_character_confirm_if_selected(self, character):
+        check_button = self.get_character_check_button(character)
+        if check_button is None:
+            return False
+        if not self.appear(ROLE_SELECT_CONFIRM, offset=(20, 20)):
+            return False
+        if not self.appear(check_button, offset=(20, 20)):
+            return False
+
+        logger.info(f'Character {self.readable_character_name(character)} already selected')
+        return self._project_character_select(check_button=check_button)
 
     def project_character_select(self, character='manjuu'):
         """
@@ -897,6 +915,8 @@ class IslandProjectRun(IslandUI):
                 for candidate in candidates:
                     if candidate in unavailable:
                         continue
+                    if self._project_character_confirm_if_selected(candidate):
+                        return candidate
                     logger.debug(f'Checking character candidate: {self.readable_character_name(candidate)}')
                     result = self._project_character_select_from_cards(
                         candidate, image, cards, grid_checked=grid_checked

--- a/module/island/project.py
+++ b/module/island/project.py
@@ -1662,7 +1662,6 @@ class IslandProjectRun(IslandUI):
                     if not self.option_is_empty(option)
                 ]
                 candidates = [option for option in candidates if option]
-                candidates = self.dedupe_options(candidates)
                 cursor_key = self.product_cursor_key(proj_id, proj_slot)
                 signature = self.product_option_signature(candidates)
                 cursor_before = self.get_product_cursor(proj_id, proj_slot, signature=signature)
@@ -1733,7 +1732,15 @@ class IslandProjectRun(IslandUI):
                     self.character = ', '.join(character_info['candidates']) or str(character_info['raw'])
                     logger.attr('Character', self.character)
                     slot_started = False
+                    skipped_options = set()
                     for current_option in self.product_candidate_sequence(option_info):
+                        option_key = str(current_option['option'])
+                        if option_key in skipped_options:
+                            logger.info(
+                                f'Product {current_option["option"]} already failed in this slot, '
+                                'skip duplicate candidate'
+                            )
+                            continue
                         logger.attr('Product', current_option['option'])
                         last_status = None
                         attempt_count = 0
@@ -1768,6 +1775,7 @@ class IslandProjectRun(IslandUI):
                                 f'Product {current_option["option"]} failed after {attempt_count} attempts: '
                                 f'{last_status}, try next candidate'
                             )
+                        skipped_options.add(option_key)
                     if self.projects_dirty:
                         break
                 timeout.reset()


### PR DESCRIPTION
## 概要

本 PR 改进了岛屿计划的自动派遣逻辑，支持每个项目槽位配置多个候选产物和多个候选角色。

主要目标是让岛屿计划在长期无人值守运行时更稳定：当某个产物材料不足、首选角色正在工作、角色体力不足，或 OCR 未能稳定识别角色/产物时，脚本可以按配置顺序继续尝试其他候选项，而不是卡在单个产物或只选取工作啾上。

现有的单角色、单产物配置方式仍然保持兼容，并会继续按原有方式工作。

## 初衷

岛屿计划中的部分产出对角色属性有较高要求。例如牛奶等产物需要使用双 A 养护属性的角色轮换，才能稳定满足餐品经营的最大化收益需求。因此，仅支持单个指定角色并不足以覆盖长期自动化运行场景，多角色候选是必要的。

此外，在玩家等级尚未解锁多个烹饪或生产位置时，或者在大多数需要长时间无人值守的使用场景中，只固定生产单个商品往往无法满足完整自动化需求。一旦该商品材料不足，脚本可能无法获得稳定收益，或者需要玩家手动介入并修改岛屿计划配置。

此前 #204 已修复产物列表滚动后无法选择可见产物的问题。本 PR 在此基础上进一步补齐多产物候选、失败原因区分、选中行验证和多角色候选逻辑，使岛屿计划在更复杂的长期运行场景中更加稳定。

因此，本 PR 增加了多产物候选和多角色候选支持，使岛屿计划可以根据配置顺序自动轮换角色、切换产物，并在失败原因明确时继续尝试下一个候选项。

## 修改内容

- 支持岛屿计划槽位配置多个产物候选。
  - 支持使用逗号等分隔符配置多个产物，例如 `小麦,玉米,白菜`。
  - 非牧场项目都会按配置顺序轮换候选产物；这同样适用于果园、苗圃等需要消耗种子或材料的项目。
  - 牧场项目保持原有单产物逻辑，使用配置中的第一个产物。
  - 现有单产物配置无需修改，仍会按单个产物执行。

- 增加产物轮换状态保存。
  - 每个项目槽位独立保存产物游标。
  - 只有项目成功启动后才推进游标。
  - 当配置的产物列表发生变化时，对应槽位的游标会自动重置。

- 优化产物启动失败后的处理逻辑。
  - 材料不足会被识别为独立失败原因。
  - 当前产物材料不足时，会尝试下一个候选产物，而不是反复重试同一个产物。
  - OCR、点击或确认失败仍保留有限重试，避免临时识别失败直接跳过。

- 支持岛屿计划槽位配置多个角色候选。
  - 支持配置有序角色列表，例如 `萨拉托加,飞云`。
  - 脚本会按顺序尝试候选角色。
  - 当角色正在工作或体力不足时，会继续尝试下一个候选角色。
  - 保留工作啾作为兜底行为。
  - 现有单角色配置无需修改，仍会按单个角色执行。

- 提升角色选择稳定性。
  - 基于已有角色名称映射做通用名称归一化与匹配。
  - 增加角色卡片网格区域 OCR 兜底，改善短名称或漏识别的问题。
  - 对不确定的角色卡片点击后，会通过右侧详情面板再次验证角色名称。
  - 避免针对特定角色 OCR 结果写硬编码修正。

- 提升产物选择稳定性。
  - 在 #204 的基础上继续改进产物列表选择逻辑。
  - 根据 OCR 识别到的产物名称位置推导整行区域。
  - 选中状态改为检测蓝色行边框，减少因为图标、标签或背景颜色导致的误判。
  - 对 fallback 识别出的产物行，会点击后再次确认目标产物确实被选中。
  - 修复之前可能把错误行、相邻行或旧选中行当作目标产物的问题。

- 优化岛屿计划运行过程中的状态刷新。
  - 当领取或启动项目可能改变页面槽位状态时，会刷新缓存的项目数据。
  - 日志中会更明确地区分角色不可用、产物选择失败、材料不足等不同失败原因。

## 测试

- [x] `python -m py_compile module/island/project.py`
- [x] `git diff --check -- module/island/project.py`
- [x] `ruff check module/island/project.py --select E9,F63,F7,F82 --ignore F821,F722`
- [x] 本地短时间岛屿计划测试：多产物与多角色候选逻辑表现正常
- [x] 本地长时间运行测试，覆盖多个岛屿计划周期

## 说明

本分支基于最新 `dev`，应以 `dev` 作为 PR base。

本 PR 不针对特定角色添加硬编码 OCR 修正。角色识别失败时，优先通过通用 OCR 兜底和详情面板名称验证来提高稳定性。

## Sourcery 总结

支持在每个岛屿项目槽位配置多个候选产品和角色，以提高自动派遣逻辑在长时间无人值守时的稳定性和健壮性。

新特性：
- 允许为每个岛屿项目槽位配置多个候选产品，并基于持久化游标进行自动轮换。
- 允许为每个槽位配置有序的候选角色列表，当首选角色不可用时自动回退到备用角色。

缺陷修复：
- 修复了可能将错误或相邻的产品行视为已选中，以及点击产品后未必能可靠选中目标产品的问题。

增强优化：
- 通过根据 OCR 结果推导完整行区域、使用蓝色边框颜色检测选中状态，以及验证回退选择，提升产品选择的可靠性。
- 通过使用共享映射表对角色名称进行规范化、在需要时使用基于网格的 OCR 作为后备方案，并在必要时通过详情面板验证已选角色，强化角色选择逻辑。
- 在多次运行之间持久化每个槽位的产品轮换游标，并在配置的产品列表发生变化时自动重置。
- 优化岛屿项目运行流程，以区分并记录详细的失败原因（例如：角色不可用、产品选择失败、材料需求不满足），并据此尝试下一个候选项。
- 清理角色模板/检查按钮相关处理，在可用时优先依赖配置而非硬编码默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support multiple candidate products and characters per island project slot to improve long-term unattended stability and robustness of automatic dispatch logic.

New Features:
- Allow configuring multiple candidate products per island project slot with automatic rotation based on persistent cursors.
- Allow configuring ordered candidate character lists per slot and automatically fall back to alternative characters when the preferred one is unavailable.

Bug Fixes:
- Fix cases where incorrect or adjacent product rows could be treated as selected, and where product clicks did not reliably result in the intended selection.

Enhancements:
- Improve product selection robustness by deriving full row regions from OCR results, detecting selection via blue border color, and verifying fallback selections.
- Strengthen character selection by normalizing names via a shared mapping, using grid-based OCR as a fallback, and validating the selected character via the detail panel when needed.
- Persist per-slot product rotation cursors across runs and reset them automatically when the configured product list changes.
- Refine island project run flow to distinguish and log detailed failure reasons (e.g., character unavailable, product selection failure, material requirements unsatisfied) and to try next candidates accordingly.
- Clean up character template/check-button handling to rely on configuration when available instead of hardcoded defaults.

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持在每个岛屿项目槽位配置多个候选产品和角色，以提高自动派遣逻辑在长时间无人值守时的稳定性和健壮性。

新特性：
- 允许为每个岛屿项目槽位配置多个候选产品，并基于持久化游标进行自动轮换。
- 允许为每个槽位配置有序的候选角色列表，当首选角色不可用时自动回退到备用角色。

缺陷修复：
- 修复了可能将错误或相邻的产品行视为已选中，以及点击产品后未必能可靠选中目标产品的问题。

增强优化：
- 通过根据 OCR 结果推导完整行区域、使用蓝色边框颜色检测选中状态，以及验证回退选择，提升产品选择的可靠性。
- 通过使用共享映射表对角色名称进行规范化、在需要时使用基于网格的 OCR 作为后备方案，并在必要时通过详情面板验证已选角色，强化角色选择逻辑。
- 在多次运行之间持久化每个槽位的产品轮换游标，并在配置的产品列表发生变化时自动重置。
- 优化岛屿项目运行流程，以区分并记录详细的失败原因（例如：角色不可用、产品选择失败、材料需求不满足），并据此尝试下一个候选项。
- 清理角色模板/检查按钮相关处理，在可用时优先依赖配置而非硬编码默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support multiple candidate products and characters per island project slot to improve long-term unattended stability and robustness of automatic dispatch logic.

New Features:
- Allow configuring multiple candidate products per island project slot with automatic rotation based on persistent cursors.
- Allow configuring ordered candidate character lists per slot and automatically fall back to alternative characters when the preferred one is unavailable.

Bug Fixes:
- Fix cases where incorrect or adjacent product rows could be treated as selected, and where product clicks did not reliably result in the intended selection.

Enhancements:
- Improve product selection robustness by deriving full row regions from OCR results, detecting selection via blue border color, and verifying fallback selections.
- Strengthen character selection by normalizing names via a shared mapping, using grid-based OCR as a fallback, and validating the selected character via the detail panel when needed.
- Persist per-slot product rotation cursors across runs and reset them automatically when the configured product list changes.
- Refine island project run flow to distinguish and log detailed failure reasons (e.g., character unavailable, product selection failure, material requirements unsatisfied) and to try next candidates accordingly.
- Clean up character template/check-button handling to rely on configuration when available instead of hardcoded defaults.

</details>

</details>