### PR TITLE
fix(island): 材料完全不足时跳过当前槽位，避免永久卡死

### DIFF
--- a/module/island/island_restaurant.py
+++ b/module/island/island_restaurant.py
@@ -308,6 +308,8 @@ class IslandRestaurant(IslandShopBase):
             logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
+            # 保存原始库存，retry 时恢复（避免 max_targets 清零影响重算）
+            _orig_totals = dict(self.current_totals)
             self._compute_base_demands()
 
             logger.info(f"待完成备餐: {self.to_post_products}")
@@ -347,8 +349,9 @@ class IslandRestaurant(IslandShopBase):
             if self.to_post_products:
                 stalled_before = set(self._stalled)
                 self.schedule_production()
-                # 有新产品被标记停滞且仍有空闲岗位 → 重跑需求
+                # 有新产品被标记停滞且仍有空闲岗位 → 恢复库存后重跑需求
                 if set(self._stalled) - stalled_before and self.get_idle_posts():
+                    self.current_totals = _orig_totals
                     self._compute_base_demands()
                     if self.to_post_products:
                         self.to_post_products = self.process_meal_requirements(self.to_post_products)

--- a/module/island/island_restaurant.py
+++ b/module/island/island_restaurant.py
@@ -343,9 +343,16 @@ class IslandRestaurant(IslandShopBase):
                 self.to_post_products = temp_products
                 logger.info(f"剩余基础需求生产计划: {self.to_post_products}")
 
-            # ============ 安排基础需求生产 ============
+            # ============ 安排基础需求生产（带停滞重试） ============
             if self.to_post_products:
+                stalled_before = set(self._stalled)
                 self.schedule_production()
+                # 有新产品被标记停滞且仍有空闲岗位 → 重跑需求
+                if set(self._stalled) - stalled_before and self.get_idle_posts():
+                    self._compute_base_demands()
+                    if self.to_post_products:
+                        self.to_post_products = self.process_meal_requirements(self.to_post_products)
+                        self.schedule_production()
             else:
                 logger.info("基础需求已满足")
 

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -391,6 +391,8 @@ class IslandShopBase(Island, WarehouseOCR):
             logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
+            # 保存原始库存，retry 时恢复
+            _orig_totals = dict(self.current_totals)
             self._compute_base_demands()
 
             logger.info(f"待完成备餐: {self.to_post_products}")
@@ -404,8 +406,9 @@ class IslandShopBase(Island, WarehouseOCR):
             if self.to_post_products:
                 stalled_before = set(self._stalled)
                 self.schedule_production()
-                # 有新产品被标记停滞且仍有空闲岗位 → 重跑需求
+                # 有新产品被标记停滞且仍有空闲岗位 → 恢复库存后重跑需求
                 if set(self._stalled) - stalled_before and self.get_idle_posts():
+                    self.current_totals = _orig_totals
                     self._compute_base_demands()
                     if self.to_post_products:
                         self.to_post_products = self.process_meal_requirements(self.to_post_products)
@@ -765,6 +768,7 @@ class IslandShopBase(Island, WarehouseOCR):
             products_to_process.sort(key=slot_priority)
 
         # 为每个空闲岗位分配生产任务
+        _produced_any = set()  # 本轮至少产出了1个的产品
         post_index = 0
         total_idle_posts = len(idle_posts)
 
@@ -802,6 +806,8 @@ class IslandShopBase(Island, WarehouseOCR):
                     logger.info(f"生产 {product} 时检测到原料不足，保留在计划中等待下一轮")
                     break  # 跳过当前产品，但保留在 to_post_products 中
 
+                # 记录已产出（部分生产不算停滞）
+                _produced_any.add(product)
                 # 更新需求
                 if product in self.to_post_products:
                     self.to_post_products[product] -= actual_number
@@ -818,15 +824,15 @@ class IslandShopBase(Island, WarehouseOCR):
             if post_index >= total_idle_posts:
                 break
 
