### PR TITLE
fix(island): 餐厅生产调度优先级改为槽位顺序

### DIFF
--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -700,29 +700,34 @@ class IslandShopBase(Island, WarehouseOCR):
         # 非常驻餐品模式：处理所有产品需求
         products_to_process = list(self.to_post_products.items())
 
-        # 如果有多个产品需求，按优先级排序
+        # 如果有多个产品需求，按槽位顺序排序（原料优先）
         if len(products_to_process) > 1:
-            def production_priority(item):
-                product, quantity = item
-                if product in self.meal_compositions:
-                    # 检查套餐原材料是否充足
-                    max_producible = self.get_max_producible(product, min(6, quantity))
-                    if max_producible > 0:
-                        return 0  # 最高优先级：可立即生产的套餐
-                    else:
-                        return 2  # 低优先级：原材料不足的套餐
-                else:
-                    # 基础餐品：检查是否可以生产
-                    max_producible = self.get_max_producible(product, min(6, quantity))
-                    if max_producible > 0:
-                        return 1  # 中等优先级：可生产的基础餐品
-                    else:
-                        return 3  # 最低优先级：无法生产的基础餐品
+            # 构建槽位顺序映射
+            slot_index = {}
+            idx = 0
+            for name, _ in self.post_products:
+                if name not in slot_index:
+                    slot_index[name] = idx
+                    idx += 1
 
-            products_to_process = sorted(products_to_process, key=production_priority)
+            # 原料取其服务套餐中最早槽位的索引
+            for meal, comp in self.meal_compositions.items():
+                if meal in slot_index:
+                    meal_slot = slot_index[meal]
+                    for mat in comp['required']:
+                        if mat not in slot_index or slot_index[mat] > meal_slot:
+                            slot_index[mat] = meal_slot
 
-        # 记录无法生产的产品
-        products_removed = []
+            # 按槽位顺序排序，同槽位内原料优先于成品
+            post_product_names = {name for name, _ in self.post_products}
+
+            def slot_priority(item):
+                product, _ = item
+                slot = slot_index.get(product, 999)
+                is_material = product not in post_product_names
+                return (slot, 0 if is_material else 1)
+
+            products_to_process.sort(key=slot_priority)
 
         # 为每个空闲岗位分配生产任务
         post_index = 0
@@ -747,12 +752,8 @@ class IslandShopBase(Island, WarehouseOCR):
                 max_producible = self.get_max_producible(product, min(6, remaining_need))
 
                 if max_producible <= 0:
-                    logger.warning(f"生产 {product} 的材料不足，从生产计划中移除")
-                    products_removed.append(product)
-                    # 从生产计划中移除该产品
-                    if product in self.to_post_products:
-                        del self.to_post_products[product]
-                    break  # 跳出当前产品的生产循环
+                    logger.info(f"生产 {product} 的材料暂时不足，保留在计划中等待下一轮")
+                    break  # 跳过当前产品，但保留在 to_post_products 中
 
                 # 分配生产
                 post_num = post_id[-1]
@@ -763,12 +764,8 @@ class IslandShopBase(Island, WarehouseOCR):
 
                 # 如果实际生产数量为0，说明原料不足
                 if actual_number == 0:
-                    logger.warning(f"生产 {product} 时检测到原料不足，从生产计划中移除")
-                    products_removed.append(product)
-                    # 从生产计划中移除该产品
-                    if product in self.to_post_products:
-                        del self.to_post_products[product]
-                    break  # 跳出当前产品的生产循环
+                    logger.info(f"生产 {product} 时检测到原料不足，保留在计划中等待下一轮")
+                    break  # 跳过当前产品，但保留在 to_post_products 中
 
                 # 更新需求
                 if product in self.to_post_products:
@@ -785,9 +782,6 @@ class IslandShopBase(Island, WarehouseOCR):
             # 如果所有岗位都已分配，退出循环
             if post_index >= total_idle_posts:
                 break
-
-        if products_removed:
-            logger.warning(f"以下产品因原料不足已从生产计划中移除: {products_removed}")
 
         if self.to_post_products:
             logger.info(f"生产安排完成，剩余需求: {self.to_post_products}")

--- a/module/island/island_teahouse.py
+++ b/module/island/island_teahouse.py
@@ -54,7 +54,7 @@ class IslandTeahouse(IslandShopBase):
                 self.special_food = self.seasonal_high_priority_drink['name']
                 logger.info(f"季节高优先级饮品: {self.seasonal_high_priority_drink['cn_name']}")
             else:
-                self.special_food = 'winter_jasmine_tea'
+                self.special_food = 'spring_flower_tea'
         else:
             logger.info("迎春花茶优先生产已关闭，跳过季节限定饮品")
 


### PR DESCRIPTION
将餐厅的生产优先级从原先的按照是否立刻可生产排序，改为按照槽位排序

在原先的生产过程中，如果一个套餐不能立刻生产，而是需要先制作前置，他就会被往后放，从而不会按照槽位顺序生产

此次改动后，一个套餐如果不能立刻生产其本体，则会先生产前置，随后生产套餐，直至套餐满足生产指标后，才会进入下一个槽位

这项改动满足了对生产顺序和生产优先级的精细化调控，与我之前的那个pr结合可以定制阶梯化的生产，例如先按顺序将abcd都生产到20，然后再将abcd按顺序生产到50，从而可以在满足经营需求的情况下稳步提升库存

o(*￣︶￣*)o

## Summary by Sourcery

调整岛屿餐厅的生产排程，使其按照槽位顺序并以“材料优先”的方式进行处理，同时保留当前无法生产的菜品以供后续轮次使用，并更新默认的四季茶楼特调饮品。

Bug Fixes:
- 确保餐厅生产遵循已配置的槽位顺序，而不是根据“当前是否可生产”重新排序，防止槽位靠后的餐品被提前生产、打乱顺序。

Enhancements:
- 在同一槽位内优先处理基础材料，再生产成品餐点，以便在制作套餐组合前自动满足前置材料需求。
- 对于由于材料暂时不足而无法生产的菜品，将其保留在生产计划中而不是移除，这样在资源补足后可以自动恢复生产。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust island restaurant production scheduling to follow slot order with material-first processing and retain unproducible items for future rounds, and update the default seasonal teahouse special drink.

Bug Fixes:
- Ensure restaurant production follows configured slot order instead of reprioritizing based on immediate producibility, preventing later-slot meals from being produced out of order.

Enhancements:
- Prioritize base materials before finished meals within the same slot to automatically fulfill prerequisites before producing meal combos.
- Keep items with temporarily insufficient materials in the production plan rather than removing them, allowing them to resume production when resources become available.

</details>