### PR TITLE
fix(island): 修复鱼苗页签与牧场空闲岗位派遣

### DIFF
--- a/module/island/island.py
+++ b/module/island/island.py
@@ -588,6 +588,8 @@ class Island(SelectCharacter):
                     return False
             if self.appear(ISLAND_POST_CHECK) or self.appear(ISLAND_POST_VACANT_CHECK):
                 return True
+            if self.appear(ISLAND_POST_SELECT, offset=1):
+                return True
             if post_appear:
                 self.device.sleep(0.1)
                 self.device.click(post)
@@ -678,19 +680,20 @@ class Island(SelectCharacter):
         for index in range(add_one_clicks):
             self.device.click(add_one_buttons[index % len(add_one_buttons)])
 
-    def switch_shop_tab(self, tab_check, tab_button, verify_button=None):
+    def switch_shop_tab(self, tab_check, tab_button):
         """切换岛屿商店内的页签。"""
         click_count = 0
         self.interval_clear([tab_button])
         for _ in self.loop(timeout=8, skip_first=False):
-            if self.appear(tab_check):
-                return True
-            if verify_button is not None and self.appear(verify_button, threshold=30):
+            if self.appear(tab_check, offset=1, threshold=30):
+                if click_count:
+                    logger.info(f"商店页签检测成功: {tab_check}，点击 {click_count} 次")
                 return True
             if self.appear(tab_button, threshold=30):
                 click_count += 1
+                logger.info(f"商店页签检测失败，点击页签: {tab_button} -> {tab_check}，第 {click_count} 次")
                 self.device.click(tab_button)
-                self.device.sleep(2)
+                self.device.sleep(1)
                 continue
 
         logger.warning(f"切换商店页签超时: tab={tab_button}, check={tab_check}, clicked={click_count}")
@@ -701,7 +704,7 @@ class Island(SelectCharacter):
         """购买岛屿商店商品，适用于种子、鱼苗等同构购买弹窗。"""
         quantity = max(1, int(quantity))
         if tab_check is not None and tab_button is not None:
-            if not self.switch_shop_tab(tab_check, tab_button, verify_button=item_button):
+            if not self.switch_shop_tab(tab_check, tab_button):
                 return False
 
         if item_name:
@@ -740,26 +743,25 @@ class Island(SelectCharacter):
             self.device.click(ISLAND_SHOP_CONFIRM)
         return True
 
-    def goto_shop_from_select_product(self, shop_check, tab_check=None, tab_button=None, tab_verify_button=None):
+    def goto_shop_from_select_product(self, shop_check, tab_check=None, tab_button=None):
         """从岗位产品选择页跳转到补充材料的商店页签。"""
         self.interval_clear([ISLAND_SELECT_GOTO_BUY_SEED, ISLAND_SELECT_SEED])
+        tab_click_count = 0
         for _ in self.loop(timeout=20, skip_first=False):
             in_select_product = self.appear(ISLAND_SELECT_PRODUCT_CHECK, offset=1)
             in_shop = self.appear(shop_check)
-            in_tab = tab_check is not None and self.appear(tab_check)
-            target_visible = (
-                tab_verify_button is not None
-                and not in_select_product
-                and in_shop
-                and self.appear(tab_verify_button, threshold=30)
-            )
+            in_tab = tab_check is not None and self.appear(tab_check, threshold=30)
             goto_buy = self.appear(ISLAND_SELECT_GOTO_BUY_SEED)
 
             if not in_select_product and tab_check is not None and in_tab:
-                return True
-            if target_visible:
+                if tab_click_count:
+                    logger.info(f"补货商店页签检测成功: {tab_check}，点击 {tab_click_count} 次")
                 return True
             if not in_select_product and tab_button is not None and in_shop:
+                tab_click_count += 1
+                logger.info(
+                    f"补货商店页签检测失败，点击页签: {tab_button} -> {tab_check}，第 {tab_click_count} 次"
+                )
                 self.device.click(tab_button)
                 self.device.sleep(1)
                 continue
@@ -987,7 +989,6 @@ class Island(SelectCharacter):
             shop_check=shop_check,
             tab_check=tab_check,
             tab_button=tab_button,
-            tab_verify_button=item_button,
         ):
             return True
         if not self.buy_shop_item(

--- a/module/island/island_rancher.py
+++ b/module/island/island_rancher.py
@@ -286,7 +286,8 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
             if self.appear_then_click(POST_ADD):
                 add_opened = True
                 continue
-            if add_opened and self.appear_then_click(ISLAND_POST_SELECT, offset=1):
+            in_vacant_post = self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
+            if (add_opened or in_vacant_post) and self.appear_then_click(ISLAND_POST_SELECT, offset=1):
                 self.device.sleep(0.5)
                 continue
             if (
@@ -333,7 +334,10 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
             if self.appear_then_click(POST_ADD):
                 add_opened = True
                 continue
-            if add_opened and self.appear_then_click(ISLAND_POST_SELECT, offset=1):
+            in_vacant_post = self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
+            if (add_opened or in_vacant_post) and self.appear_then_click(ISLAND_POST_SELECT, offset=1):
+                if in_vacant_post and not add_opened:
+                    logger.info(f"牧场岗位{post_id}为空闲岗位，直接进入派遣")
                 self.device.sleep(0.5)
                 continue
             if self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1):
@@ -376,6 +380,7 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
             if (
                     self.appear(ISLAND_POSTMANAGE_CHECK, offset=1)
                     and not self.appear(ISLAND_POST_CHECK)
+                    and not self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
             ):
                 return True
         logger.warning(f"牧场岗位{post_id}收取并追加派遣超时")


### PR DESCRIPTION
- 鱼苗补货页签切换重新只依赖 ISLAND_FISH_FRY_SHOP_*_CHECK 判定，避免目标商品颜色误识别导致跳过页签切换
- 页签检测使用 offset=1 与更宽松阈值，并在点击页签后等待点击特效消失
- 增加鱼苗商店页签检测日志，便于确认页签点击后是否识别成功
- 允许检测到 ISLAND_POST_VACANT_CHECK 的牧场空闲岗位直接点击 ISLAND_POST_SELECT 进入派遣
- 收紧牧场岗位管理页返回判断，避免空闲岗位详情页被误判为流程已结束

# Conflicts:
#	module/island/island.py