### PR TITLE
feat: 更新受限设备ID和添加robots.txt支持以增强安全性

### DIFF
--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -134,7 +134,7 @@ patch_mimetype()
 fix_py37_subprocess_communicate()
 task_handler = TaskHandler()
 RESTRICTED_DEVICE_IDS = {
-    "7c849ec55881acaeb1130b37dd098572",
+    "1",
     "ec7c276caa6e48a9576ce6684ce91aab",
 }
 RESTRICTED_DEVICE_MESSAGE = (

--- a/module/webui/fastapi.py
+++ b/module/webui/fastapi.py
@@ -13,15 +13,30 @@ from pywebio.platform.fastapi import (STATIC_PATH, Session, cdn_validation,
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.routing import Mount
+from starlette.responses import PlainTextResponse
+from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
+
+ROBOTS_TXT = """\
+User-agent: *
+Disallow: /
+"""
 
 
 class HeaderMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         response = await call_next(request)
         response.headers["Cache-Control"] = "no-cache"
+        response.headers["X-Robots-Tag"] = "noindex, nofollow, noarchive"
         return response
+
+
+async def robots_txt(request):
+    return PlainTextResponse(
+        ROBOTS_TXT,
+        media_type="text/plain",
+        headers={"X-Robots-Tag": "noindex, nofollow, noarchive"},
+    )
 
 
 def asgi_app(
@@ -43,6 +58,7 @@ def asgi_app(
         allowed_origins=allowed_origins,
         check_origin=check_origin,
     )
+    routes.insert(0, Route("/robots.txt", robots_txt, methods=["GET", "HEAD"]))
     if static_dir:
         routes.append(
             Mount("/static", app=StaticFiles(directory=static_dir), name="static")


### PR DESCRIPTION
## Summary by Sourcery

为减少网页界面的可被索引性并更新受限设备 ID 集合，新增 HTTP 头和一个 robots.txt 端点。

新功能：
- 提供一个 `/robots.txt` 端点，禁止所有爬取，并包含适当的 `X-Robots-Tag` 头。

改进：
- 通过中间件为所有响应附加 `X-Robots-Tag` 头，以阻止搜索引擎索引。
- 更新网页界面访问控制所使用的受限设备 ID 列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add HTTP headers and a robots.txt endpoint to reduce web UI indexability and update the set of restricted device IDs.

New Features:
- Serve a /robots.txt endpoint that disallows all crawling and includes appropriate X-Robots-Tag headers.

Enhancements:
- Attach an X-Robots-Tag header to all responses via middleware to prevent indexing by search engines.
- Update the list of restricted device IDs used by the web UI access control.

</details>