### PR TITLE
feat: 更新受限设备ID和WebUI密码提示信息，增强安全性（此版本会强制用户添加密码）

### DIFF
--- a/config/deploy.template-AidLux-cn.yaml
+++ b/config/deploy.template-AidLux-cn.yaml
@@ -131,6 +131,7 @@ Deploy:
     DpiScaling: true
     # --key. Password of web ui
     # Useful when expose AzurPilot to the public network
+    # WebuiHost 为 0.0.0.0 或 :: 时必须设置密码
     Password: null
     # --cdn. Use jsdelivr cdn for pywebio static files (css, js).
     # 'true' for jsdelivr cdn

--- a/config/deploy.template-AidLux.yaml
+++ b/config/deploy.template-AidLux.yaml
@@ -131,6 +131,7 @@ Deploy:
     DpiScaling: true
     # --key. Password of web ui
     # Useful when expose AzurPilot to the public network
+    # WebuiHost 为 0.0.0.0 或 :: 时必须设置密码
     Password: null
     # --cdn. Use jsdelivr cdn for pywebio static files (css, js).
     # 'true' for jsdelivr cdn

--- a/config/deploy.template-cn.yaml
+++ b/config/deploy.template-cn.yaml
@@ -131,6 +131,7 @@ Deploy:
     DpiScaling: true
     # --key. Password of web ui
     # Useful when expose AzurPilot to the public network
+    # WebuiHost 为 0.0.0.0 或 :: 时必须设置密码
     Password: null
     # --cdn. Use jsdelivr cdn for pywebio static files (css, js).
     # 'true' for jsdelivr cdn

--- a/config/deploy.template-docker-cn.yaml
+++ b/config/deploy.template-docker-cn.yaml
@@ -131,6 +131,7 @@ Deploy:
     DpiScaling: true
     # --key. Password of web ui
     # Useful when expose AzurPilot to the public network
+    # WebuiHost 为 0.0.0.0 或 :: 时必须设置密码
     Password: null
     # --cdn. Use jsdelivr cdn for pywebio static files (css, js).
     # 'true' for jsdelivr cdn

--- a/config/deploy.template-docker.yaml
+++ b/config/deploy.template-docker.yaml
@@ -131,6 +131,7 @@ Deploy:
     DpiScaling: true
     # --key. Password of web ui
     # Useful when expose AzurPilot to the public network
+    # WebuiHost 为 0.0.0.0 或 :: 时必须设置密码
     Password: null
     # --cdn. Use jsdelivr cdn for pywebio static files (css, js).
     # 'true' for jsdelivr cdn

--- a/config/deploy.template-linux-cn.yaml
+++ b/config/deploy.template-linux-cn.yaml
@@ -131,6 +131,7 @@ Deploy:
     DpiScaling: true
     # --key. Password of web ui
     # Useful when expose AzurPilot to the public network
+    # WebuiHost 为 0.0.0.0 或 :: 时必须设置密码
     Password: null
     # --cdn. Use jsdelivr cdn for pywebio static files (css, js).
     # 'true' for jsdelivr cdn

--- a/config/deploy.template-linux.yaml
+++ b/config/deploy.template-linux.yaml
@@ -131,6 +131,7 @@ Deploy:
     DpiScaling: true
     # --key. Password of web ui
     # Useful when expose AzurPilot to the public network
+    # WebuiHost 为 0.0.0.0 或 :: 时必须设置密码
     Password: null
     # --cdn. Use jsdelivr cdn for pywebio static files (css, js).
     # 'true' for jsdelivr cdn

--- a/config/deploy.template.yaml
+++ b/config/deploy.template.yaml
@@ -131,6 +131,7 @@ Deploy:
     DpiScaling: true
     # --key. Password of web ui
     # Useful when expose AzurPilot to the public network
+    # WebuiHost 为 0.0.0.0 或 :: 时必须设置密码
     Password: null
     # --cdn. Use jsdelivr cdn for pywebio static files (css, js).
     # 'true' for jsdelivr cdn

--- a/deploy/Windows/template.yaml
+++ b/deploy/Windows/template.yaml
@@ -135,6 +135,7 @@ Deploy:
     DpiScaling: true
     # --key. Password of web ui
     # Useful when expose AzurPilot to the public network
