### PR TITLE
fix(island): 修复岛屿岗位派遣与角色选择异常

### DIFF
--- a/module/island/island_rancher.py
+++ b/module/island/island_rancher.py
@@ -392,17 +392,39 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
 
     def ranch_ocr_finish_time(self, post_id):
         """读取当前牧场岗位详情页的剩余时间并换算为完成时间。"""
+        if (
+                self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
+                or self.appear(ISLAND_WORK_COMPLETE, offset=1)
+                or self.appear(POST_GET, offset=(50, 0))
+        ):
+            logger.info(f"牧场岗位{post_id}当前为空闲或可收取状态，不记录完成时间")
+            return None
+
+        if not self.appear(ISLAND_WORKING):
+            logger.info(f"牧场岗位{post_id}当前未确认处于工作状态，不记录完成时间")
+            return None
+
         time_work = Duration(ISLAND_WORKING_TIME)
         for retry in range(2):
             if retry:
                 self.device.screenshot()
+            if (
+                    self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
+                    or self.appear(ISLAND_WORK_COMPLETE, offset=1)
+                    or self.appear(POST_GET, offset=(50, 0))
+            ):
+                logger.info(f"牧场岗位{post_id}复检为空闲或可收取状态，不记录完成时间")
+                return None
+            if not self.appear(ISLAND_WORKING):
+                logger.info(f"牧场岗位{post_id}复检后未处于工作状态，不记录完成时间")
+                return None
             time_value = time_work.ocr(self.device.image)
             if time_value.total_seconds() > 0:
                 finish_time = datetime.now() + time_value
-                logger.info(f"牧场岗位{post_id}已满，当前队列最早剩余时间: {time_value}")
+                logger.info(f"牧场岗位{post_id}当前队列最早剩余时间: {time_value}")
                 return finish_time
 
-        logger.warning(f"牧场岗位{post_id}已满，但未识别到剩余时间")
+        logger.warning(f"牧场岗位{post_id}疑似工作中，但未识别到有效剩余时间")
         return None
 
     def post_mode_check(self, post_id):
@@ -435,23 +457,31 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
         self.device.sleep(0.5)
         self.device.screenshot()
         if self.appear(ISLAND_WORKING) and self.post_mode_check(post_id):
-            time_work = Duration(ISLAND_WORKING_TIME)
-            time_value = time_work.ocr(self.device.image)
-            setattr(self, time_var_name, datetime.now() + time_value)
-        else:
-            self.ranch_last_finish_time = None
-            if not self.ranch_post_get_and_add(post_id, config_str):
+            finish_time = self.ranch_ocr_finish_time(post_id)
+            if finish_time is not None:
+                setattr(self, time_var_name, finish_time)
                 self.post_close()
-                return False
-            if self.ranch_last_finish_time is not None:
-                setattr(self, time_var_name, self.ranch_last_finish_time)
                 return True
-            self.post_open(post_button)
-            self.device.sleep(0.5)
-            self.device.screenshot()
-            time_work = Duration(ISLAND_WORKING_TIME)
-            time_value = time_work.ocr(self.device.image)
-            setattr(self, time_var_name, datetime.now() + time_value)
+
+            logger.warning(f"牧场岗位{post_id}工作状态疑似误判，继续尝试收取或追加派遣")
+
+        self.ranch_last_finish_time = None
+        if not self.ranch_post_get_and_add(post_id, config_str):
+            self.post_close()
+            return False
+        if self.ranch_last_finish_time is not None:
+            setattr(self, time_var_name, self.ranch_last_finish_time)
+            return True
+
+        self.post_open(post_button)
+        self.device.sleep(0.5)
+        self.device.screenshot()
+        finish_time = self.ranch_ocr_finish_time(post_id)
+        if finish_time is None:
+            self.post_close()
+            logger.warning(f"牧场岗位{post_id}未取得有效完成时间，本次不写入岗位计时器")
+            return False
+        setattr(self, time_var_name, finish_time)
         self.post_close()
         return True
 

--- a/module/island/island_select_character.py
+++ b/module/island/island_select_character.py
@@ -252,12 +252,84 @@ class SelectCharacter(UI):
 
         return working
 