-        # 更新停滞标记：生产失败的记录下来，成功的清除
+        # 更新停滞标记：只标记零产量的（真正游戏层不足），部分生产的跳过
         remaining = set(self.to_post_products.keys())
-        failed = to_post_before & remaining
+        zero_produced = {p for p in (to_post_before & remaining) if p not in _produced_any}
         cleared = to_post_before - remaining
-        if failed:
-            logger.info(f"[stalled] 标记游戏层失败: {failed}")
+        if zero_produced:
+            logger.info(f"[stalled] 标记游戏层失败: {zero_produced}")
         if cleared:
             logger.info(f"[stalled] 清除标记: {cleared}")
-        self._stalled.update(failed)
+        self._stalled.update(zero_produced)
         self._stalled.difference_update(cleared)
 
         if self.to_post_products:

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -32,6 +32,7 @@ class IslandShopBase(Island, WarehouseOCR):
         self.warehouse_counts = {}  # 仓库识别到的产品
         self.to_post_products = {}
         self.current_totals = {}
+        self._stalled_products = set()  # 游戏层材料不足的产品，本轮跳过
 
         # 特殊材料（子类可覆盖）
         self.special_materials = {}
@@ -312,6 +313,10 @@ class IslandShopBase(Island, WarehouseOCR):
         for idx, (name, target) in enumerate(self.post_products):
             current = virtual_totals.get(name, 0)
             if current < target:
+                # 此前游戏中材料不足 → 本轮跳过，等后续模块补料
+                if name in self._stalled_products:
+                    logger.info(f"槽位{idx + 1} {name} 此前游戏中材料不足，本轮跳过")
+                    continue
                 deficit = target - current
                 # 检查能否至少生产一部分（>0 即材料部分可得）
                 if self.get_max_producible(name, min(6, deficit)) <= 0:
@@ -704,6 +709,7 @@ class IslandShopBase(Island, WarehouseOCR):
             return
 
         # 非常驻餐品模式：处理所有产品需求
+        to_post_before = set(self.to_post_products.keys())
         products_to_process = list(self.to_post_products.items())
 
         # 如果有多个产品需求，按槽位顺序排序（原料优先）
@@ -794,6 +800,11 @@ class IslandShopBase(Island, WarehouseOCR):
             # 如果所有岗位都已分配，退出循环
             if post_index >= total_idle_posts:
                 break
+
+        # 更新停滞标记：生产失败的记录下来，成功的清除
+        remaining = set(self.to_post_products.keys())
+        self._stalled_products.update(to_post_before & remaining)
+        self._stalled_products.difference_update(to_post_before - remaining)
 
         if self.to_post_products:
             logger.info(f"生产安排完成，剩余需求: {self.to_post_products}")

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -400,10 +400,16 @@ class IslandShopBase(Island, WarehouseOCR):
                 self.to_post_products = self.process_meal_requirements(self.to_post_products)
                 logger.info(f"基础需求生产计划: {self.to_post_products}")
 
-            # ============ 安排基础需求生产 ============
+            # ============ 安排基础需求生产（带停滞重试） ============
             if self.to_post_products:
-                # 安排基础需求生产
+                stalled_before = set(self._stalled)
                 self.schedule_production()
+                # 有新产品被标记停滞且仍有空闲岗位 → 重跑需求
+                if set(self._stalled) - stalled_before and self.get_idle_posts():
+                    self._compute_base_demands()
+                    if self.to_post_products:
+                        self.to_post_products = self.process_meal_requirements(self.to_post_products)
+                        self.schedule_production()
             else:
                 logger.info("基础需求已满足")
 

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -8,6 +8,9 @@ from module.island.island_season import get_global_season_config
 
 
 class IslandShopBase(Island, WarehouseOCR):
+    # 游戏层材料不足的产品集，按店铺类型分 key，跨运行实例持久化
+    _stalled_by_shop = {}
+
     def __init__(self, config, device=None, task=None):
         # 分别初始化每个父类
         Island.__init__(self, config=config, device=device, task=task)
