### PR TITLE
fix: 修复道中战斗失败撤退配置不生效的问题

### DIFF
--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -215,6 +215,7 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
         """
         logger.info('Auto search combat loading')
         self._withdraw = False
+        self._withdraw_timeout.clear()
         self.device.stuck_record_clear()
         self.device.click_record_clear()
         self.device.screenshot_interval_set('combat')

--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -13,6 +13,7 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
     _auto_search_in_stage_timer = Timer(3, count=6)
     _auto_search_status_confirm = False
     _withdraw = False
+    _withdraw_timeout = Timer(30)
     auto_search_oil_limit_triggered = False
     auto_search_coin_limit_triggered = False
 
@@ -213,6 +214,7 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
             out: combat status
         """
         logger.info('Auto search combat loading')
+        self._withdraw = False
         self.device.stuck_record_clear()
         self.device.click_record_clear()
         self.device.screenshot_interval_set('combat')
@@ -328,17 +330,62 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
             # End
             if self.is_auto_search_running():
                 self._auto_search_status_confirm = False
+                self._withdraw = False
+                self._withdraw_timeout.clear()
                 break
             if self.is_in_auto_search_menu() or self._handle_auto_search_menu_missing():
+                self._withdraw = False
+                self._withdraw_timeout.clear()
                 raise CampaignEnd
+
+            # 通用弹窗处理——放在撤退分支之前，
+            # 确保撤退等待期间弹窗也能被正常关闭。
+            if self.handle_get_ship():
+                continue
+            if self.handle_popup_confirm('AUTO_SEARCH_COMBAT_STATUS'):
+                continue
+            if self.handle_urgent_commission():
+                continue
+            if self.handle_story_skip():
+                continue
+            if self.handle_guild_popup_cancel():
+                continue
+            if self.handle_vote_popup():
+                continue
+            if self.handle_mission_popup_ack():
+                continue
 
             # Withdraw
             if self._withdraw:
+                # 心跳：将 BATTLE_STATUS_S 注册到 detect_record，
+                # 将卡死超时从 60 秒延长到 195 秒。
+                self.appear(BATTLE_STATUS_S)
+
+                # 启动撤退超时计时器
+                if not self._withdraw_timeout.started():
+                    self._withdraw_timeout.reset()
+
+                # 舰队切换确认弹窗——仅在用户不期望直接撤退时才确认换队。
+                # 当 Campaign_DefeatWithdraw 为 True 时，点击关闭弹窗后直接撤退。
                 if self.appear_then_click(FLEET_SWITCH_CONFIRM, offset=(30, 30)):
                     self.fleet_alive_multiple = False
                     self._withdraw = False
+                    self._withdraw_timeout.clear()
+                    if self.config.Campaign_DefeatWithdraw:
+                        # 道中战斗失败撤退：确认通知弹窗后直接撤退
+                        self.withdraw()
+                        break
                     continue
-                
+
+                # 超时升级：30 秒后仍未出现撤退按钮，重新点击
+                # OPTS_INFO_D 尝试推进画面。
+                if self._withdraw_timeout.reached():
+                    logger.warning('撤退等待超时，重新点击 OPTS_INFO_D')
+                    self.device.click(OPTS_INFO_D)
+                    self._withdraw_timeout.reset()
+                    continue
+
+                # WITHDRAW 按钮稳定检测
                 if self.appear(WITHDRAW, offset=(30, 30)):
                     if not withdraw_stable_timer.reached():
                         continue
@@ -346,11 +393,15 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
                     withdraw_stable_timer.reset()
                     continue
 
+                # 撤退按钮已稳定出现，执行撤退决策。
                 self._withdraw = False
+                self._withdraw_timeout.clear()
                 if self.config.Campaign_DefeatWithdraw or not self.fleet_alive_multiple:
+                    # 开启了道中战斗失败撤退，或没有第二舰队可接管 → 直接撤退
                     self.withdraw()
                     break
                 else:
+                    # 关闭了撤退选项且有多舰队 → 尝试切换舰队接管
                     while True:
                         self.device.screenshot()
                         if self.appear_then_click(FLEET_WITHDRAW, offset=(30, 30)):
@@ -364,23 +415,8 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
                     continue
 
             # Combat status
-            if self.handle_get_ship():
-                continue
             if not self._withdraw and self.handle_auto_search_map_option():
                 self._auto_search_status_confirm = False
-                continue
-            # bunch of popup handlers
-            if self.handle_popup_confirm('AUTO_SEARCH_COMBAT_STATUS'):
-                continue
-            if self.handle_urgent_commission():
-                continue
-            if self.handle_story_skip():
-                continue
-            if self.handle_guild_popup_cancel():
-                continue
-            if self.handle_vote_popup():
-                continue
-            if self.handle_mission_popup_ack():
                 continue
 
             # Handle low emotion combat


### PR DESCRIPTION
fix(combat): 修复道中战斗失败撤退配置不生效的问题

当 Campaign_DefeatWithdraw 为 True 时，道中队战斗失败后不再切换
第2队继续战斗，而是点击确认弹窗后直接撤退离开关卡。

改动要点：
- 弹窗处理前移到撤退块之前，防止撤退等待期间被奖励弹窗阻塞
- FLEET_SWITCH_CONFIRM 弹窗照常点击关闭，随后检查配置决定进退
- 新增30秒超时安全网 + BATTLE_STATUS_S 心跳延长卡死检测
- 进入/退出战斗时主动清理 _withdraw 状态防止残留

影响的模块: GemsFarming / ThreeOilLowCost / Ambush11 及所有使用 CampaignBase 的自动搜索战役任务


@

## Summary by Sourcery

确保自动搜索战役在战斗中正确遵守“失败撤退”配置，并增强撤退流程的稳健性。

Bug Fixes:
- 修复自动搜索在战斗中途失败时的逻辑，使启用 `Campaign_DefeatWithdraw` 后，运行会选择撤退而不是切换到第二舰队。

Enhancements:
- 在战斗进入/结束时重置撤退状态，避免陈旧的撤退标记影响后续战斗。
- 在进入撤退分支之前集中处理通用弹窗，防止奖励或其他弹窗阻塞撤退流程。
- 添加 30 秒撤退超时和扩展的战斗状态心跳，用于检测并从卡在撤退界面的情况中恢复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure auto-search campaign battles correctly honor defeat-withdraw configuration and improve robustness of the withdraw flow.

Bug Fixes:
- Fix auto-search mid-battle defeat logic so that enabling Campaign_DefeatWithdraw causes the run to retreat instead of switching to the second fleet.

Enhancements:
- Reset withdraw state at battle enter/exit to avoid stale withdraw flags affecting subsequent battles.
- Centralize common popup handling before the withdraw branch to prevent reward or other popups from blocking the retreat sequence.
- Add a 30-second withdraw timeout and extended battle status heartbeat to detect and recover from stuck withdraw screens.

</details>