### PR TITLE
[codex] Fix macOS MuMu Pro auto reconnect

### DIFF
--- a/module/device/connection.py
+++ b/module/device/connection.py
@@ -1079,6 +1079,52 @@ class Connection(ConnectionAttr):
                                 '它们会劫持电脑上所有的网络连接，包括Alas与模拟器之间的本地连接。')
         return SelectedGrids(devices)
 
+    def auto_connect_mac_emulators(self):
+        """Connect running macOS emulator instances discovered by their vendor tools.
+
+        ADB does not automatically reconnect MuMu Pro after the emulator process is
+        restarted.  Querying ``mumutool`` is more reliable than guessing a fixed
+        port, and also supports instances whose ADB port has changed.
+
+        Returns:
+            bool: Whether at least one connection attempt was made.
+        """
+        if not IS_MACINTOSH:
+            return False
+
+        try:
+            from module.device.platform.emulator_mac import EmulatorManagerMac, EmulatorMac
+
+            instances = [
+                instance for instance in EmulatorManagerMac().all_emulator_instances
+                if instance.type == EmulatorMac.MuMuPro
+                and getattr(instance, 'state', '') == 'running'
+            ]
+        except Exception as e:
+            logger.warning(f'Failed to discover running macOS emulators: {e}')
+            return False
+
+        configured_name = getattr(self.config, 'EmulatorInfo_name', None)
+        if configured_name:
+            instances.sort(key=lambda instance: instance.name != configured_name)
+
+        self._mac_auto_serials = []
+        attempted = False
+        for instance in instances:
+            # 5037 is the ADB server itself, never an emulator endpoint.
+            if instance.serial == '127.0.0.1:5037':
+                continue
+            self._mac_auto_serials.append(instance.serial)
+            attempted = True
+            try:
+                logger.info(f'Auto connecting macOS emulator: {instance}')
+                msg = self.adb_client.connect(instance.serial)
+                if msg:
+                    logger.info(msg)
+            except Exception as e:
+                logger.warning(f'Failed to auto connect {instance.serial}: {e}')
+        return attempted
+
     def detect_device(self):
         """检测可用设备。
 
@@ -1120,6 +1166,8 @@ class Connection(ConnectionAttr):
                 if IS_WINDOWS:
                     brute_force_connect()
                     continue
+                elif IS_MACINTOSH and self.auto_connect_mac_emulators():
+                    continue
                 else:
                     break
             else:
@@ -1127,13 +1175,24 @@ class Connection(ConnectionAttr):
 
         # 自动设备检测
         if self.config.Emulator_Serial == 'auto':
-            if available.count == 0:
+            preferred_serials = getattr(self, '_mac_auto_serials', [])
+            preferred = SelectedGrids([
+                device for device in available
+                if device.serial in preferred_serials
+            ])
+            if preferred.count == 1:
+                logger.info(f'自动设备检测使用 MuMu 工具发现的设备')
+                self.serial = preferred[0].serial
+                del_cached_property(self, 'adb')
+            elif available.count == 0:
                 logger.critical('没有找到可用设备，自动设备检测无法工作，'
                                 '请在 Alas.Emulator.Serial 中设置一个确切的序列号，而不是使用 "auto"')
                 raise RequestHumanTakeover
             elif available.count == 1:
                 logger.info(f'自动设备检测只找到一个设备，正在使用它')
-                self.config.Emulator_Serial = self.serial = available[0].serial
+                # Keep the configured value as "auto". Only update this connection
+                # object so a later emulator restart can perform discovery again.
+                self.serial = available[0].serial
                 del_cached_property(self, 'adb')
             elif available.count == 2 \
                     and available.select(serial='127.0.0.1:7555') \
@@ -1142,7 +1201,7 @@ class Connection(ConnectionAttr):
                 # 对于 MuMu12 序列号如 127.0.0.1:7555 和 127.0.0.1:16384
                 # 忽略 7555，使用 16384
                 remain = available.select(may_mumu12_family=True).first_or_none()
-                self.config.Emulator_Serial = self.serial = remain.serial
+                self.serial = remain.serial
                 del_cached_property(self, 'adb')
             else:
                 logger.critical('找到多个设备，自动设备检测无法决定选择哪个，'


### PR DESCRIPTION
## What changed

- Discover running macOS MuMu Pro instances through the existing `mumutool`-backed emulator manager when `Serial=auto` has no connected ADB devices.
- Connect the discovered ADB endpoints before retrying device detection.
- Prefer the MuMu endpoint reported by the vendor tool when duplicate aliases are present.
- Keep the saved emulator serial as `auto`; only update the active connection object's serial.

## Why

After MuMu Pro or ADB restarts, MuMu may still be running while its ADB endpoint is no longer registered. Existing automatic detection only inspects devices already known to ADB, so it reports no available device and cannot recover.

Automatic detection also replaced the configured `auto` value with the currently detected serial. That leaves a stale fixed serial after a later emulator restart or endpoint change and forces users to edit the device serial repeatedly.

## Impact

On macOS, a running MuMu Pro instance can be rediscovered and reconnected automatically after ADB disconnects or the emulator endpoint changes. Users can leave `Alas.Emulator.Serial` set to `auto`.

Windows behavior is unchanged.

## Validation

- `python -m py_compile module/device/connection.py`
- `git diff --check`
- Manual macOS reproduction with MuMu Pro:
  1. Start MuMu Pro with ADB endpoint `127.0.0.1:16384`.
  2. Disconnect the endpoint so `adb devices` is empty.
  3. Initialize an AzurPilot connection with `Serial=auto`.
  4. Confirm AzurPilot queries MuMu, reconnects `127.0.0.1:16384`, detects `com.bilibili.azurlane`, and leaves the saved serial as `auto`.
