### PR TITLE
fix(island): 修复岛屿计划-每日补给领取自己的补给后可能不会开箱子的问题

### DIFF
--- a/module/island/island_air_drop.py
+++ b/module/island/island_air_drop.py
@@ -24,11 +24,13 @@ class IslandAirDrop(Island):
                     if self.appear(ISLAND_CHECK):
                         break
                     if self.appear(ISLAND_PHONE_CHECK, offset=1):
-                        break
+                        self.device.click(ISLAND_SEASON_GOTO_ISLAND)
+                        continue
                     if self.appear(ISLAND_SEASON_CHECK, offset=1):
                         self.device.click(ISLAND_SEASON_GOTO_ISLAND)
                         continue
                     if self.appear_then_click(AIR_DROP_SKIP, offset=1):
+                        self.device.sleep(0.5)
                         continue
                     self.device.sleep(0.5)
                 if self.appear(ISLAND_SEASON_CHECK, offset=1):


### PR DESCRIPTION
点击AIR_DROP_SKIP时, 可能在skip动画放完后, 点到了同一位置的管理按钮上, 打开了手机, 导致下一次点击(island_down)被吞掉, 实际上只是关闭了手机, 并没有移动

## Summary by Sourcery

Bug Fixes:
- 通过在手机出现时重定向回岛屿，并在跳过后添加短暂延迟，防止 `AIR_DROP_SKIP` 点击意外打开手机并吞掉后续的岛屿点击。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent AIR_DROP_SKIP taps from accidentally opening the phone and swallowing the subsequent island tap by redirecting back to the island when the phone appears and adding a short delay after skipping.

</details>