### PR TITLE
Fix fleet handling and connect activity graphs

### DIFF
--- a/campaign/war_archives_20240725_cn/campaign_base.py
+++ b/campaign/war_archives_20240725_cn/campaign_base.py
@@ -4,6 +4,12 @@ from ..campaign_war_archives.campaign_base import CampaignBase as CampaignBase_
 class CampaignBase(CampaignBase_):
     def campaign_set_chapter_event(self, chapter, mode='normal'):
         self.ui_goto_sp()
+        if chapter in ['a', 'b', 'as', 'bs', 't', 'ts', 'tss']:
+            self.campaign_ensure_mode('normal')
+        elif chapter in ['c', 'd', 'cs', 'ds', 'ht', 'hts']:
+            self.campaign_ensure_mode('hard')
+        elif chapter == 'ex_sp':
+            self.campaign_ensure_mode('ex')
         self.campaign_ensure_chapter(chapter)
         return True
 
@@ -18,4 +24,6 @@ class CampaignBase(CampaignBase_):
         if mode == 'hard':
             self.config.override(Campaign_Mode='hard')
 
-        self.campaign_ensure_mode_20241219(mode)
+        # this event only have chapter T/HT and chapter SP, and war archive does not have SP
+        # so there is no mode switch buttons
+        # self.campaign_ensure_mode_20241219(mode)

--- a/module/config/config_manual.py
+++ b/module/config/config_manual.py
@@ -121,7 +121,7 @@ class ManualConfig:
     MAP_CHAPTER_SWITCH_20241219_SPEX = False
     # Since event_20241219_cn chapter B unlocks event startup
     # which means chapter AB are continuous
-    STAGE_INCREASE_AB = False
+    STAGE_INCREASE_AB = True
     # Insert anything to STAGE_INCREASE
     STAGE_INCREASE_CUSTOM = ''
     MAP_HAS_CLEAR_PERCENTAGE = True

--- a/module/handler/enemy_searching.py
+++ b/module/handler/enemy_searching.py
@@ -120,6 +120,10 @@ class EnemySearchingHandler(InfoHandler):
             # although here expects an enemy searching animation.
             if self.handle_in_stage():
                 return True
+            # immediately enter submarine combat in W16
+            if hasattr(self, 'is_combat_loading') and self.is_combat_loading():
+                logger.warning('Entered map with is_combat_loading appeared')
+                break
             if self.handle_auto_search_exit(drop=drop):
                 timeout.limit = 10
                 timeout.reset()

--- a/module/handler/fast_forward.py
+++ b/module/handler/fast_forward.py
@@ -372,8 +372,7 @@ class FastForwardHandler(AutoSearchHandler):
         # Insert custom increase logic
         if self.config.STAGE_INCREASE_AB:
             stage_increase = [
-                'A1 > A2 > A3 > B1 > B2 > B3',
-                'C1 > C2 > C3 > D1 > D2 > D3',
+                'A1 > A2 > A3 > B1 > B2 > B3',                
             ] + stage_increase
         custom = self.config.STAGE_INCREASE_CUSTOM
         if custom:

--- a/module/map/fleet.py
+++ b/module/map/fleet.py
@@ -102,7 +102,7 @@ class Fleet(Camera, AmbushHandler):
             self.show_fleet()
             self.hp_get()
             self.lv_get()
-            self.handle_strategy(index=self.fleet_current_index)
+            self.handle_strategy(index=self.fleet_show_index)
             return True
         else:
             return False


### PR DESCRIPTION
## Summary by Sourcery

修复舰队处理逻辑，并调整活动关卡与敌人搜索行为。

错误修复：
- 将活动关卡章节选择与战役回顾中的对应难度模式对齐。
- 防止在地图 W16 进入潜艇战斗加载状态时发生无限敌人搜索的问题。
- 在显示舰队详情后应用战术策略时，使用正确的舰队索引。
- 为 2024-12-19 活动禁用旧版模式切换逻辑，因为该活动中不存在模式按钮。

功能改进：
- 调整快进关卡推进逻辑，使其仅根据配置延长 A/B 关卡序列，并默认启用该行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix fleet handling and adjust event campaign and enemy searching behavior.

Bug Fixes:
- Align event campaign chapter selection with appropriate difficulty modes for war archives.
- Prevent infinite enemy searching when entering submarine combat loading states in map W16.
- Use the correct fleet index when applying strategies after showing fleet details.
- Disable legacy mode switching logic for the 2024-12-19 event where no mode buttons exist.

Enhancements:
- Adjust fast forward stage progression to only extend A/B sequences based on configuration and enable this behavior by default.

</details>