-    def get_character_by_position(self, screenshot, row, col):
+    @staticmethod
+    def _normalize_grid_positions(positions):
+        if positions is None:
+            return []
+
+        if isinstance(positions, np.ndarray):
+            positions = positions.tolist()
+
+        if (
+                isinstance(positions, (tuple, list))
+                and len(positions) == 2
+                and all(isinstance(value, (int, np.integer)) for value in positions)
+        ):
+            return [(int(positions[0]), int(positions[1]))]
+
+        normalized = []
+        for position in positions:
+            if isinstance(position, np.ndarray):
+                position = position.tolist()
+            if not isinstance(position, (tuple, list)) or len(position) != 2:
+                continue
+            row, col = position
+            try:
+                normalized.append((int(row), int(col)))
+            except (TypeError, ValueError):
+                continue
+        return normalized
+
+    def _iter_grid_position_buttons(self, positions):
+        width, height = self.select_character_grid.grid_shape
+        for row, col in self._normalize_grid_positions(positions):
+            if row < 0 or col < 0 or row >= width or col >= height:
+                logger.warning(f"角色选择格子位置越界: {(row, col)}")
+                continue
+            yield row, col, self.select_character_grid[row, col]
+
+    def get_characters_by_positions(self, screenshot, positions, character_names=None):
+        """获取指定格子位置的角色状态，支持单个位置或多个位置。"""
+        results = []
+        if character_names is None:
+            character_targets = None
+        else:
+            character_targets = {
+                name: self.character_templates[name]
+                for name in character_names
+                if name in self.character_templates
+            }
+            if not character_targets:
+                return results
+
+        for row, col, button in self._iter_grid_position_buttons(positions):
+            character_status = self._recognize_character_status(
+                screenshot, button, character_targets=character_targets
+            )
+            if character_status:
+                results.append({
+                    "grid_position": (row, col),
+                    "button_area": button.area,
+                    **character_status
+                })
+
+        return results
+
+    def get_character_by_position(self, screenshot, position, col=None):
         """获取指定网格位置的字符状态"""
-        for char_info in self.recognize_all_characters(screenshot):
-            if char_info["grid_position"] == (row, col):
-                return char_info
+        if col is not None:
+            position = (position, col)
+        characters = self.get_characters_by_positions(screenshot, position)
+        if characters:
+            return characters[0]
         return None
+
+    def is_any_character_selected_by_positions(self, screenshot, positions):
+        """检查指定格子位置中是否已有角色被选中。"""
+        for _, _, button in self._iter_grid_position_buttons(positions):
+            if self._check_selected_status(screenshot, button):
+                return True
+        return False
 
     def select_character_filter(self):
         if self.appear_then_click(SELECT_CHARACTER_FILTER):
@@ -452,12 +524,12 @@ class SelectCharacter(UI):
         # 尝试点击选择，最多5次
         max_attempts = 5
         attempts = 0
+        target_positions = [(row, col)]
 
         while attempts < max_attempts:
             screenshot = self.device.screenshot()
-            current_char_info = self.get_character_by_position(screenshot, row, col)
 
-            if current_char_info and current_char_info["is_selected"]:
+            if self.is_any_character_selected_by_positions(screenshot, target_positions):
                 return True
             else:
                 self.device.click(button)

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -9,6 +9,7 @@ from module.island.island_season import get_global_season_config
 
 class IslandShopBase(Island, WarehouseOCR):
     _MAX_FILL_LOOP = 10  # while 循环填岗最大迭代次数
+    PRODUCT_SELECT_RETRY_LIMIT = 3  # 餐品选择识别失败后，退出重进的最大次数
     POST_PRODUCE_LIMIT = 7  # 餐馆每个岗位单次最多生产数量
 
     def __init__(self, config, device=None, task=None):
@@ -187,6 +188,33 @@ class IslandShopBase(Island, WarehouseOCR):
         return self.select_character(character_list=self.chef_config)
     def produce_special_food(self):
         pass
+
+    def retry_product_selection_from_postmanage(self, post_button, product, failed_product, failed_count):
+        """餐品选择失败后退出岗位，重新进入同一岗位走完整派遣流程。"""
+        if failed_count >= self.PRODUCT_SELECT_RETRY_LIMIT:
+            raise GameStuckError(
+                f"{product}生产选择餐品时连续{failed_count}次未识别到 {failed_product}"
+            )
+
+        logger.warning(
+            f"{product}生产选择餐品时未识别到 {failed_product}，"
+            f"退出岗位后重新进入 ({failed_count}/{self.PRODUCT_SELECT_RETRY_LIMIT})"
+        )
+        if not self.back_to_postmanage_from_dispatch():
+            raise GameStuckError(f"{product}生产选择餐品失败后无法返回岗位管理页")
+
+        self.post_manage_mode(POST_MANAGE_PRODUCTION)
+        self.post_manage_swipe(self.post_manage_swipe_count)
+        if not self.post_open(post_button):
+            raise GameStuckError(f"{product}生产选择餐品失败后无法重新打开岗位")
+        self.device.sleep(0.5)
+
+    def increase_product_selection_failure(self, product_select_failures, failed_product):
+        """记录单个餐品的选择失败次数。"""
+        failed_count = product_select_failures.get(failed_product, 0) + 1
+        product_select_failures[failed_product] = failed_count
+        return failed_count
+
     def post_produce(self, post_id, product, number, time_var_name,product2=None):
         """生产产品（通用）"""
         post_button = self.posts[post_id]['button']
