### PR TITLE
Fix：主界面识别错误

### DIFF
--- a/module/freebies/mail_white.py
+++ b/module/freebies/mail_white.py
@@ -107,8 +107,8 @@ class MailWhite(UI):
                 self.device.screenshot()
 
             # End
-            if self.ui_page_appear(page_main):
-                logger.info('Mail quit to page_main')
+            if self.is_in_main():
+                logger.info('Mail quit to main')
                 break
 
             # Click

--- a/module/ui/ui.py
+++ b/module/ui/ui.py
@@ -278,6 +278,11 @@ class UI(InfoHandler):
             if self.ui_page_appear(page=destination, offset=offset):
                 logger.info(f'Page arrive: {destination}')
                 break
+            # 主界面新旧主题互为等价：目标为任一主界面时，
+            # 检测到另一主题也视为到达
+            if destination in (page_main, page_main_white) and self.is_in_main():
+                logger.info(f'Page arrive: {destination}')
+                break
 
             # 其他页面：按 A* 路径点击导航
             clicked = False
@@ -316,6 +321,10 @@ class UI(InfoHandler):
         self.ui_get_current_page(skip_first_screenshot=skip_first_screenshot)
         if self.ui_current == destination:
             logger.info("Already at %s" % destination)
+            return False
+        # 主界面新旧主题互为等价
+        if {self.ui_current, destination} == {page_main, page_main_white}:
+            logger.info("Already at %s (equivalent main page)" % destination)
             return False
         else:
             logger.info("Goto %s" % destination)

--- a/module/ui/ui.py
+++ b/module/ui/ui.py
@@ -35,11 +35,7 @@ class UI(InfoHandler):
             interval: 检测间隔。
         """
         if page == page_main:
-            if self.appear(page_main_white.check_button, offset=offset, interval=interval):
-                return True
-            if self.appear(page_main.check_button, offset=(5, 5), interval=interval):
-                return True
-            return False
+            return self.appear(page_main.check_button, offset=(5, 5), interval=interval)
         if page == page_island_shop:
             return self.appear(page.check_button, interval=interval)
         if page == page_shop:
@@ -53,7 +49,8 @@ class UI(InfoHandler):
         return self.appear(page.check_button, offset=offset, interval=interval)
 
     def is_in_main(self, offset=(30, 30), interval=0):
-        return self.ui_page_appear(page_main, offset=offset, interval=interval)
+        return (self.ui_page_appear(page_main, offset=offset, interval=interval)
+                or self.ui_page_appear(page_main_white, offset=offset, interval=interval))
 
     def ui_main_appear_then_click(self, page, offset=(30, 30), interval=3):
         """


### PR DESCRIPTION
fix(ui): 修复白色主题主界面按钮坐标偏移导致 GameTooManyClickError

根因：ui_page_appear(page=page_main) 交叉检测白色主题按钮，命
中后返回旧版 page_main 身份，导致 ui_goto() / ui_get_current_page() 使用旧版按钮坐标点击（偏移约 146 像素），点击落空循环重试触发
GameTooManyClickError。

修复：
- ui_page_appear(page=page_main)：移除对 page_main_white 的交叉 检测，每个页面只检测自己的按钮
- is_in_main()：显式同时检测 page_main 和 page_main_white
- mail_white.py：ui_page_appear(page_main) 改为 is_in_main()， 不再依赖交叉检测副作用


@

## Summary by Sourcery

修复主页检测逻辑，将经典主题和白色主题视为等价，同时避免使用过时的坐标。

Bug 修复：
- 通过停止在标准主页检查中对白色主题主页的交叉检测，并使用正确的按钮坐标，防止出现 `GameTooManyClickError`。

功能增强：
- 通过统一的 `is_in_main` 辅助函数同时检测经典主题和白色主题主页，并将它们视为等价的导航目标。
- 简化邮件退出流程，依赖统一的主页检测，而不是仅假定存在默认主页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix main page detection to treat classic and white themes as equivalent while avoiding use of outdated coordinates.

Bug Fixes:
- Prevent GameTooManyClickError by stopping cross-detection of the white-theme main page in standard main page checks and using correct button coordinates.

Enhancements:
- Detect both classic and white-theme main pages via a unified is_in_main helper and treat them as equivalent navigation destinations.
- Simplify mail exit flow to rely on the unified main page detection instead of assuming the default main page only.

</details>

Bug 修复：
- 通过禁止在 `page_main` 检测中使用带有过期坐标的白色主题主界面按钮，防止出现 `GameTooManyClickError`。

增强：
- 在检测主界面存在与否时，明确同时处理普通主题和白色主题的主界面，而不再依赖跨页面检测的副作用。
- 简化邮件退出流程，改为使用统一的主界面检测辅助函数，而不是只直接检测默认主界面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复主页检测逻辑，将经典主题和白色主题视为等价，同时避免使用过时的坐标。

Bug 修复：
- 通过停止在标准主页检查中对白色主题主页的交叉检测，并使用正确的按钮坐标，防止出现 `GameTooManyClickError`。

功能增强：
- 通过统一的 `is_in_main` 辅助函数同时检测经典主题和白色主题主页，并将它们视为等价的导航目标。
- 简化邮件退出流程，依赖统一的主页检测，而不是仅假定存在默认主页。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix main page detection to treat classic and white themes as equivalent while avoiding use of outdated coordinates.

Bug Fixes:
- Prevent GameTooManyClickError by stopping cross-detection of the white-theme main page in standard main page checks and using correct button coordinates.

Enhancements:
- Detect both classic and white-theme main pages via a unified is_in_main helper and treat them as equivalent navigation destinations.
- Simplify mail exit flow to rely on the unified main page detection instead of assuming the default main page only.

</details>

</details>