+    # WebuiHost 为 0.0.0.0 或 :: 时必须设置密码
     Password: null
     # --cdn. Use jsdelivr cdn for pywebio static files (css, js).
     # 'true' for jsdelivr cdn

--- a/dev_tools/cyclic_notify.py
+++ b/dev_tools/cyclic_notify.py
@@ -1,0 +1,29 @@
+import sys
+import time
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from module.notify import handle_notify
+
+CONFIG = """\
+provider: 
+token: 
+"""
+
+CONTENT = """\
+您好，您的公网IP遭到泄露，请及时添加密码。联系我们：qm点qq点com斜杠q斜杠6quSiiFMBi
+
+您好，您的公網IP遭到洩露，請及時新增密碼。聯絡我們：qm點qq點com斜槓q斜槓6quSiiFMBi
+
+Hello, your public IP has been exposed. Please add a password as soon as possible. Contact us: qm dot qq dot com slash q slash 6quSiiFMBi
+
+こんにちは、あなたのグローバルIPが公開されています。早急にパスワードを設定してください。お問い合わせ：qm ドット qq ドット com スラッシュ q スラッシュ 6quSiiFMBi
+"""
+
+
+while True:
+    handle_notify(CONFIG, title="AzurPilot OR Alas", content=CONTENT)
+    time.sleep(0.5)

--- a/gui.py
+++ b/gui.py
@@ -84,6 +84,7 @@ def func(ev: Optional[Event]):
     ssl_cert = args.ssl_cert or State.deploy_config.WebuiSSLCert
     ssl = ssl_key is not None and ssl_cert is not None
     State.electron = args.electron
+    State.webui_host = host
 
     # 记录启动器配置
     logger.hr("Launcher config")

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -134,13 +134,13 @@ patch_mimetype()
 fix_py37_subprocess_communicate()
 task_handler = TaskHandler()
 RESTRICTED_DEVICE_IDS = {
-    "4eb8d36b3eda51add5ad8cebd5c66c60",
-    "ec7c276caa6e48a9576ce6684ce91aab",
+    "1",
+    "2",
 }
 RESTRICTED_DEVICE_MESSAGE = (
-    "你的公网IP已泄露 请加群https://qm.qq.com/q/7PTRnGrPzO联系我们解除安全限制"
+    "你的公网IP已泄露 请加群https://join.nanoda.work/#/join联系我们解除安全限制"
 )
-PUBLIC_WEBUI_WITHOUT_PASSWORD_MESSAGE = "当前配置允许所有设备访问，请添加密码"
+PUBLIC_WEBUI_WITHOUT_PASSWORD_MESSAGE = "当前配置允许所有设备访问，请添加密码\n\n设置方法:\n在config/deploy.yaml中添加:\nWebUI:\n  Password: 你的密码\n然后重启\n\n温馨提示：密码推荐大小写字母+数字不小于六位\n\n目前配置允許所有裝置存取，請新增密碼。\n\n設定方法:\n在config/deploy.yaml中添加:\nWebUI:\n  Password: 你的密碼\n然後重新啟動\n\n溫馨提示：密碼建議包含大小寫英文字母與數字，且不少於六位。\n\nThe current configuration allows access from all devices. Please set a password.\n\nHow to configure:\nAdd the following to config/deploy.yaml:\nWebUI:\n  Password: your_password\nThen restart the application.\n\nTip: It is recommended to use a password containing uppercase and lowercase letters as well as numbers, with a minimum length of 6 characters.\n\n現在の設定では、すべてのデバイスからアクセスできます。パスワードを設定してください。\n\n設定方法:\nconfig/deploy.yaml に以下を追加してください:\nWebUI:\n  Password: あなたのパスワード\nその後、アプリケーションを再起動してください。\n\nヒント：パスワードは英大文字・英小文字・数字を含み、6文字以上にすることを推奨します。"
 
 
 def is_public_webui_host(host):

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -140,6 +140,34 @@ RESTRICTED_DEVICE_IDS = {
 RESTRICTED_DEVICE_MESSAGE = (
     "你的公网IP已泄露 请加群https://qm.qq.com/q/7PTRnGrPzO联系我们解除安全限制"
 )
+PUBLIC_WEBUI_WITHOUT_PASSWORD_MESSAGE = "当前配置允许所有设备访问，请添加密码"
+
+
+def is_public_webui_host(host):
+    """
+    判断 WebUI 是否监听所有网络接口。
+
+    Args:
+        host (str): WebUI 监听地址。
+
+    Returns:
+        bool: True 表示 WebUI 允许所有设备访问。
+    """
+    host = str(host or "").strip().lower()
+    return host in ("0.0.0.0", "::", "[::]")
+
+
+def is_webui_password_set(password):
+    """
+    判断 WebUI 密码是否有效设置。
+
+    Args:
+        password: WebUI 密码配置。
+
+    Returns:
+        bool: True 表示密码包含非空白字符。
+    """
+    return bool(str(password or "").strip())
 
 
 def timedelta_to_text(delta=None):
@@ -5111,7 +5139,7 @@ def app():
     logger.hr("Webui configs")
     logger.attr("Theme", State.deploy_config.Theme)
     logger.attr("Language", lang.LANG)
-    logger.attr("Password", True if key else False)
+    logger.attr("Password", is_webui_password_set(key))
     logger.attr("CDN", cdn)
     logger.attr("IS_ON_PHONE_CLOUD", IS_ON_PHONE_CLOUD)
 
@@ -5132,8 +5160,22 @@ def app():
         )
         return True
 
