### PR TITLE
fix(config): remove global 24h NextRun cap to preserve user-set schedules / 移除全局 24 小时 NextRun 上限，保留用户手动设置的任务时间

### DIFF
--- a/module/config/config.py
+++ b/module/config/config.py
@@ -337,7 +337,7 @@ class AzurLaneConfig(ConfigUpdater, ManualConfig, GeneratedConfig, ConfigWatcher
         limit_next_run(["OpsiArchive"], limit=now + timedelta(days=7, seconds=-1))
         # IslandPearlSell 按周调度，合法 NextRun 可能超过 24 小时。
         limit_next_run(["IslandPearlSell"], limit=now + timedelta(days=8, seconds=-1))
-        limit_next_run(self.args.keys(), limit=now + timedelta(hours=24, seconds=-1))
+        # 注意：全局 24 小时上限已移除。各任务专属限制（Commission 12h、Research 24h、Opsi 31d 等）保留。
 
         """
         强制覆盖任意配置项。


### PR DESCRIPTION
### 问题

用户通过 WebUI 手动设置的任务运行时间（`Scheduler.NextRun`）如果超过当前时间 24 小时，会在配置重载时被 `config_override()` 静默重置为 `now`，导致用户设置的时间无法保存。
导致想把任务安排到两天后结果任务触发时间被重置

### 根因

`module/config/config.py` 中 `override()` 方法有一个全局兜底规则：

```python
limit_next_run(self.args.keys(), limit=now + timedelta(hours=24, seconds=-1))
```

每次 `load()` 和 `update()` 时都会执行。所有任务的 NextRun 超过 `now+24h` 都会被重置为当前时间，无法区分"用户手动设置"和"模块自动计算"。

### 修复

移除全局 24 小时上限。保留各任务的专属上限：

| 任务 | 上限 | 说明 |
|---|---|---|
| Commission, Reward | 12h | 高频收菜，防止错过 |
| Research | 24h | 科研每日刷新 |
| OpsiExplore 等 | 31天 | 大世界月度周期 |
| OpsiArchive | 7天 | 作战档案周周期 |
| IslandPearlSell | 8天 | 岛屿珍珠按周调度 |

### 影响

- 用户手动设置任意任务的 NextRun 为任意未来时间都能保留
- 自动计算的时间（`task_delay`）正常情况下不超 24h，不受影响
- 专属上限继续防止模块 bug 导致的时间溢出

## Summary by Sourcery

改进：
- 记录在配置覆盖逻辑中移除全局 24 小时 `NextRun` 上限的变更，同时保留现有的按任务限定的限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Document the removal of the global 24-hour NextRun cap in the configuration override logic, preserving existing per-task limits.

</details>