### PR TITLE
feat(demo): 添加演示模式支持，禁用实时预览和控制功能

### DIFF
--- a/module/webui/api.py
+++ b/module/webui/api.py
@@ -26,6 +26,11 @@ from module.device.method.utils import recv_all
 from module.logger import logger
 from module.config.utils import DEFAULT_CONFIG_NAME
 
+
+def is_demo_mode():
+    return os.environ.get("DEMO") == "1"
+
+
 def api_cl1_stats(request):
     try:
         from module.statistics.opsi_month import get_opsi_stats
@@ -968,6 +973,13 @@ CONTROL_ACTION_KEYCODES = {
 
 async def ws_live_screenshot(websocket):
     await websocket.accept()
+    if is_demo_mode():
+        await websocket.send_text(json.dumps({
+            "type": "error",
+            "message": "DEMO=1，实时预览已禁用，避免初始化设备资源。",
+        }))
+        await websocket.close()
+        return
 
     instance = websocket.query_params.get("instance", DEFAULT_CONFIG_NAME)
     mode = websocket.query_params.get("mode", "auto").lower()
@@ -1265,6 +1277,13 @@ async def _ws_live_screenshot_fallback(websocket, instance, codec, ffmpeg, fps, 
 
 async def ws_live_control(websocket):
     await websocket.accept()
+    if is_demo_mode():
+        await websocket.send_text(json.dumps({
+            "type": "error",
+            "message": "DEMO=1，实时控制已禁用，避免初始化设备资源。",
+        }))
+        await websocket.close()
+        return
     instance = websocket.query_params.get("instance", DEFAULT_CONFIG_NAME)
     fallback = None
 

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -146,6 +146,7 @@ PUBLIC_WEBUI_PASSWORD_GENERATE_FAILED_MESSAGE = (
     "当前配置允许所有设备访问，但自动生成密码失败，请手动在 config/deploy.yaml 设置 Password 后重启。"
 )
 WEBUI_AUTO_PASSWORD_FILE = "password.txt"
+DEMO_DEVICE_ID_TEXT = "此程序是为了演示用途构建的版本/This application is a version built for demonstration purposes."
 
 
 def is_demo_mode():
@@ -3184,7 +3185,7 @@ class AlasGUI(Frame):
 
             # 在掉落记录组中显示可复制的设备ID
             if group_name == "DropRecord":
-                device_id = get_device_id()
+                device_id = DEMO_DEVICE_ID_TEXT if is_demo_mode() else get_device_id()
                 put_html(build_copyable_device_id(device_id))
 
         return len(output_list)
@@ -3205,13 +3206,12 @@ class AlasGUI(Frame):
 
     def _alas_start(self):
         self.alas.start(None, updater.event)
-        if os.environ.get("DEMO") == "1":
-            threading.Timer(5, self.alas.stop).start()
 
     def _simulator_start(self):
+        if is_demo_mode():
+            logger.info("DEMO=1，跳过大世界模拟器启动。")
+            return
         self.simulator.start()
-        if os.environ.get("DEMO") == "1":
-            threading.Timer(5, self.simulator.interrupt).start()
 
     @use_scope("content", clear=True)
     def alas_overview(self) -> None:
@@ -3392,8 +3392,9 @@ class AlasGUI(Frame):
             # version
             local_commit = updater.get_commit(short_sha1=True)
             version = local_commit[0] if local_commit and local_commit[0] else "Unknown"
+            device_id = DEMO_DEVICE_ID_TEXT if is_demo_mode() else get_device_id()
             put_scope("log-container", [put_scope("log", [put_html("")])]).style(
-                f"--device-id: '{get_device_id()}'; --version: 'Ver.{version}';"
+                f"--device-id: '{device_id}'; --version: 'Ver.{version}';"
             )
 
         log.console.width = log.get_width()
@@ -5088,7 +5089,7 @@ def startup():
     task_handler.start()
     if State.deploy_config.DiscordRichPresence:
         init_discord_rpc()
-    if State.deploy_config.StartOcrServer:
+    if State.deploy_config.StartOcrServer and not is_demo_mode():
         start_ocr_server_process(State.deploy_config.OcrServerPort)
     if State.deploy_config.EnableRemoteAccess and (
         State.deploy_config.Password is not None or os.environ.get("DEMO") == "1"
@@ -5169,6 +5170,8 @@ def app():
     static_path = os.getcwd()
 
     def _block_restricted_device():
+        if is_demo_mode():
+            return False
         if get_device_id() not in RESTRICTED_DEVICE_IDS:
             return False
         popup(

--- a/module/webui/process_manager.py
+++ b/module/webui/process_manager.py
@@ -180,6 +180,8 @@ class ProcessManager:
                 if update_tail_hit:
                     return 4
                 return 2
+            elif "此版本为演示用途" in s:
+                return 2
             elif update_tail_hit:
                 return 4
             else:
@@ -229,6 +231,16 @@ class ProcessManager:
             from module.logger import console_hdlr
             logger.removeHandler(console_hdlr)
         set_func_logger(func=q.put)
+
+        if os.environ.get("DEMO") == "1":
+            logger.info("Log3")
+            time.sleep(1)
+            logger.info("Log2")
+            time.sleep(1)
+            logger.info("Log1")
+            time.sleep(1)
+            logger.info("此版本为演示用途")
+            return
 
         from module.config.config import AzurLaneConfig
 


### PR DESCRIPTION
## Summary by Sourcery

添加一个演示模式，用于禁用资源密集型的实时预览/控制功能，并调整标识符和进程以支持安全的演示构建。

新功能：
- 引入演示模式标志，通过环境变量 `DEMO=1` 控制，在演示构建中改变 Web UI 的行为。

改进：
- 在演示模式下禁用实时截图和实时控制的 WebSocket 端点，并为用户展示说明此限制的错误消息。
- 在演示模式运行时，在 UI 中显示特定于演示的设备标识字符串，而不显示真实设备 ID。
- 在演示模式下跳过启动世界模拟器和 OCR 服务器进程，以避免初始化占用资源较多的设备服务。
- 在演示模式下绕过受限设备检查，使演示可以在任意设备上运行。
- 调整进程管理器以识别演示模式终止日志，并在状态报告中将其视为正常运行状态。
- 在演示模式下启动进程时输出一段简短且确定性的演示日志序列，以展示日志输出效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a demo mode that disables resource-intensive live preview/control features and adjusts identifiers and processes to support a safe demonstration build.

New Features:
- Introduce a demo mode flag controlled via the DEMO=1 environment variable to alter web UI behavior for demonstration builds.

Enhancements:
- Disable live screenshot and live control WebSocket endpoints in demo mode with user-facing error messages explaining the restriction.
- Display a demo-specific device identifier string in the UI instead of the real device ID when running in demo mode.
- Skip starting the world simulator and OCR server processes in demo mode to avoid initializing heavy device resources.
- Bypass restricted-device checks in demo mode to allow the demo to run on any device.
- Adjust the process manager to recognize demo-mode termination logs and treat them as a normal running state for status reporting.
- Emit a short, deterministic demo log sequence when launching processes in demo mode to showcase logging output.

</details>