### PR TITLE
[codex] fix MuMu Pro detection for generic ADB serials

### DIFF
--- a/module/device/connection_attr.py
+++ b/module/device/connection_attr.py
@@ -169,7 +169,12 @@ class ConnectionAttr:
     def is_mumu_family(self):
         # 127.0.0.1:7555
         # 127.0.0.1:16384 + 32*n
-        return self.serial == '127.0.0.1:7555' or self.is_mumu12_family
+        # MuMu Pro on macOS may expose a generic emulator-* serial instead.
+        return (
+            self.serial == '127.0.0.1:7555'
+            or self.is_mumu12_family
+            or self.config.EmulatorInfo_Emulator == 'MuMuPro'
+        )
 
     @cached_property
     def is_ldplayer_bluestacks_family(self):


### PR DESCRIPTION
## What changed

Treat devices explicitly configured as `MuMuPro` as part of the MuMu family, even when they expose a generic `emulator-*` ADB serial.

## Root cause

MuMu Pro on macOS can expose `emulator-5554` instead of its usual `127.0.0.1:16xxx` serial. `is_mumu_family` previously identified MuMu only by serial and port, so this connection was classified as a generic emulator.

As a result, DroidCast_raw skipped the MuMu-specific physical resolution and orientation handling. Its `720x1280` RGB565 buffer was interpreted without the required rotation, producing a sideways `1280x720` screenshot and causing repeated `Unknown ui page` errors.

## Impact

DroidCast and DroidCast_raw now apply their existing MuMu orientation handling when MuMu Pro is explicitly selected, while other emulators using `emulator-*` serials remain unaffected.

## Validation

- Confirmed the affected setup reports:
  - configured emulator: `MuMuPro`
  - serial: `emulator-5554`
  - physical display: `720x1280`
  - orientation: `1`
- Before the change, `is_mumu_family` and `is_mumu_over_version_356` were both false.
- After the change, both are true.
- Captured a live DroidCast_raw screenshot after the change and verified it is correctly oriented at `1280x720`.
- Compared it with an ADB screenshot; static UI regions align, with expected RGB565 color precision differences.
- Ran `git diff --check` and compiled `module/device/connection_attr.py`.

## Summary by Sourcery

扩展岛屿自动化功能，并改进模拟器与战斗处理。

Bug Fixes（错误修复）:
- 在使用通用 `emulator-*` ADB 序列号时，也将显式配置的 MuMu Pro 实例视为 MuMu 家族。
- 在自动搜索战斗中，通过检测专门的 Boss 撤退按钮来处理 Boss 舰队撤退。
- 通过更新按钮区域和页面映射，修正岛屿商店和渔场商店的 UI 检测。

Enhancements（功能增强）:
- 为 YukikazeTaskManager 的岛屿相关任务优先级配置扩展更细致的岛屿子任务。
- 调整岛屿任务配置，使其绕过 Scheduler 封装，直接运行 `IslandPlan`。
- 优化岛屿 UI 资源，适配新的岛屿商店、农场、牧场、矿山/森林、每日采集、制造和商业据点。
- 引入按钮区域编辑开发工具，用于帮助重新生成精确的 UI 按钮元数据。

Documentation（文档）:
- 增补一份全面的岛屿功能扩展设计文档，涵盖计划中的 TODO 列表、阈值、顺序、运输、业务逻辑和交互细节。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend island automation features and improve emulator and combat handling.

Bug Fixes:
- Treat explicitly configured MuMu Pro instances as MuMu family even when using generic emulator-* ADB serials.
- Handle boss-fleet withdrawal by detecting a dedicated boss withdraw button during auto search combat.
- Correct island shop and fishery shop UI detection by updating button regions and page mappings.

Enhancements:
- Expand YukikazeTaskManager island-related task priority configuration with detailed island sub-tasks.
- Adjust Island task configuration to run IslandPlan directly without the Scheduler wrapper.
- Refine island UI assets for new island shop, farm, ranch, mine/forest, daily gather, manufacture, and business locations.
- Introduce a button-region editing dev tool to assist regenerating accurate UI button metadata.

Documentation:
- Add a comprehensive island feature extension design document covering planned TODO list, thresholds, orders, transport, business logic, and interactions.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

扩展岛屿自动化功能，并改进模拟器与战斗处理。

Bug Fixes（错误修复）:
- 在使用通用 `emulator-*` ADB 序列号时，也将显式配置的 MuMu Pro 实例视为 MuMu 家族。
- 在自动搜索战斗中，通过检测专门的 Boss 撤退按钮来处理 Boss 舰队撤退。
- 通过更新按钮区域和页面映射，修正岛屿商店和渔场商店的 UI 检测。

Enhancements（功能增强）:
- 为 YukikazeTaskManager 的岛屿相关任务优先级配置扩展更细致的岛屿子任务。
- 调整岛屿任务配置，使其绕过 Scheduler 封装，直接运行 `IslandPlan`。
- 优化岛屿 UI 资源，适配新的岛屿商店、农场、牧场、矿山/森林、每日采集、制造和商业据点。
- 引入按钮区域编辑开发工具，用于帮助重新生成精确的 UI 按钮元数据。

Documentation（文档）:
- 增补一份全面的岛屿功能扩展设计文档，涵盖计划中的 TODO 列表、阈值、顺序、运输、业务逻辑和交互细节。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend island automation features and improve emulator and combat handling.

Bug Fixes:
- Treat explicitly configured MuMu Pro instances as MuMu family even when using generic emulator-* ADB serials.
- Handle boss-fleet withdrawal by detecting a dedicated boss withdraw button during auto search combat.
- Correct island shop and fishery shop UI detection by updating button regions and page mappings.

Enhancements:
- Expand YukikazeTaskManager island-related task priority configuration with detailed island sub-tasks.
- Adjust Island task configuration to run IslandPlan directly without the Scheduler wrapper.
- Refine island UI assets for new island shop, farm, ranch, mine/forest, daily gather, manufacture, and business locations.
- Introduce a button-region editing dev tool to assist regenerating accurate UI button metadata.

Documentation:
- Add a comprehensive island feature extension design document covering planned TODO list, thresholds, orders, transport, business logic, and interactions.

</details>

</details>