### PR TITLE
fix: 修改调度类型为存储，调整任务调度限制以避免重置

### DIFF
--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -13358,7 +13358,7 @@
         ]
       },
       "NextRun": {
-        "type": "datetime",
+        "type": "stored",
         "value": "2020-01-01 00:00:00",
         "validate": "datetime",
         "display": "hide"

--- a/module/config/argument/override.yaml
+++ b/module/config/argument/override.yaml
@@ -581,6 +581,7 @@ OpsiHazard1Leveling:
 OpsiScheduling:
   Scheduler:
     NextRun:
+      type: stored
       display: hide
     SuccessInterval:
       value: 1440

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -339,9 +339,10 @@ class AzurLaneConfig(ConfigUpdater, ManualConfig, GeneratedConfig, ConfigWatcher
         limit_next_run(["OpsiScheduling"], limit=now + timedelta(hours=48, seconds=-1))
         # IslandPearlSell 按周调度，合法 NextRun 可能超过 24 小时。
         limit_next_run(["IslandPearlSell"], limit=now + timedelta(days=8, seconds=-1))
+        # 通用兜底保留 24 小时调度的少量误差空间，避免刚好延后一天的任务被重置。
         limit_next_run(
             [task for task in self.args.keys() if task != "OpsiScheduling"],
-            limit=now + timedelta(hours=24, seconds=-1),
+            limit=now + timedelta(hours=25, seconds=-1),
         )
 
         """


### PR DESCRIPTION
## Summary by Sourcery

放宽任务下一次运行时间的限制窗口，并调整 OpsiScheduling 配置，以使用存储的调度元数据并隐藏其“下一次运行”显示。

Bug Fixes:
- 配置 OpsiScheduling 使用已存储的调度器下一次运行（next-run）元数据，以防止其调度被重置。

Enhancements:
- 将通用下一次运行时间限制缓冲从 24 小时增加到 25 小时，以避免在接近一天的延迟情况下任务被意外重置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax task next-run limiting window and adjust OpsiScheduling configuration to use stored scheduling metadata and hide its next-run display.

Bug Fixes:
- Configure OpsiScheduling to use stored scheduler next-run metadata to prevent its schedule from being reset.

Enhancements:
- Increase the generic next-run time limit buffer from 24 to 25 hours to avoid unintended task reset for near-one-day delays.

</details>