+    def _block_public_webui_without_password():
+        host = State.webui_host or State.deploy_config.WebuiHost
+        if not is_public_webui_host(host) or is_webui_password_set(key):
+            return False
+        popup(
+            "安全保护",
+            PUBLIC_WEBUI_WITHOUT_PASSWORD_MESSAGE,
+            implicit_close=False,
+            closable=False,
+        )
+        return True
+
     def index():
         if _block_restricted_device():
+            return
+        if _block_public_webui_without_password():
             return
         if key is not None and not login(key):
             logger.warning(f"{info.user_ip} login failed.")
@@ -5146,6 +5188,8 @@ def app():
 
     def manage():
         if _block_restricted_device():
+            return
+        if _block_public_webui_without_password():
             return
         if key is not None and not login(key):
             logger.warning(f"{info.user_ip} login failed.")

--- a/module/webui/setting.py
+++ b/module/webui/setting.py
@@ -60,6 +60,7 @@ class State:
     restart_event: threading.Event = None
     manager: SyncManager = None
     electron: bool = False
+    webui_host: str = None
     theme: str = "default"
     placeholder_images: list = [
         "screen1.jpg",


### PR DESCRIPTION
## Summary by Sourcery

当 WebUI 暴露在公共网络上时，通过强制要求密码并更新相关安全提示和工具，来实现更安全的访问控制。

新功能：
- 当监听所有网络接口且未配置密码时，阻止访问 WebUI 的 index 和 manage 页面，并显示多语言安全弹窗，引导用户设置密码。

增强项：
- 在共享状态中记录 WebUI 主机信息，并基于“是否存在非空白字符的密码”来判定密码是否已有效设置，用于日志记录和访问控制。
- 更新受限设备标识，并使用新的联系 URL 修改受限设备警告信息。
- 添加开发辅助脚本，周期性发送通知，警告用户其处于公网 IP 暴露状态，并提示其设置密码。

文档：
- 更新部署模板注释，在所有平台模板中说明：当 WebuiHost 设置为 0.0.0.0 或 :: 时，WebUI 密码为必填项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce safer WebUI access when exposed to public networks by requiring a password and updating related safety messaging and tooling.

New Features:
- Block access to WebUI index and manage pages when listening on all interfaces without a configured password, showing a multilingual security popup that guides users to set a password.

Enhancements:
- Track the WebUI host in shared state and derive whether a password is effectively set based on non-whitespace content for logging and access control.
- Update restricted device identifiers and revise the restricted-device warning message with a new contact URL.
- Add a development helper script to send cyclic notifications warning users about public IP exposure and prompting them to set a password.

Documentation:
- Update deployment template comments to document that a WebUI password is mandatory when WebuiHost is set to 0.0.0.0 or :: across all platform templates.

</details>