### PR TITLE
fix：修复三油低耗防止委托过多功能

### DIFF
--- a/module/commission/commission.py
+++ b/module/commission/commission.py
@@ -758,29 +758,24 @@ class RewardCommission(UI, InfoHandler):
             self.config.task_delay(success=False)
 
         # 延迟钻石 farming / 三油低耗任务
-        # 分别检查 GemsFarming 和 ThreeOilLowCost 是否启用且开启了 CommissionLimit
-        gems_limit = self.config.is_task_enabled('GemsFarming') and \
-            self.config.cross_get(keys='GemsFarming.GemsFarming.CommissionLimit', default=False)
-        three_oil_limit = self.config.is_task_enabled('ThreeOilLowCost') and \
-            self.config.cross_get(keys='ThreeOilLowCost.GemsFarming.CommissionLimit', default=False)
+        # 遍历使用 GemsFarming 配置组的任务，检查是否启用且开启了 CommissionLimit
+        limit_tasks = [
+            task for task in ['GemsFarming', 'ThreeOilLowCost']
+            if self.config.is_task_enabled(task)
+            and self.config.cross_get(keys=f'{task}.GemsFarming.CommissionLimit', default=False)
+        ]
 
-        if gems_limit or three_oil_limit:
+        if limit_tasks:
             daily = self.daily.select(category_str='daily', status='pending').count
             filtered_urgent = self.comm_choose.intersect_by_eq(self.urgent.select(status='pending')).count
             filtered_extra = self.comm_choose.intersect_by_eq(self.daily.select(category_str='extra', status='pending')).count
             logger.info(f'Daily commission: {daily}, filtered_urgent: {filtered_urgent}, filtered_extra: {filtered_extra}')
             future = nearest_future(future_finish) if len(future_finish) else None
             if daily > 0 and filtered_urgent >= 1:
-                if gems_limit:
-                    logger.info('Having daily commissions to do, delay task `GemsFarming`')
-                    self.config.task_delay(minute=None if future else 120, target=future, task='GemsFarming')
-                if three_oil_limit:
-                    logger.info('Having daily commissions to do, delay task `ThreeOilLowCost`')
-                    self.config.task_delay(minute=None if future else 120, target=future, task='ThreeOilLowCost')
+                for task in limit_tasks:
+                    logger.info(f"Having daily commissions to do, delay task '{task}'")
+                    self.config.task_delay(minute=None if future else 120, target=future, task=task)
             elif filtered_urgent >= 4:
-                if gems_limit:
-                    logger.info('Having too many urgent commissions, delay task `GemsFarming`')
-                    self.config.task_delay(minute=None if future else 120, target=future, task='GemsFarming')
-                if three_oil_limit:
-                    logger.info('Having too many urgent commissions, delay task `ThreeOilLowCost`')
-                    self.config.task_delay(minute=None if future else 120, target=future, task='ThreeOilLowCost')
+                for task in limit_tasks:
+                    logger.info(f"Having too many urgent commissions, delay task '{task}'")
+                    self.config.task_delay(minute=None if future else 120, target=future, task=task)

--- a/module/commission/commission.py
+++ b/module/commission/commission.py
@@ -757,17 +757,30 @@ class RewardCommission(UI, InfoHandler):
             logger.info('No commission running')
             self.config.task_delay(success=False)
 
-        # 延迟钻石 farming 任务
-        if self.config.is_task_enabled('GemsFarming') and \
-                self.config.cross_get(keys='GemsFarming.GemsFarming.CommissionLimit', default=False):
+        # 延迟钻石 farming / 三油低耗任务
+        # 分别检查 GemsFarming 和 ThreeOilLowCost 是否启用且开启了 CommissionLimit
+        gems_limit = self.config.is_task_enabled('GemsFarming') and \
+            self.config.cross_get(keys='GemsFarming.GemsFarming.CommissionLimit', default=False)
+        three_oil_limit = self.config.is_task_enabled('ThreeOilLowCost') and \
+            self.config.cross_get(keys='ThreeOilLowCost.GemsFarming.CommissionLimit', default=False)
+
+        if gems_limit or three_oil_limit:
             daily = self.daily.select(category_str='daily', status='pending').count
             filtered_urgent = self.comm_choose.intersect_by_eq(self.urgent.select(status='pending')).count
             filtered_extra = self.comm_choose.intersect_by_eq(self.daily.select(category_str='extra', status='pending')).count
             logger.info(f'Daily commission: {daily}, filtered_urgent: {filtered_urgent}, filtered_extra: {filtered_extra}')
             future = nearest_future(future_finish) if len(future_finish) else None
             if daily > 0 and filtered_urgent >= 1:
-                logger.info('Having daily commissions to do, delay task `GemsFarming`')
-                self.config.task_delay(minute=None if future else 120, target=future, task='GemsFarming')
+                if gems_limit:
+                    logger.info('Having daily commissions to do, delay task `GemsFarming`')
+                    self.config.task_delay(minute=None if future else 120, target=future, task='GemsFarming')
+                if three_oil_limit:
+                    logger.info('Having daily commissions to do, delay task `ThreeOilLowCost`')
+                    self.config.task_delay(minute=None if future else 120, target=future, task='ThreeOilLowCost')
             elif filtered_urgent >= 4:
-                logger.info('Having too many urgent commissions, delay task `GemsFarming`')
-                self.config.task_delay(minute=None if future else 120, target=future, task='GemsFarming')
+                if gems_limit:
+                    logger.info('Having too many urgent commissions, delay task `GemsFarming`')
+                    self.config.task_delay(minute=None if future else 120, target=future, task='GemsFarming')
+                if three_oil_limit:
+                    logger.info('Having too many urgent commissions, delay task `ThreeOilLowCost`')
+                    self.config.task_delay(minute=None if future else 120, target=future, task='ThreeOilLowCost')


### PR DESCRIPTION
修复了三油低耗防止委托过多功能不起作用的问题
(～￣▽￣)～

## Summary by Sourcery

Bug Fixes:
- 确保 ThreeOilLowCost 低消耗任务能够被正确延迟，当其佣金上限与每日或紧急佣金同时启用时，防止产生过高的佣金。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the ThreeOilLowCost low-consumption task is delayed correctly to prevent excessive commissions when its commission limit is enabled alongside daily or urgent commissions.

</details>