### PR TITLE
[codex] fix ThreeOilLowCost event selection

### DIFF
--- a/module/campaign/run.py
+++ b/module/campaign/run.py
@@ -188,17 +188,19 @@ class CampaignRun(CampaignEvent, ShopStatus):
             # d3 保持不变，使用标准逻辑
             elif name == 'd3':
                 logger.info('Stage name d3 using standard logic')
-        # GemsFarming 和 ThreeOilLowCost 自动选择活动或主线章节
+        # GemsFarming 和 ThreeOilLowCost 根据各自任务配置选择活动或主线章节
         if self.config.task.command in ['GemsFarming', 'ThreeOilLowCost']:
             if self.stage_is_main(name):
                 logger.info(f'Stage name {name} is from campaign_main')
                 folder = 'campaign_main'
             else:
-                folder = self.config.cross_get('GemsFarming.Campaign.Event')
-                if folder is not None:
+                if folder and folder != 'campaign_main':
                     logger.info(f'Stage name {name} is from event {folder}')
                 else:
-                    logger.warning(f'Cannot get the latest event, fallback to campaign_main')
+                    logger.warning(
+                        f'Cannot get event configured for {self.config.task.command}, '
+                        f'fallback to campaign_main'
+                    )
                     folder = 'campaign_main'
         # 处理特殊 SP 地图名称
         if folder == 'event_20201126_cn' and name == 'vsp':

--- a/module/config/config_updater.py
+++ b/module/config/config_updater.py
@@ -699,7 +699,7 @@ class ConfigUpdater:
                              keys=f'{task}.Campaign.Event',
                              value=opts[0])
 
-            for task in ['GemsFarming']:
+            for task in GEMS_FARMINGS:
                 opts = deep_get(self.args, keys=f'{task}.Campaign.Event.option_{server}', default=[])
                 if opts and deep_get(new, keys=f'{task}.Campaign.Event', default='campaign_main') not in opts:
                     deep_set(new,


### PR DESCRIPTION
## 问题背景

在“三油低耗”任务中选择活动关卡 A3（本次复刻活动“绽放于辉光之城”）后，任务会进入活动页面，但无法正常选中 A3，并持续点击不属于当前活动页面的模式切换按钮，最终触发 `GameTooManyClickError` 和游戏重启。

同一实例使用普通“活动图”任务时可以正常选择 A3。

## 复现与排查过程

实例配置如下：

- `Event.Campaign.Name = A3`
- `Event.Campaign.Event = event_20240521_cn`
- `ThreeOilLowCost.Campaign.Name = A3`
- `ThreeOilLowCost.Campaign.Event = campaign_main`
- `GemsFarming.Campaign.Event = event_20260520_cn`

运行日志显示，三油低耗虽然配置的是 A3，但实际加载了另一活动：

```text
Stage name a3 is from event event_20260520_cn
Mode_switch_20241219 set to combat
[Mode_switch_20241219] unknown
GameTooManyClickError: Too many click for a button: SWITCH_20241219_COMBAT
```

检查 `CampaignRun.handle_stage_name()` 后确认，`GemsFarming` 和 `ThreeOilLowCost` 共用分支中写死读取：

```python
self.config.cross_get('GemsFarming.Campaign.Event')
```

因此 `ThreeOilLowCost` 不会使用自身已经绑定的 `Campaign.Event`，而会错误继承 `GemsFarming` 的活动目录。活动页面布局与错误目录的适配逻辑不一致，导致页面模式识别和关卡选择失败。

此外，配置更新逻辑只会为 `GemsFarming` 自动更新当前活动，没有包含同属 `GEMS_FARMINGS` 的 `ThreeOilLowCost`，导致已有配置容易长期保留 `campaign_main`。

## 修复方案

1. `CampaignRun.handle_stage_name()` 直接使用当前任务传入并已绑定的 `folder`。
   - `GemsFarming` 使用自己的 `Campaign.Event`。
   - `ThreeOilLowCost` 使用自己的 `Campaign.Event`。
   - 主线关卡仍强制使用 `campaign_main`。
   - 活动目录为空或仍为 `campaign_main` 时保留原有回退行为，并输出包含任务名的警告。

2. 配置更新时由只处理 `GemsFarming` 改为遍历 `GEMS_FARMINGS`。
   - `ThreeOilLowCost.Campaign.Event` 无效或过期时，也会迁移到当前服务器可用的最新活动。

## 影响

- 修复三油低耗选择活动关卡时错误读取其他任务活动配置的问题。
- 不改变普通活动图、主线关卡或 GemsFarming 的预期行为。
- 避免活动轮换后 `ThreeOilLowCost.Campaign.Event` 停留在 `campaign_main` 或旧活动。

## 验证

- `python3 -m py_compile module/campaign/run.py module/config/config_updater.py`
- `git diff --check`
- 针对 `handle_stage_name()` 验证：
  - `GemsFarming + A3 + event_20240521_cn`
  - `ThreeOilLowCost + A3 + event_20240521_cn`
  - `ThreeOilLowCost + 12-4` 主线回退
- 针对 `ConfigUpdater.config_update()` 验证：
  - `ThreeOilLowCost.Campaign.Event = campaign_main` 会迁移为当前 CN 可用活动 `event_20240521_cn`
- 实机验证：
  - 修复前日志加载 `event_20260520_cn` 并卡在 `Mode_switch_20241219`
  - 修复后日志加载 `event_20240521_cn`
  - OCR 正确识别活动关卡 `['A1', 'A3', 'A2']`
  - 不再进入错误的 `Mode_switch_20241219` 连续点击流程，并继续执行三油低耗舰队更换逻辑

## Summary by Sourcery

调整战役关卡选择和配置更新逻辑，使 ThreeOilLowCost 和 GemsFarming 各自使用其配置的活动关卡，或在必要时正确回退到主战役。

Bug Fixes:
- 修复 ThreeOilLowCost 在选择活动关卡时错误继承 GemsFarming 活动配置的问题，该问题可能导致误点循环和报错。

Enhancements:
- 当任务缺少有效的活动配置并回退到主战役时，记录更清晰的警告日志。
- 更新战役配置迁移逻辑，使其处理所有 GEMS_FARMINGS 任务，而不仅仅是 GemsFarming。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust campaign stage selection and config updating so ThreeOilLowCost and GemsFarming each use their own configured event or correctly fall back to the main campaign.

Bug Fixes:
- Fix ThreeOilLowCost incorrectly inheriting GemsFarming event configuration when selecting event stages, which could cause mis-click loops and errors.

Enhancements:
- Log clearer warnings when a task lacks a valid event configuration and falls back to the main campaign.
- Update campaign config migration to handle all GEMS_FARMINGS tasks instead of only GemsFarming.

</details>