### PR TITLE
fix(island): 修复经营结算与种子商店返回异常

### DIFF
--- a/module/island/island_business.py
+++ b/module/island/island_business.py
@@ -1007,9 +1007,11 @@ class IslandBusiness(Island):
     # ===================================================================
 
     # 商店列表中的行常量
-    # 商店标签区域：x=(548, 668)，各行Y不同
-    # 按钮与标签的偏移：从标签左上角到按钮左上角
-    _SHOP_LABEL_TO_BUTTON_OFFSET = (472, 89)
+    # 列表页店名标签模板位于左侧，右侧经营按钮的 X 位置固定。
+    # Y 位置跟随店名标签所在行偏移，用于检测/点击蓝色、黄色、深蓝按钮。
+    _SHOP_BUTTON_X_RANGE = (1020, 1154)
+    _SHOP_LABEL_TO_BUTTON_OFFSET_Y = 88
+    _SHOP_BUTTON_HEIGHT = 27
     # 经营商店列表的可视区域
     _BUSINESS_LIST_SEARCH_AREA = (50, 80, 1200, 640)
     # 商店行高（经验值，适用于各行）
@@ -1046,9 +1048,12 @@ class IslandBusiness(Island):
             ly2 = btn.area[3] + sy1
             label_rect = (lx1, ly1, lx2, ly2)
 
