### PR TITLE
fix紧急修复

### DIFF
--- a/module/exercise/exercise.py
+++ b/module/exercise/exercise.py
@@ -213,12 +213,7 @@ class Exercise(ExerciseCombat):
         logger.attr('Exercise_ExerciseStrategy', self.config.Exercise_ExerciseStrategy)
         self.preserve, admiral_interval = self._get_exercise_strategy()
 
-        if not self.server_support_ocr_reset_remain():
-            logger.info(f'Server {self.config.SERVER} does not yet support OCR exercise reset remain time')
-            logger.info('Please contact the developer to improve as soon as possible')
-            remain_time = datetime.timedelta(days=0)
-        else:
-            remain_time = OCR_PERIOD_REMAIN.ocr(self.device.image)
+        remain_time = OCR_PERIOD_REMAIN.ocr(self.device.image)
         logger.info(f'Exercise period remain: {remain_time}')
 
         if admiral_interval is not None and remain_time:


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过移除会强制产生零时长值的非 OCR 回退路径，纠正了行权期剩余时间的计算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct exercise period remaining time calculation by removing the non-OCR fallback path that forced a zero-duration value.

</details>