### PR TITLE
fix(island): 修正货运委托空闲时段延迟时间

### DIFF
--- a/module/island/island_cargo_preparation.py
+++ b/module/island/island_cargo_preparation.py
@@ -557,10 +557,13 @@ class IslandCargoPreparation(IslandUI):
 
     def _next_grey_retry_time(self):
         now = datetime.now().replace(microsecond=0)
+        today_morning = now.replace(hour=self.EARLY_MORNING_DELAY_HOUR, minute=0, second=0)
         today_evening = now.replace(hour=self.EVENING_DELAY_HOUR, minute=0, second=0)
         tomorrow_morning = (now + timedelta(days=1)).replace(
             hour=self.EARLY_MORNING_DELAY_HOUR, minute=0, second=0
         )
+        if now < today_morning:
+            return today_morning
         if now < today_evening:
             return today_evening
         return tomorrow_morning


### PR DESCRIPTION
- 修复 03:00 前检测到所有货运栏位暂无可操作委托时，被错误延迟到 18:00 的问题
- 调整灰色不可操作状态的重试时间：03:00 前延到当天 03:00，18:00 前延到当天 18:00
- 保持 18:00 后延迟到次日 03:00 的原有行为

## Summary by Sourcery

调整货物佣金灰色状态的重试调度，以正确处理清晨空闲时段。

Bug Fixes:
- 修复在所有货物槽在 03:00 之前处于非激活状态时，错误地将延迟设置为 18:00 的问题。

Enhancements:
- 优化灰色状态的重试时间逻辑：在 03:00 之前的重试将移动到 03:00，03:00 到 18:00 之前的重试将移动到 18:00，而 18:00 之后的重试将保持计划在第二天的 03:00。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust cargo commission grey-state retry scheduling to correctly handle early-morning idle periods.

Bug Fixes:
- Fix incorrect delay to 18:00 when all cargo slots are inactive before 03:00.

Enhancements:
- Refine grey-state retry timing so retries before 03:00 move to 03:00, before 18:00 move to 18:00, and after 18:00 remain scheduled for the next day at 03:00.

</details>