### PR TITLE
fix(island): 修复岛屿计划-每日补给领取自己的补给后可能不会开箱子的问题

### DIFF
--- a/module/island/island_air_drop.py
+++ b/module/island/island_air_drop.py
@@ -24,11 +24,13 @@ class IslandAirDrop(Island):
                     if self.appear(ISLAND_CHECK):
                         break
                     if self.appear(ISLAND_PHONE_CHECK, offset=1):
-                        break
+                        self.device.click(ISLAND_SEASON_GOTO_ISLAND)
+                        continue
                     if self.appear(ISLAND_SEASON_CHECK, offset=1):
                         self.device.click(ISLAND_SEASON_GOTO_ISLAND)
                         continue
                     if self.appear_then_click(AIR_DROP_SKIP, offset=1):
+                        self.device.sleep(0.5)
                         continue
                     self.device.sleep(0.5)
                 if self.appear(ISLAND_SEASON_CHECK, offset=1):


### PR DESCRIPTION
点击AIR_DROP_SKIP时, 可能在skip动画放完后, 点到了同一位置的管理按钮上, 打开了手机, 导致下一次点击(island_down)被吞掉, 实际上只是关闭了手机, 并没有移动

## Summary by Sourcery

确保岛屿每日补给空投流程在跳过动画后，能够正确返回岛屿并处理后续的点击操作。

Bug 修复：
- 防止在点击空投跳过按钮后，手机 UI 拦截并吞掉下一次对岛屿的点击。
- 保证在空投流程中出现手机 UI 时，能够导航回岛屿。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure island daily supply airdrop flow correctly returns to the island and processes subsequent taps after skipping the animation.

Bug Fixes:
- Prevent the phone UI from intercepting and swallowing the next island tap after tapping the airdrop skip button.
- Guarantee navigation back to the island when the phone UI appears during the airdrop flow.

</details>