### PR TITLE
Fix：岛屿计划餐厅中相同餐品在不同位置不同数量下的生产逻辑

### DIFF
--- a/module/island/island_manufacture.py
+++ b/module/island/island_manufacture.py
@@ -92,7 +92,7 @@ class IslandManufacture(IslandShopBase):
             self.shop_items.extend(category['items'])
 
         # 初始化需求列表（制造业不需要外部配置的需求）
-        self.post_products = {}
+        self.post_products = []
 
         # 设置配置（使用4个参数，删除任务相关配置）
         self.setup_config(

--- a/module/island/island_restaurant.py
+++ b/module/island/island_restaurant.py
@@ -308,33 +308,9 @@ class IslandRestaurant(IslandShopBase):
             logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
-            # 清空待生产列表
-            self.to_post_products = {}
-
             # ============ 基础需求计算 ============
             logger.info("阶段：基础需求")
-            # 计算基础需求（按槽位顺序处理，同名餐品后续槽位只补差额）
-            virtual_totals = dict(self.current_totals)
-            for name, target in self.post_products:
-                current = virtual_totals.get(name, 0)
-                if current < target:
-                    deficit = target - current
-                    if name in self.to_post_products:
-                        self.to_post_products[name] += deficit
-                    else:
-                        self.to_post_products[name] = deficit
-                    virtual_totals[name] = target
-
-            # 更新 current_totals 为满足所有阶段最高目标后的剩余库存
-            max_targets = {}
-            for name, target in self.post_products:
-                max_targets[name] = max(max_targets.get(name, 0), target)
-            for name, max_target in max_targets.items():
-                current = self.current_totals.get(name, 0)
-                if current < max_target:
-                    self.current_totals[name] = 0
-                else:
-                    self.current_totals[name] = current - max_target
+            self._compute_base_demands()
 
             logger.info(f"待完成备餐: {self.to_post_products}")
             logger.info(f"当前剩余库存: {self.current_totals}")

--- a/module/island/island_restaurant.py
+++ b/module/island/island_restaurant.py
@@ -153,23 +153,27 @@ class IslandRestaurant(IslandShopBase):
         current_season = self.season_config.season
         current_restaurant_items = SEASONAL_ITEMS.get(current_season, {}).get('restaurant', [])
         for spring_item, slot_idx in SEASONAL_MEAL_SWITCH.items():
-            if spring_item not in self.post_products:
+            if not any(name == spring_item for name, _ in self.post_products):
                 continue
+            spring_name = '凉拌双笋' if spring_item == 'double_bamboo_shoots' else '芦笋炒虾仁'
             if slot_idx < len(current_restaurant_items):
                 seasonal_item = current_restaurant_items[slot_idx]
                 if seasonal_item != spring_item:
-                    qty = self.post_products.pop(spring_item)
-                    self.post_products[seasonal_item] = qty
-                    spring_name = '凉拌双笋' if spring_item == 'double_bamboo_shoots' else '芦笋炒虾仁'
+                    self.post_products = [
+                        (seasonal_item, target) if name == spring_item else (name, target)
+                        for name, target in self.post_products
+                    ]
                     logger.info(
                         f"季节餐品自动切换: {spring_item}({spring_name}) -> {seasonal_item}"
                         f"（当前季节: {self.season_config.season_name}）"
                     )
             else:
-                qty = self.post_products.pop(spring_item)
-                spring_name = '凉拌双笋' if spring_item == 'double_bamboo_shoots' else '芦笋炒虾仁'
+                self.post_products = [
+                    (name, target) for name, target in self.post_products
+                    if name != spring_item
+                ]
                 logger.info(
-                    f"季节餐品自动移除: {spring_item}({spring_name}) x{qty}"
+                    f"季节餐品自动移除: {spring_item}({spring_name})"
                     f"（{self.season_config.season_name} 无对应槽位的季节餐品）"
                 )
 
@@ -291,7 +295,8 @@ class IslandRestaurant(IslandShopBase):
 
             # 计算当前总库存
             self.current_totals = {}
-            for item in set(self.post_products.keys()) | set(self.post_check_meal.keys()) | set(
+            all_product_names = set(name for name, _ in self.post_products)
+            for item in all_product_names | set(self.post_check_meal.keys()) | set(
                     self.warehouse_counts.keys()):
                 self.current_totals[item] = self.post_check_meal.get(item, 0) + self.warehouse_counts.get(item, 0)
 
@@ -300,7 +305,7 @@ class IslandRestaurant(IslandShopBase):
             logger.info(f"仓库库存: {self.warehouse_counts}")
             logger.info(f"生产中库存: {self.post_check_meal}")
             logger.info(f"当前总库存: {self.current_totals}")
-            logger.info(f"基础需求配置: {self.post_products}")
+            logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
             # 清空待生产列表
@@ -308,13 +313,29 @@ class IslandRestaurant(IslandShopBase):
 
             # ============ 基础需求计算 ============
             logger.info("阶段：基础需求")
-            for item, target in self.post_products.items():
-                current = self.current_totals.get(item, 0)
+            # 计算基础需求（按槽位顺序处理，同名餐品后续槽位只补差额）
+            virtual_totals = dict(self.current_totals)
+            for name, target in self.post_products:
+                current = virtual_totals.get(name, 0)
                 if current < target:
-                    self.to_post_products[item] = target - current
-                    self.current_totals[item] = 0
+                    deficit = target - current
+                    if name in self.to_post_products:
+                        self.to_post_products[name] += deficit
+                    else:
+                        self.to_post_products[name] = deficit
+                    virtual_totals[name] = target
+
+            # 更新 current_totals 为满足所有阶段最高目标后的剩余库存
+            max_targets = {}
+            for name, target in self.post_products:
+                max_targets[name] = max(max_targets.get(name, 0), target)
+            for name, max_target in max_targets.items():
+                current = self.current_totals.get(name, 0)
+                if current < max_target:
+                    self.current_totals[name] = 0
                 else:
-                    self.current_totals[item] = current - target
+                    self.current_totals[name] = current - max_target
+
             logger.info(f"待完成备餐: {self.to_post_products}")
             logger.info(f"当前剩余库存: {self.current_totals}")
 

--- a/module/island/island_restaurant.py
+++ b/module/island/island_restaurant.py
@@ -308,8 +308,6 @@ class IslandRestaurant(IslandShopBase):
             logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
-            # ============ 基础需求计算 ============
-            logger.info("阶段：基础需求")
             self._compute_base_demands()
 
             logger.info(f"待完成备餐: {self.to_post_products}")

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -298,6 +298,9 @@ class IslandShopBase(Island, WarehouseOCR):
         将结果写入 self.to_post_products 并更新 self.current_totals
         为满足所有阶段最高目标后的剩余库存。
         """
+        # ============ 基础需求计算 ============
+        logger.info("阶段：基础需求")
+
         self.to_post_products = {}
         virtual_totals = dict(self.current_totals)
 
@@ -364,8 +367,6 @@ class IslandShopBase(Island, WarehouseOCR):
             logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
-            # ============ 基础需求计算 ============
-            logger.info("阶段：基础需求")
             self._compute_base_demands()
 
             logger.info(f"待完成备餐: {self.to_post_products}")

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -292,6 +292,36 @@ class IslandShopBase(Island, WarehouseOCR):
 
     # ============ 核心逻辑 ============
 
+    def _compute_base_demands(self):
+        """计算基础需求：按槽位顺序处理，同名餐品后续槽位只补差额。
+
+        将结果写入 self.to_post_products 并更新 self.current_totals
+        为满足所有阶段最高目标后的剩余库存。
+        """
+        self.to_post_products = {}
+        virtual_totals = dict(self.current_totals)
+
+        for name, target in self.post_products:
+            current = virtual_totals.get(name, 0)
+            if current < target:
+                deficit = target - current
+                if name in self.to_post_products:
+                    self.to_post_products[name] += deficit
+                else:
+                    self.to_post_products[name] = deficit
+                virtual_totals[name] = target
+
+        # 更新 current_totals 为满足所有阶段最高目标后的剩余库存
+        max_targets = {}
+        for name, target in self.post_products:
+            max_targets[name] = max(max_targets.get(name, 0), target)
+        for name, max_target in max_targets.items():
+            current = self.current_totals.get(name, 0)
+            if current < max_target:
+                self.current_totals[name] = 0
+            else:
+                self.current_totals[name] = current - max_target
+
     def run(self):
         self.island_error = False
         self.goto_postmanage()
@@ -334,33 +364,9 @@ class IslandShopBase(Island, WarehouseOCR):
             logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
-            # 清空待生产列表
-            self.to_post_products = {}
-
             # ============ 基础需求计算 ============
             logger.info("阶段：基础需求")
-            # 计算基础需求（按槽位顺序处理，同名餐品后续槽位只补差额）
-            virtual_totals = dict(self.current_totals)
-            for name, target in self.post_products:
-                current = virtual_totals.get(name, 0)
-                if current < target:
-                    deficit = target - current
-                    if name in self.to_post_products:
-                        self.to_post_products[name] += deficit
-                    else:
-                        self.to_post_products[name] = deficit
-                    virtual_totals[name] = target
-
-            # 更新 current_totals 为满足所有阶段最高目标后的剩余库存
-            max_targets = {}
-            for name, target in self.post_products:
-                max_targets[name] = max(max_targets.get(name, 0), target)
-            for name, max_target in max_targets.items():
-                current = self.current_totals.get(name, 0)
-                if current < max_target:
-                    self.current_totals[name] = 0
-                else:
-                    self.current_totals[name] = current - max_target
+            self._compute_base_demands()
 
             logger.info(f"待完成备餐: {self.to_post_products}")
             logger.info(f"当前剩余库存: {self.current_totals}")

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -302,6 +302,8 @@ class IslandShopBase(Island, WarehouseOCR):
         logger.info("阶段：基础需求")
 
         self.to_post_products = {}
+        # virtual_totals 用于模拟按槽位顺序扣除库存后的剩余值，
+        # 确保同名餐品的后续槽位只补差额，不重复计算已分配给前序槽位的库存
         virtual_totals = dict(self.current_totals)
 
         for name, target in self.post_products:

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -28,7 +28,7 @@ class IslandShopBase(Island, WarehouseOCR):
         self.name_to_config = {}
         self.posts = {}
         self.post_check_meal = {}  # 岗位生产中的产品
-        self.post_products = {}
+        self.post_products = []  # 有序列表，允许同名餐品出现在多个槽位
         self.warehouse_counts = {}  # 仓库识别到的产品
         self.to_post_products = {}
         self.current_totals = {}
@@ -112,7 +112,7 @@ class IslandShopBase(Island, WarehouseOCR):
         self.config_post_number = config_post_number
 
         # 读取8种餐品需求
-        self.post_products = {}
+        self.post_products = []
 
         for i in range(1, 9):  # 1到8
             meal_key = f'{self.config_meal_prefix}{i}'
@@ -121,7 +121,7 @@ class IslandShopBase(Island, WarehouseOCR):
             meal_name = getattr(self.config, meal_key, None)
             if meal_name is not None and meal_name != "None":
                 meal_number = getattr(self.config, number_key, 0)
-                self.post_products[meal_name] = meal_number
+                self.post_products.append((meal_name, meal_number))
 
     def initialize_shop(self):
         """初始化店铺，子类必须在__init__中调用"""
@@ -321,7 +321,8 @@ class IslandShopBase(Island, WarehouseOCR):
 
             # 计算当前总库存
             self.current_totals = {}
-            for item in set(self.post_products.keys()) | set(self.post_check_meal.keys()) | set(
+            all_product_names = set(name for name, _ in self.post_products)
+            for item in all_product_names | set(self.post_check_meal.keys()) | set(
                     self.warehouse_counts.keys()):
                 self.current_totals[item] = self.post_check_meal.get(item, 0) + self.warehouse_counts.get(item, 0)
 
@@ -330,7 +331,7 @@ class IslandShopBase(Island, WarehouseOCR):
             logger.info(f"仓库库存: {self.warehouse_counts}")
             logger.info(f"生产中库存: {self.post_check_meal}")
             logger.info(f"当前总库存: {self.current_totals}")
-            logger.info(f"基础需求配置: {self.post_products}")
+            logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
             # 清空待生产列表
@@ -338,14 +339,29 @@ class IslandShopBase(Island, WarehouseOCR):
 
             # ============ 基础需求计算 ============
             logger.info("阶段：基础需求")
-            # 计算基础需求
-            for item, target in self.post_products.items():
-                current = self.current_totals.get(item, 0)
+            # 计算基础需求（按槽位顺序处理，同名餐品后续槽位只补差额）
+            virtual_totals = dict(self.current_totals)
+            for name, target in self.post_products:
+                current = virtual_totals.get(name, 0)
                 if current < target:
-                    self.to_post_products[item] = target - current
-                    self.current_totals[item] = 0
+                    deficit = target - current
+                    if name in self.to_post_products:
+                        self.to_post_products[name] += deficit
+                    else:
+                        self.to_post_products[name] = deficit
+                    virtual_totals[name] = target
+
+            # 更新 current_totals 为满足所有阶段最高目标后的剩余库存
+            max_targets = {}
+            for name, target in self.post_products:
+                max_targets[name] = max(max_targets.get(name, 0), target)
+            for name, max_target in max_targets.items():
+                current = self.current_totals.get(name, 0)
+                if current < max_target:
+                    self.current_totals[name] = 0
                 else:
-                    self.current_totals[item] = current - target
+                    self.current_totals[name] = current - max_target
+
             logger.info(f"待完成备餐: {self.to_post_products}")
             logger.info(f"当前剩余库存: {self.current_totals}")
             # ============ 处理套餐分解 ============

--- a/module/island/island_teahouse.py
+++ b/module/island/island_teahouse.py
@@ -154,22 +154,27 @@ class IslandTeahouse(IslandShopBase):
         current_season = self.season_config.season
         current_teahouse_items = SEASONAL_ITEMS.get(current_season, {}).get('teahouse', [])
         for spring_item, slot_idx in SEASONAL_TEAHOUSE_SWITCH.items():
-            if spring_item not in self.post_products:
+            if not any(name == spring_item for name, _ in self.post_products):
                 continue
             cn_name = CN_NAMES.get(spring_item, spring_item)
             if slot_idx < len(current_teahouse_items):
                 seasonal_item = current_teahouse_items[slot_idx]
                 if seasonal_item != spring_item:
-                    qty = self.post_products.pop(spring_item)
-                    self.post_products[seasonal_item] = qty
+                    self.post_products = [
+                        (seasonal_item, target) if name == spring_item else (name, target)
+                        for name, target in self.post_products
+                    ]
                     logger.info(
                         f"季节餐品自动切换: {spring_item}({cn_name}) -> {seasonal_item}"
                         f"（当前季节: {self.season_config.season_name}）"
                     )
             else:
-                qty = self.post_products.pop(spring_item)
+                self.post_products = [
+                    (name, target) for name, target in self.post_products
+                    if name != spring_item
+                ]
                 logger.info(
-                    f"季节餐品自动移除: {spring_item}({cn_name}) x{qty}"
+                    f"季节餐品自动移除: {spring_item}({cn_name})"
                     f"（{self.season_config.season_name} 无对应槽位的季节餐品）"
                 )
 
@@ -311,7 +316,8 @@ class IslandTeahouse(IslandShopBase):
 
             # 计算当前总库存
             self.current_totals = {}
-            for item in set(self.post_products.keys()) | set(self.post_check_meal.keys()) | set(
+            all_product_names = set(name for name, _ in self.post_products)
+            for item in all_product_names | set(self.post_check_meal.keys()) | set(
                     self.warehouse_counts.keys()):
                 self.current_totals[item] = self.post_check_meal.get(item, 0) + self.warehouse_counts.get(item, 0)
 
@@ -320,7 +326,7 @@ class IslandTeahouse(IslandShopBase):
             logger.info(f"仓库库存: {self.warehouse_counts}")
             logger.info(f"生产中库存: {self.post_check_meal}")
             logger.info(f"当前总库存: {self.current_totals}")
-            logger.info(f"基础需求配置: {self.post_products}")
+            logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
             # 清空待生产列表
@@ -328,13 +334,29 @@ class IslandTeahouse(IslandShopBase):
 
             # ============ 基础需求计算 ============
             logger.info("阶段：基础需求")
-            for item, target in self.post_products.items():
-                current = self.current_totals.get(item, 0)
+            # 计算基础需求（按槽位顺序处理，同名餐品后续槽位只补差额）
+            virtual_totals = dict(self.current_totals)
+            for name, target in self.post_products:
+                current = virtual_totals.get(name, 0)
                 if current < target:
-                    self.to_post_products[item] = target - current
-                    self.current_totals[item] = 0
+                    deficit = target - current
+                    if name in self.to_post_products:
+                        self.to_post_products[name] += deficit
+                    else:
+                        self.to_post_products[name] = deficit
+                    virtual_totals[name] = target
+
+            # 更新 current_totals 为满足所有阶段最高目标后的剩余库存
+            max_targets = {}
+            for name, target in self.post_products:
+                max_targets[name] = max(max_targets.get(name, 0), target)
+            for name, max_target in max_targets.items():
+                current = self.current_totals.get(name, 0)
+                if current < max_target:
+                    self.current_totals[name] = 0
                 else:
-                    self.current_totals[item] = current - target
+                    self.current_totals[name] = current - max_target
+
             logger.info(f"待完成备餐: {self.to_post_products}")
             logger.info(f"当前剩余库存: {self.current_totals}")
 

--- a/module/island/island_teahouse.py
+++ b/module/island/island_teahouse.py
@@ -329,33 +329,9 @@ class IslandTeahouse(IslandShopBase):
             logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
-            # 清空待生产列表
-            self.to_post_products = {}
-
             # ============ 基础需求计算 ============
             logger.info("阶段：基础需求")
-            # 计算基础需求（按槽位顺序处理，同名餐品后续槽位只补差额）
-            virtual_totals = dict(self.current_totals)
-            for name, target in self.post_products:
-                current = virtual_totals.get(name, 0)
-                if current < target:
-                    deficit = target - current
-                    if name in self.to_post_products:
-                        self.to_post_products[name] += deficit
-                    else:
-                        self.to_post_products[name] = deficit
-                    virtual_totals[name] = target
-
-            # 更新 current_totals 为满足所有阶段最高目标后的剩余库存
-            max_targets = {}
-            for name, target in self.post_products:
-                max_targets[name] = max(max_targets.get(name, 0), target)
-            for name, max_target in max_targets.items():
-                current = self.current_totals.get(name, 0)
-                if current < max_target:
-                    self.current_totals[name] = 0
-                else:
-                    self.current_totals[name] = current - max_target
+            self._compute_base_demands()
 
             logger.info(f"待完成备餐: {self.to_post_products}")
             logger.info(f"当前剩余库存: {self.current_totals}")

--- a/module/island/island_teahouse.py
+++ b/module/island/island_teahouse.py
@@ -329,8 +329,6 @@ class IslandTeahouse(IslandShopBase):
             logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
-            # ============ 基础需求计算 ============
-            logger.info("阶段：基础需求")
             self._compute_base_demands()
 
             logger.info(f"待完成备餐: {self.to_post_products}")


### PR DESCRIPTION
修复了岛屿计划中餐厅生产时相同餐品在不不同位置不同数量下的生产逻辑

举例：

餐品一：20个a，餐品二：20个b，餐品3：20个c，餐品4：20个d，餐品5：50个a，餐品6：50个b，餐品7：50个c，餐品8：50个d

当前版本下，同名餐品重复出现在不同槽位时，后面的会覆盖前面的，按字典遍历顺序 A→B→C→D 直接生产到 50，不会先到 20

o(*￣︶￣*)o

（如果有问题，我就去拷打蓝色小鲸鱼）

## Summary by Sourcery

允许岛上商店处理不同档位中重复的菜品，并相应修复基础需求（base demand）计算

Bug Fixes（错误修复）:
- 修复餐厅和茶馆的生产逻辑，使不同档位中的相同菜品能累积计算，而不是由后面的档位覆盖前面的档位
- 修正季节性菜品自动切换逻辑，使其在不依赖字典键的情况下，更新或移除所有匹配的档位

Enhancements（增强改进）:
- 将 `post_products` 表示为有序的档位列表，以支持基于档位的逻辑，并更清晰地记录各个商店中配置的菜品档位日志
- 优化基础需求计算，按档位顺序处理，仅在存在缺口时补足，并根据每道菜的最大目标值调整剩余库存

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow island shops to handle duplicate meals across different slots and fix base demand calculation accordingly

Bug Fixes:
- Fix restaurant and teahouse production so identical meals in different slots contribute cumulatively instead of later slots overwriting earlier ones
- Correct seasonal meal auto-switching to update or remove all matching slots without relying on dictionary keys

Enhancements:
- Represent post_products as an ordered list of slots, enabling slot-based logic and clearer logging of configured meal slots across shops
- Refine base demand calculation to process slots in order, only topping up deficits and adjusting remaining inventory based on the maximum target per meal

</details>