@@ -196,8 +224,8 @@ class IslandShopBase(Island, WarehouseOCR):
         time_work = Duration(ISLAND_WORKING_TIME)
         selection = self.name_to_config[product]['selection']
         selection_check = self.name_to_config[product]['selection_check']
-        while 1:
-            self.device.screenshot()
+        product_select_failures = {}
+        for _ in self.loop(timeout=120, skip_first=False):
             if self.appear_then_click(ISLAND_POST_SELECT, offset=1):
                 self.device.sleep(0.5)
                 continue
@@ -227,7 +255,14 @@ class IslandShopBase(Island, WarehouseOCR):
                             if product2:
                                 selection2 = self.name_to_config[product2]['selection']
                                 selection_check2 = self.name_to_config[product2]['selection_check']
-                                self.select_product(selection2, selection_check2)
+                                if not self.select_product(selection2, selection_check2):
+                                    failed_count = self.increase_product_selection_failure(
+                                        product_select_failures, product2
+                                    )
+                                    self.retry_product_selection_from_postmanage(
+                                        post_button, product, product2, failed_count
+                                    )
+                                    continue
                                 self.device.sleep(0.5)
                                 if self.produce_check():
                                     logger.warning(f"原料不足，无法生产 {product2}")
@@ -257,7 +292,16 @@ class IslandShopBase(Island, WarehouseOCR):
                         self.device.click(POST_ADD_ORDER)
                         self.device.sleep(0.5)
                         break
+                else:
+                    failed_count = self.increase_product_selection_failure(
+                        product_select_failures, product
+                    )
+                    self.retry_product_selection_from_postmanage(
+                        post_button, product, product, failed_count
+                    )
                 continue
+        else:
+            raise GameStuckError(f"{product}生产派遣流程超时")
         self.wait_until_appear(ISLAND_POSTMANAGE_CHECK)
         self.device.sleep(0.5)
         self.post_manage_swipe(self.post_manage_swipe_count)


### PR DESCRIPTION
## 修改内容

- 修复牧场空岗位被误写入无效计时器的问题
  - 空闲、可收取和已完成状态不再写入岗位完成时间
  - 仅在确认岗位工作中且 OCR 到有效剩余时间时更新计时器
  - 工作状态疑似误判时继续走收取或追加派遣流程，避免 NextRun 写到过去导致循环

- 修复餐品选择失败后重复下滑的问题
  - 为单个餐品选择失败增加重试计数，最多重进岗位重试 3 次
  - 选餐未命中时先退回岗位管理页，再重新打开同一岗位走完整派遣流程
  - 将排产状态循环改为 `self.loop(timeout=120)`，连续失败后抛出 `GameStuckError`

- 优化岛屿角色选择复检
  - 新增按单个或多个格子位置识别角色状态的接口
  - 保留 `get_character_by_position` 旧参数兼容，同时支持直接传入位置元组
  - 点击角色后仅检查目标格子的选中状态，避免整页重复体力 OCR
## 关联 Issue

Fixes #379
Fixes #380

## Summary by Sourcery

修复岛屿牧场栏位完成时间和餐厅商品选择的鲁棒性问题，并根据网格位置优化角色选择逻辑。

Bug 修复：
- 防止空的或仅有可收集物的牧场栏位错误记录完成计时器，并在工作状态不确定时，避免写入早于 `NextRun` 的值。
- 通过按商品跟踪选择失败状态，从岗位管理界面重新尝试，并在超时后抛出“游戏卡住”错误，来避免在餐厅商品选择失败时不断重复滚动。
- 确保角色选择仅检查目标网格位置，而不是依赖整页识别，从而避免误判已选择/未选择状态。

增强功能：
- 添加灵活的辅助方法，用于查询和归一化角色网格位置，以及检查指定单元格中是否有角色被选中。
- 优化牧场栏位完成时间的 OCR：重新验证栏位状态，并仅在识别到有效剩余时间时才存储计时器。
- 为餐厅生产派单流程中的商品选择重试添加可配置的上限和记录机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix island ranch post timing and restaurant product selection robustness, and refine character selection by grid position.

Bug Fixes:
- Prevent empty or collectible ranch posts from incorrectly recording finish timers and handle uncertain working status without writing past NextRun values.
- Avoid repeated scrolling when restaurant product selection fails by tracking per-product failures, retrying from the post management screen, and timing out with a game-stuck error.
- Ensure character selection checks only the target grid positions instead of relying on full-page recognition, avoiding mis-detected selection states.

Enhancements:
- Add flexible helpers to query and normalize character grid positions, and to check whether any character is selected in specified cells.
- Refine ranch post finish time OCR to re-validate post status and only store timers when a valid remaining time is recognized.
- Add configurable limits and bookkeeping for product selection retries during restaurant production dispatch flows.

</details>