@@ -32,7 +35,6 @@ class IslandShopBase(Island, WarehouseOCR):
         self.warehouse_counts = {}  # 仓库识别到的产品
         self.to_post_products = {}
         self.current_totals = {}
-        self._stalled_products = set()  # 游戏层材料不足的产品，本轮跳过
 
         # 特殊材料（子类可覆盖）
         self.special_materials = {}
@@ -293,6 +295,13 @@ class IslandShopBase(Island, WarehouseOCR):
 
     # ============ 核心逻辑 ============
 
+    @property
+    def _stalled(self):
+        """获取当前店铺的游戏层材料不足产品集（跨实例持久化）。"""
+        if self.shop_type not in IslandShopBase._stalled_by_shop:
+            IslandShopBase._stalled_by_shop[self.shop_type] = set()
+        return IslandShopBase._stalled_by_shop[self.shop_type]
+
     def _compute_base_demands(self):
         """计算基础需求：严格按槽位顺序处理，找到第一个有缺口的槽位
         即停止，后续槽位本轮不处理。
@@ -314,7 +323,7 @@ class IslandShopBase(Island, WarehouseOCR):
             current = virtual_totals.get(name, 0)
             if current < target:
                 # 此前游戏中材料不足 → 本轮跳过，等后续模块补料
-                if name in self._stalled_products:
+                if name in self._stalled:
                     logger.info(f"槽位{idx + 1} {name} 此前游戏中材料不足，本轮跳过")
                     continue
                 deficit = target - current
@@ -803,8 +812,8 @@ class IslandShopBase(Island, WarehouseOCR):
 
         # 更新停滞标记：生产失败的记录下来，成功的清除
         remaining = set(self.to_post_products.keys())
-        self._stalled_products.update(to_post_before & remaining)
-        self._stalled_products.difference_update(to_post_before - remaining)
+        self._stalled.update(to_post_before & remaining)
+        self._stalled.difference_update(to_post_before - remaining)
 
         if self.to_post_products:
             logger.info(f"生产安排完成，剩余需求: {self.to_post_products}")

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -318,6 +318,8 @@ class IslandShopBase(Island, WarehouseOCR):
 
         # 遍历槽位，找到第一个有缺口且可生产的就只处理它
         # 材料完全不可得的槽位本轮跳过，等后续模块补料后再试
+        if self._stalled:
+            logger.info(f"[stalled] 当前店铺({self.shop_type})的停滞列表: {self._stalled}")
         break_idx = len(self.post_products)
         for idx, (name, target) in enumerate(self.post_products):
             current = virtual_totals.get(name, 0)
@@ -812,8 +814,14 @@ class IslandShopBase(Island, WarehouseOCR):
 
         # 更新停滞标记：生产失败的记录下来，成功的清除
         remaining = set(self.to_post_products.keys())
-        self._stalled.update(to_post_before & remaining)
-        self._stalled.difference_update(to_post_before - remaining)
+        failed = to_post_before & remaining
+        cleared = to_post_before - remaining
+        if failed:
+            logger.info(f"[stalled] 标记游戏层失败: {failed}")
+        if cleared:
+            logger.info(f"[stalled] 清除标记: {cleared}")
+        self._stalled.update(failed)
+        self._stalled.difference_update(cleared)
 
         if self.to_post_products:
             logger.info(f"生产安排完成，剩余需求: {self.to_post_products}")

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -306,12 +306,17 @@ class IslandShopBase(Island, WarehouseOCR):
         self.to_post_products = {}
         virtual_totals = dict(self.current_totals)
 
-        # 遍历槽位，找到第一个有缺口的就只处理它
+        # 遍历槽位，找到第一个有缺口且可生产的就只处理它
+        # 材料完全不可得的槽位本轮跳过，等后续模块补料后再试
         break_idx = len(self.post_products)
         for idx, (name, target) in enumerate(self.post_products):
             current = virtual_totals.get(name, 0)
             if current < target:
                 deficit = target - current
+                # 检查能否至少生产一部分（>0 即材料部分可得）
+                if self.get_max_producible(name, min(6, deficit)) <= 0:
+                    logger.info(f"槽位{idx + 1} {name} 材料完全不足，本轮跳过")
+                    continue
                 self.to_post_products[name] = deficit
                 virtual_totals[name] = target
                 break_idx = idx

--- a/module/island/island_teahouse.py
+++ b/module/island/island_teahouse.py
@@ -360,9 +360,16 @@ class IslandTeahouse(IslandShopBase):
             else:
                 logger.info("迎春花茶优先生产已关闭，直接处理基础需求")
 
-            # ============ 安排基础需求生产 ============
+            # ============ 安排基础需求生产（带停滞重试） ============
             if self.to_post_products:
+                stalled_before = set(self._stalled)
                 self.schedule_production()
+                # 有新产品被标记停滞且仍有空闲岗位 → 重跑需求
+                if set(self._stalled) - stalled_before and self.get_idle_posts():
+                    self._compute_base_demands()
+                    if self.to_post_products:
+                        self.to_post_products = self.process_meal_requirements(self.to_post_products)
+                        self.schedule_production()
             else:
                 logger.info("基础需求已满足")
 

--- a/module/island/island_teahouse.py
+++ b/module/island/island_teahouse.py
@@ -329,6 +329,8 @@ class IslandTeahouse(IslandShopBase):
             logger.info(f"基础需求配置（共{len(self.post_products)}个槽位）: {self.post_products}")
             logger.info("===============")
 
+            # 保存原始库存，retry 时恢复
+            _orig_totals = dict(self.current_totals)
             self._compute_base_demands()
 
             logger.info(f"待完成备餐: {self.to_post_products}")
@@ -364,8 +366,9 @@ class IslandTeahouse(IslandShopBase):
             if self.to_post_products:
                 stalled_before = set(self._stalled)
                 self.schedule_production()
-                # 有新产品被标记停滞且仍有空闲岗位 → 重跑需求
+                # 有新产品被标记停滞且仍有空闲岗位 → 恢复库存后重跑需求
                 if set(self._stalled) - stalled_before and self.get_idle_posts():
+                    self.current_totals = _orig_totals
                     self._compute_base_demands()
                     if self.to_post_products:
                         self.to_post_products = self.process_meal_requirements(self.to_post_products)


### PR DESCRIPTION
**背景**
本 PR 是岛屿餐厅生产逻辑系列优化的一环。

相关 PR 链
1     ；     #252 → #257   ；post_products dict→list，支持同名餐品多槽位
2     ；     #259                ；槽位顺序优先级、break 首个缺口、保留线机制
3     ；     本 PR               ；材料完全不足时跳过当前槽位，避免永久卡死



**问题**
当 break 到的槽位的产品所需原材料完全不可得时（如农场未开启、原料产线未启动），_compute_base_demands() 会永久卡在该槽位，后续槽位永远不被执行，导致整个店铺停转。

**修复**
在 _compute_base_demands() 的 break 循环中，找到缺口后增加一步可生产性检查：调用已有的 get_max_producible() 判断该产品材料是否可得。若返回 ≤0 则 continue 跳过当前槽位，继续检查下一槽位。

下一轮运行时从槽位①重新开始检测（break 循环本身的设计），若被跳过的槽位的材料已由其他模块补足则照常处理。

**改动**
仅 module/island/island_shop_base.py — _compute_base_demands() 方法，新增 5 行跳过逻辑。

**验证**
场景：槽① 需要材料 B=0不可得 → 槽② 材料可得

修复前：永久卡在槽①
修复后：槽①跳过 → 槽②正常生产 → 下轮再试槽①

## Summary by Sourcery

错误修复：
- 当某个生产槽位所需的产品物料完全不可用时，通过在当前周期中跳过该槽位，避免后续生产槽位被永久阻塞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid permanent blocking of subsequent production slots when a slot's product materials are completely unavailable by skipping that slot for the current cycle.

</details>