### PR TITLE
fix(island): 修复季节餐优先制作与岛屿任务冷启动问题

### DIFF
--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -3675,8 +3675,8 @@
       "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "DoubleBambooShoots": {
-      "name": "Cold Bamboo Shoots",
-      "help": "Produced with highest priority before base meals."
+      "name": "Prioritize Seasonal Dish",
+      "help": "When enabled, produce the current restaurant seasonal dish before base meals. Spring uses Cold Bamboo Shoots, summer uses Amaranth Rice Ball; autumn and winter have no extra restaurant seasonal dish."
     },
     "Meal1": {
       "name": "Meal 1",
@@ -3886,8 +3886,8 @@
       "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "Seasonal": {
-      "name": "Spring Flower Tea",
-      "help": "Checked and produced before permanent meals."
+      "name": "Prioritize Seasonal Drink",
+      "help": "When enabled, produce the current Teahouse seasonal drink before base drinks. Spring uses Spring Flower Tea, summer uses Watermelon Juice; autumn and winter have no extra teahouse seasonal drink."
     },
     "Meal1": {
       "name": "Meal 1",

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -3675,8 +3675,8 @@
       "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "DoubleBambooShoots": {
-      "name": "涼拌双筍",
-      "help": "基本メニューの前に最優先で生産されます。"
+      "name": "季節料理を優先生産",
+      "help": "有効にすると、現在の季節のレストラン季節料理を基本メニューより先に生産します。春は涼拌双筍、夏はアマランサスおにぎりです。秋冬は追加の季節料理を生産しません。"
     },
     "Meal1": {
       "name": "メニュー1",
@@ -3886,8 +3886,8 @@
       "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "Seasonal": {
-      "name": "春花茶",
-      "help": "常設メニューの前にチェックして生産されます。"
+      "name": "季節ドリンクを優先生産",
+      "help": "有効にすると、現在の季節の白熊ドリンク季節品を基本ドリンクより先に生産します。春は迎春花茶、夏はスイカジュースです。秋冬は追加の季節ドリンクを生産しません。"
     },
     "Meal1": {
       "name": "メニュー1",

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -3675,8 +3675,8 @@
       "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "DoubleBambooShoots": {
-      "name": "凉拌双笋",
-      "help": "在基础餐品之前优先制作（最高优先级）"
+      "name": "季节餐优先制作",
+      "help": "开启后按当前季节选择餐馆季节餐，并在基础餐品之前优先制作。春季为凉拌双笋，夏季为苋菜饭团；秋冬无餐馆季节餐时不额外制作。"
     },
     "Meal1": {
       "name": "餐品1",
@@ -3886,8 +3886,8 @@
       "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Seasonal": {
-      "name": "迎春花茶",
-      "help": "在常驻餐品之前检查并制作"
+      "name": "季节饮品优先制作",
+      "help": "开启后按当前季节选择白熊饮品的季节饮品，并在基础饮品之前优先制作。春季为迎春花茶，夏季为西瓜汁；秋冬无白熊饮品季节饮品时不额外制作。"
     },
     "Meal1": {
       "name": "餐品1",

--- a/module/config/i18n/zh-MIAO.json
+++ b/module/config/i18n/zh-MIAO.json
@@ -3675,8 +3675,8 @@
       "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "DoubleBambooShoots": {
-      "name": "凉拌双笋",
-      "help": "在基础餐品之前优先制作（最高优先级）"
+      "name": "季节餐优先制作",
+      "help": "开启后按当前季节选择餐馆季节餐，并在基础餐品之前优先制作喵。春季为凉拌双笋，夏季为苋菜饭团；秋冬无餐馆季节餐时不额外制作喵。"
     },
     "Meal1": {
       "name": "餐品1",
@@ -3886,8 +3886,8 @@
       "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Seasonal": {
-      "name": "迎春花茶",
-      "help": "在常驻餐品之前检查并制作"
+      "name": "季节饮品优先制作",
+      "help": "开启后按当前季节选择白熊饮品的季节饮品，并在基础饮品之前优先制作喵。春季为迎春花茶，夏季为西瓜汁；秋冬无白熊饮品季节饮品时不额外制作喵。"
     },
     "Meal1": {
       "name": "餐品1",

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -3675,8 +3675,8 @@
       "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "DoubleBambooShoots": {
-      "name": "涼拌雙筍",
-      "help": "在基礎餐品之前優先製作（最高優先級）"
+      "name": "季節餐優先製作",
+      "help": "開啟後按目前季節選擇餐館季節餐，並在基礎餐品之前優先製作。春季為涼拌雙筍，夏季為莧菜飯糰；秋冬無餐館季節餐時不額外製作。"
     },
     "Meal1": {
       "name": "餐品1",
@@ -3886,8 +3886,8 @@
       "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "Seasonal": {
-      "name": "迎春花茶",
-      "help": "在常駐餐品之前檢查並製作"
+      "name": "季節飲品優先製作",
+      "help": "開啟後按目前季節選擇白熊飲品的季節飲品，並在基礎飲品之前優先製作。春季為迎春花茶，夏季為西瓜汁；秋冬無白熊飲品季節飲品時不額外製作。"
     },
     "Meal1": {
       "name": "餐品1",

--- a/module/island/island_cargo_preparation.py
+++ b/module/island/island_cargo_preparation.py
@@ -34,7 +34,7 @@ from module.island.ui import IslandUI
 from module.logger import logger
 from module.map.map_grids import SelectedGrids
 from module.ocr.ocr import Duration
-from module.ui.page import page_island_phone
+from module.ui.page import page_island, page_island_phone
 from module.ui_white.assets import POPUP_CANCEL_WHITE
 
 
@@ -238,6 +238,7 @@ class IslandCargoPreparation(IslandUI):
     def run(self):
         logger.hr('Island Cargo Preparation Run', level=1)
 
+        self.ui_ensure(page_island)
         self.ui_goto(page_island_phone, get_ship=False)
         self.island_transport_enter()
 

--- a/module/island/island_daily_interact.py
+++ b/module/island/island_daily_interact.py
@@ -18,6 +18,7 @@ class IslandDailyInteract(Island):
     def run(self):
         """执行启用的岛屿低频互动任务。"""
         logger.hr('Island Daily Interact Run', level=1)
+        self.ui_ensure(page_island)
 
         all_done = True
         self.pet_cat()

--- a/module/island/island_daily_order.py
+++ b/module/island/island_daily_order.py
@@ -3,7 +3,7 @@ import module.island_daily_order.assets as daily_order_assets
 from module.island_daily_order.assets import *
 from module.island.assets import ISLAND_BACK, ISLAND_GET, ISLAND_CLICK_SAFE_AREA
 from module.base.button import Button
-from module.ui.page import page_island_phone
+from module.ui.page import page_island, page_island_phone
 from module.logger import logger
 from module.ocr.ocr import DigitCounter, Duration
 from datetime import datetime, timedelta
@@ -58,6 +58,8 @@ class IslandDailyOrder(Island):
 
     def run(self):
         logger.hr('Island Daily Order Run', level=1)
+
+        self.ui_ensure(page_island)
 
         # 导航到岛屿手机页面
         self.ui_goto(page_island_phone, get_ship=False)

--- a/module/island/island_farm.py
+++ b/module/island/island_farm.py
@@ -360,6 +360,7 @@ class IslandFarm(Island, WarehouseOCR, LoginHandler):
 
     def run(self):
         self.island_error = False
+        self.ui_ensure(page_island)
         self.check_inventory_and_prepare_lists()
 
         logger.info("\n当前库存统计:")

--- a/module/island/island_pearl_sell.py
+++ b/module/island/island_pearl_sell.py
@@ -8,6 +8,7 @@ from module.island.assets import *
 from module.island_pearl_sell.assets import *
 from module.logger import logger
 from module.ocr.ocr import Digit, Ocr
+from module.ui.page import page_island
 
 
 class IslandPearlSell(Island):
@@ -63,6 +64,8 @@ class IslandPearlSell(Island):
             self.config.task_delay(target=target)
             self.config.save()
             return
+
+        self.ui_ensure(page_island)
 
         # 采购售卖时间已到，执行完整周循环
         if trade_due:

--- a/module/island/island_rancher.py
+++ b/module/island/island_rancher.py
@@ -532,6 +532,7 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
 
     def run(self):
         self.island_error = False
+        self.ui_ensure(page_island)
         time_vars = ['time_ranch1', 'time_ranch2', 'time_ranch3', 'time_ranch4']
         all_configs = [
             ('ISLAND_RANCH_POST1', 'time_ranch1'),

--- a/module/island/island_restaurant.py
+++ b/module/island/island_restaurant.py
@@ -14,6 +14,38 @@ FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS = Button(
     file={'cn': '', 'en': '', 'jp': '', 'tw': ''}
 )
 
+RESTAURANT_SEASONAL_DISHES = {
+    'double_bamboo_shoots': {
+        'name': 'double_bamboo_shoots', 'template': TEMPLATE_DOUBLE_BAMBOO_SHOOTS,
+        'selection': SELECT_DOUBLE_BAMBOO_SHOOTS, 'selection_check': SELECT_DOUBLE_BAMBOO_SHOOTS_CHECK,
+        'post_action': POST_DOUBLE_BAMBOO_SHOOTS, 'cn_name': '凉拌双笋'
+    },
+    'asparagus_shrimp': {
+        'name': 'asparagus_shrimp', 'template': TEMPLATE_ASPARAGUS_SHRIMP,
+        'selection': SELECT_ASPARAGUS_SHRIMP, 'selection_check': SELECT_ASPARAGUS_SHRIMP_CHECK,
+        'post_action': POST_ASPARAGUS_SHRIMP, 'cn_name': '芦笋炒虾仁'
+    },
+    'amaranth_rice_ball': {
+        'name': 'amaranth_rice_ball', 'template': TEMPLATE_AMARANTH_RICE_BALL,
+        'selection': SELECT_AMARANTH_RICE_BALL, 'selection_check': SELECT_AMARANTH_RICE_BALL_CHECK,
+        'post_action': POST_AMARANTH_RICE_BALL, 'cn_name': '苋菜饭团'
+    },
+    'tomato_egg': {
+        'name': 'tomato_egg', 'template': TEMPLATE_TOMATO_EGG,
+        'selection': SELECT_TOMATO_EGG, 'selection_check': SELECT_TOMATO_EGG_CHECK,
+        'post_action': POST_TOMATO_EGG, 'cn_name': '番茄炒蛋'
+    },
+}
+
+HIGH_PRIORITY_SEASONAL_DISHES = {
+    name: {
+        **RESTAURANT_SEASONAL_DISHES[name],
+        'selection': FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS,
+        'selection_check': FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS,
+    }
+    for name in ('double_bamboo_shoots', 'amaranth_rice_ball')
+}
+
 
 class IslandRestaurant(IslandShopBase):
     def __init__(self, *args, **kwargs):
@@ -26,39 +58,15 @@ class IslandRestaurant(IslandShopBase):
 
         # === 初始化全局季节配置 ===
         self._init_season_config()
-        # 兼容旧配置
-        old_double_enabled = getattr(self.config, 'IslandRestaurant_DoubleBambooShoots', False)
 
         # === 高优先级季节菜品映射 ===
-        self.seasonal_dish_slot = None
-        seasonal_items = self.season_config.get_seasonal_items('restaurant') if hasattr(self, 'season_config') else []
-
-        if 'double_bamboo_shoots' in seasonal_items:
-            self.seasonal_dish_slot = {
-                'name': 'double_bamboo_shoots', 'template': TEMPLATE_DOUBLE_BAMBOO_SHOOTS,
-                'selection': FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS, 'selection_check': FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS,
-                'post_action': POST_DOUBLE_BAMBOO_SHOOTS, 'cn_name': '凉拌双笋'
-            }
-        elif 'amaranth_rice_ball' in seasonal_items:
-            self.seasonal_dish_slot = {
-                'name': 'amaranth_rice_ball', 'template': TEMPLATE_AMARANTH_RICE_BALL,
-                'selection': FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS, 'selection_check': FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS,
-                'post_action': POST_AMARANTH_RICE_BALL, 'cn_name': '苋菜饭团'
-            }
-        elif old_double_enabled:
-            self.seasonal_dish_slot = {
-                'name': 'double_bamboo_shoots', 'template': TEMPLATE_DOUBLE_BAMBOO_SHOOTS,
-                'selection': FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS, 'selection_check': FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS,
-                'post_action': POST_DOUBLE_BAMBOO_SHOOTS, 'cn_name': '凉拌双笋'
-            }
+        self.seasonal_dish_slot = self._get_high_priority_seasonal_dish()
 
         if self.seasonal_dish_slot:
             logger.info(f"高优先级季节菜品: {self.seasonal_dish_slot['cn_name']}")
 
         # 设置商品列表（根据季节自动选择对应菜品）
-        self.shop_items = []
-        if self.seasonal_dish_slot:
-            self.shop_items.append(self.seasonal_dish_slot)
+        self.shop_items = self._get_current_seasonal_shop_items()
         # ---- 常规菜品 ----
         self.shop_items.extend([
             {'name': 'tofu', 'template': TEMPLATE_TOFU, 'var_name': 'tofu',
@@ -91,13 +99,6 @@ class IslandRestaurant(IslandShopBase):
             {'name': 'onion_fish', 'template': TEMPLATE_ONION_FISH, 'var_name': 'onion_fish',
              'selection': SELECT_ONION_FISH, 'selection_check': SELECT_ONION_FISH_CHECK,
              'post_action': POST_ONION_FISH},
-            # 季节限定菜品（需在 shop_items 中注册，以支持季节自动切换和配置读取）
-            {'name': 'asparagus_shrimp', 'template': TEMPLATE_ASPARAGUS_SHRIMP, 'var_name': 'asparagus_shrimp',
-             'selection': SELECT_ASPARAGUS_SHRIMP, 'selection_check': SELECT_ASPARAGUS_SHRIMP_CHECK,
-             'post_action': POST_ASPARAGUS_SHRIMP},
-            {'name': 'tomato_egg', 'template': TEMPLATE_TOMATO_EGG, 'var_name': 'tomato_egg',
-             'selection': SELECT_TOMATO_EGG, 'selection_check': SELECT_TOMATO_EGG_CHECK,
-             'post_action': POST_TOMATO_EGG},
         ])
 
         # 设置套餐组成
@@ -139,6 +140,34 @@ class IslandRestaurant(IslandShopBase):
 
         # 初始化店铺
         self.initialize_shop()
+
+    def _is_seasonal_priority_enabled(self):
+        return getattr(self.config, 'IslandRestaurant_DoubleBambooShoots', False)
+
+    def _get_current_seasonal_shop_items(self):
+        if not hasattr(self, 'season_config') or not self.season_config:
+            return []
+
+        seasonal_items = self.season_config.get_seasonal_items('restaurant') or []
+        result = []
+        for item_name in seasonal_items:
+            dish = RESTAURANT_SEASONAL_DISHES.get(item_name)
+            if dish:
+                result.append(dish.copy())
+        return result
+
+    def _get_high_priority_seasonal_dish(self):
+        if not self._is_seasonal_priority_enabled():
+            return None
+        if not hasattr(self, 'season_config') or not self.season_config:
+            return None
+
+        seasonal_items = self.season_config.get_seasonal_items('restaurant') or []
+        for item_name in seasonal_items:
+            dish = HIGH_PRIORITY_SEASONAL_DISHES.get(item_name)
+            if dish:
+                return dish.copy()
+        return None
 
     def _auto_switch_seasonal_meals(self):
         """
@@ -183,10 +212,14 @@ class IslandRestaurant(IslandShopBase):
         高优先级季节菜品使用固定坐标点击，不进行模板匹配和滑动。
         其他餐品走父类逻辑。
         """
-        if self.seasonal_dish_slot and product_selection == self.seasonal_dish_slot['selection']:
-            self.device.click(FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS)
-            self.device.sleep(0.5)
-            return True
+        if self.seasonal_dish_slot:
+            dish_name = self.seasonal_dish_slot['name']
+            fixed_selection = self.seasonal_dish_slot['selection']
+            normal_selection = self.name_to_config.get(dish_name, {}).get('selection')
+            if product_selection in (fixed_selection, normal_selection):
+                self.device.click(FIXED_SELECT_DOUBLE_BAMBOO_SHOOTS)
+                self.device.sleep(0.5)
+                return True
         return super().select_product(product_selection, product_selection_check)
 
     def check_special_materials(self, product, batch_size):


### PR DESCRIPTION
## 修改内容

- 修正有鱼餐馆“凉拌双笋”配置项语义，调整为“季节餐优先制作”
- 餐馆季节餐改为按当前季节动态注册，避免跨季节识别或制作非当前季节餐品
- 更新有鱼餐馆与白熊饮品季节优先制作相关 i18n 文案
- 修复部分岛屿任务在游戏未启动时直接进入 `ui_goto()` 或仓库读取导致卡死的问题
- 每日互动、珍珠售卖、每日订单、货运筹备、农场、牧场入口统一先走 `ui_ensure(page_island)`

## 问题原因

部分岛屿任务入口没有先经过 `ui_get_current_page()` 的页面识别链，而是直接 `ui_goto()` 或在进入管理页前读取仓库。游戏未运行时，这些流程无法触发既有的 `app_check()` 和上层 Restart 恢复逻辑，导致任务启动后卡在截图检查流程中。

餐馆季节菜品原先配置名绑定在“凉拌双笋”上，但实际需求是按季节优先制作当前季节餐品，旧语义在季节切换后容易造成配置含义不准确。

## Summary by Sourcery

使海岛餐厅的季节菜品与当前季节配置对齐，并确保海岛自动化任务从海岛页面安全启动，避免在冷启动时出现卡死。

Bug Fixes:
- 修复海岛餐厅的季节菜品配置，使优先生产目标为当前季节的菜品，而非固定的某个菜单项。
- 防止在游戏未运行时海岛任务（每日互动、珍珠出售、每日订单、货物准备、农场、牧场）出现卡死问题，方式是确保它们在执行前先进入海岛页面。

Enhancements:
- 重构餐厅季节菜品注册逻辑，从季节配置中动态推导商店商品和高优先级菜品。
- 改进选择逻辑，使高优先级季节菜品同时支持固定选择和普通选择路径，以提升兼容性。
- 更新与餐厅和饮品季节优先级设置相关的 i18n 文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align island restaurant seasonal dishes with current season configuration and ensure island automation tasks safely start from the island page to avoid cold-start hangs.

Bug Fixes:
- Fix island restaurant seasonal dish configuration so that priority production targets the current season’s dish instead of a specific menu item.
- Prevent island tasks (daily interactions, pearl selling, daily orders, cargo preparation, farm, ranch) from hanging when the game is not running by ensuring they first enter the island page.

Enhancements:
- Refactor restaurant seasonal dish registration to dynamically derive shop items and high-priority dishes from season configuration.
- Improve selection logic so high-priority seasonal dishes support both fixed and normal selection paths for better compatibility.
- Update i18n strings related to seasonal-priority restaurant and drink settings.

</details>