-            # 计算按钮区域
-            dx, dy = self._SHOP_LABEL_TO_BUTTON_OFFSET
-            button_rect = (lx1 + dx, ly1 + dy, lx2 + dx, ly2 + dy)
+            # 计算右侧经营按钮区域。按钮宽度不能沿用店名标签宽度偏移，
+            # 否则会落到中间餐品图标上，导致黄色结算按钮被误判为 gray。
+            bx1, bx2 = self._SHOP_BUTTON_X_RANGE
+            by1 = ly1 + self._SHOP_LABEL_TO_BUTTON_OFFSET_Y
+            by2 = by1 + self._SHOP_BUTTON_HEIGHT
+            button_rect = (bx1, by1, bx2, by2)
 
             return {
                 'label_rect': label_rect,

--- a/module/island/island_business.py
+++ b/module/island/island_business.py
@@ -7,7 +7,7 @@ from module.island_select_character.assets import *
 from module.logger import logger
 from module.base.button import Button
 from module.base.template import Template
-from module.base.utils import crop
+from module.base.utils import crop, get_color, color_similar
 from module.island.island_season import SEASONAL_ITEMS
 from datetime import datetime, timedelta
 from module.ocr.ocr import Duration
@@ -833,6 +833,19 @@ class IslandBusiness(Island):
             return review_btn
         return None
 
+    def _appear_business_settlement(self):
+        """检测经营结算按钮，并用按钮颜色过滤灰色休息中按钮条的误匹配。"""
+        settlement = self._appear_at_positions(BUSINESS_SETTLEMENT)
+        if not settlement:
+            return None
+
+        area_color = get_color(self.device.image, settlement.area)
+        if color_similar(area_color, BUSINESS_SETTLEMENT.color, threshold=50):
+            return settlement
+
+        logger.info(f"经营结算按钮颜色不匹配，跳过: {area_color}")
+        return None
+
     def _parse_character_config(self, config_str):
         if isinstance(config_str, str):
             return [char.strip() for char in config_str.split('>')]
@@ -1075,8 +1088,6 @@ class IslandBusiness(Island):
         Returns:
             str: 'blue' | 'yellow' | 'darkblue' | 'gray'
         """
-        from module.base.utils import get_color, color_similar
-
         x1, y1, x2, y2 = button_rect
         area_color = get_color(self.device.image, (x1, y1, x2, y2))
 
@@ -1273,7 +1284,6 @@ class IslandBusiness(Island):
 
                 elif status == 'yellow':
                     logger.info(f"{shop_name}: 黄色可领取奖励")
-                    self._has_seen_blue = True
 
                     # 点击该商店的黄色按钮
                     btn = Button(
@@ -1559,7 +1569,7 @@ class IslandBusiness(Island):
             # 检测到"经营结算"按钮 → 优先处理结算（必须在 ISLAND_BACK 之前检测，
             # 防止结算界面出现时返回按钮也被检测到而导致提前退出）
             # 同时检测偏移150px位置（美食评审模式）
-            settlement = self._appear_at_positions(BUSINESS_SETTLEMENT)
+            settlement = self._appear_business_settlement()
             if settlement:
                 logger.info("检测到经营结算按钮")
                 self.device.click(settlement)

--- a/module/island/island_farm.py
+++ b/module/island/island_farm.py
@@ -362,6 +362,28 @@ class IslandFarm(Island, WarehouseOCR, LoginHandler):
         if self.appear(ISLAND_SHOP_GET):
             self.device.click(ISLAND_SHOP_CONFIRM)
 
+    def _back_to_island_after_seed_purchase(self):
+        """从种子商店返回岛屿页，避免商店页误判导致漏点返回。"""
+        logger.info('返回岛屿页')
+        confirm_timer = Timer(1, count=2).start()
+        self.interval_clear([ISLAND_BACK, ISLAND_SHOP_GOTO_ISLAND])
+        self.device.click(ISLAND_BACK)
+        self.device.sleep(0.5)
+        for _ in self.loop(timeout=12, skip_first=False):
+            if self.appear(ISLAND_CHECK):
+                if confirm_timer.reached():
+                    return True
+                continue
+            confirm_timer.reset()
+
+            if self.appear_then_click(ISLAND_BACK, offset=(20, 20), interval=2):
+                continue
+            if self.appear_then_click(ISLAND_SHOP_GOTO_ISLAND, offset=(20, 20), interval=2):
+                continue
+
+        logger.warning('返回岛屿页超时，继续尝试后续导航')
+        return False
+
     def run(self):
         self.island_error = False
         self.check_inventory_and_prepare_lists()
@@ -533,12 +555,7 @@ class IslandFarm(Island, WarehouseOCR, LoginHandler):
                     logger.info(f"购买{category}类别的{crop}种子，{count}份")
                     for _ in range(count):
                         self.buy_seeds(crop, category)
-            while 1:
-                self.device.screenshot()
-                if self.appear(ISLAND_CHECK):
-                    break
-                self.device.click(ISLAND_BACK)
-                self.device.sleep(0.5)
+            self._back_to_island_after_seed_purchase()
 
             self.goto_management()
             self.ui_goto(page_island_postmanage, get_ship=False)

--- a/module/island/island_farm.py
+++ b/module/island/island_farm.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from module.handler.login import LoginHandler
 from module.island.warehouse import *
 from module.logger import logger
+from module.base.timer import Timer
 
 
 class IslandFarm(Island, WarehouseOCR, LoginHandler):


### PR DESCRIPTION
## Summary

- 修复岛屿经营列表页右侧经营按钮区域计算错误，避免黄色结算按钮被识别到餐品区域后误判为 gray。
- 为 BUSINESS_SETTLEMENT 增加颜色校验，避免灰色“休息中”按钮条被误识别为经营结算。
- 修复分批经营中领取黄色奖励后误标记为已启动经营的问题，避免后续错误延迟 8 小时。
- 优化种子商店购买完成后的返回流程，先返回岛屿页并确认 ISLAND_CHECK，再进入岗位管理，保留 ISLAND_SHOP_GOTO_ISLAND 作为兜底。

Close #291

## Summary by Sourcery

修复岛屿商铺结算检测和种子商店返回流程，避免误分类和导航错误。

Bug 修复：
- 修正商铺列表按钮区域的计算方式，防止黄色结算按钮被误判为灰色按钮。
- 在检测 `BUSINESS_SETTLEMENT` 时按按钮颜色进行过滤，避免将灰色的“休息”条误认为是结算操作。
- 避免在仅领取黄色奖励后就将批量商铺标记为已开始，防止出现意外的 8 小时延迟。
- 确保从种子商店返回时，能够可靠地先导航回岛屿页面，再继续进行管理操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix island business settlement detection and seed shop return flow to avoid misclassification and navigation errors.

Bug Fixes:
- Correct business list button area calculation so yellow settlement buttons are not misclassified as gray.
- Filter BUSINESS_SETTLEMENT detection by button color to avoid confusing gray 'resting' bars with settlement actions.
- Avoid marking batch business shops as started after only claiming yellow rewards, preventing unintended 8-hour delays.
- Ensure returning from the seed shop reliably navigates back to the island page before proceeding to management.

</details>