### PR TITLE
[codex] 修复战术学院满级技能自动切换失效

### DIFF
--- a/module/tactical/tactical_class.py
+++ b/module/tactical/tactical_class.py
@@ -593,7 +593,7 @@ class RewardTacticalClass(Dock):
             return False, False, pending_skill_auto_switch
 
         study_finished = False
-        if pending_skill_auto_switch or self.config.AddNewStudent_Enable:
+        if pending_skill_auto_switch or self.config.Tactical_SkillAutoSwitch or self.config.AddNewStudent_Enable:
             pending_skill_auto_switch = False
             if not self._tactical_skill_choose():
                 study_finished = True


### PR DESCRIPTION
已撤回：现场复查确认真正问题是进入技能选择页后，被战术学院结束检查抢先处理并退出。此 PR 只修复了技能选择页内的配置判断，未覆盖处理顺序问题，将以新的完整修复 PR 替代。