### PR TITLE
fix(island): 修复牧场再次委派、珍珠售卖与岛屿对话识别问题

### DIFF
--- a/module/island/island.py
+++ b/module/island/island.py
@@ -415,19 +415,31 @@ class Island(SelectCharacter):
 
     def post_close(self):
         for _ in self.loop(timeout=15, skip_first=False):
-            if self.ui_page_appear(page_island_postmanage) and not self.appear(ISLAND_POST_CHECK) and not self.appear(ISLAND_POST_VACANT_CHECK):
+            if self.ui_page_appear(page_island_postmanage) and not self.is_post_detail_visible():
                 return True
             if self.appear(ISLAND_GET, offset=30):
                 self.device.click(ISLAND_POST_SAFE_AREA)
                 continue
-            if self.appear(ISLAND_POST_CHECK) or self.appear(ISLAND_POST_VACANT_CHECK):
+            if self.is_post_detail_visible():
                 self.device.click(POST_CLOSE)
                 continue
         logger.warning("关闭岗位详情超时")
         return False
+
+    def is_post_detail_visible(self):
+        """判断岗位详情弹窗是否仍覆盖在岗位管理页上。"""
+        return (
+                self.appear(ISLAND_POST_CHECK, offset=1)
+                or self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
+                or self.appear(ISLAND_POST_SELECT, offset=1)
+                or self.appear(ISLAND_WORKING, offset=1)
+                or self.appear(POST_ADD)
+                or self.appear(POST_GET, offset=(50, 0))
+        )
+
     def post_get_and_close(self):
         for _ in self.loop(timeout=20, skip_first=False):
-            if self.ui_page_appear(page_island_postmanage) and not self.appear(ISLAND_POST_CHECK) and not self.appear(ISLAND_POST_VACANT_CHECK):
+            if self.ui_page_appear(page_island_postmanage) and not self.is_post_detail_visible():
                 return True
             if self.appear(ERROR1, offset=30):
                 self.device.click(POST_CLOSE)
@@ -444,7 +456,7 @@ class Island(SelectCharacter):
                 self.device.click(ISLAND_POST_SAFE_AREA)
                 self.device.sleep(0.5)
                 continue
-            if (self.appear(ISLAND_POST_CHECK) or self.appear(ISLAND_POST_VACANT_CHECK)) and not self.appear(POST_GET, offset=(50, 0)):
+            if self.is_post_detail_visible() and not self.appear(POST_GET, offset=(50, 0)):
                 self.device.click(POST_CLOSE)
                 continue
         logger.warning("收取并关闭岗位详情超时")
@@ -468,7 +480,7 @@ class Island(SelectCharacter):
                 self.device.click(ISLAND_POST_SAFE_AREA)
                 self.device.sleep(0.5)
                 continue
-            if (self.appear(ISLAND_POST_CHECK) or self.appear(ISLAND_POST_VACANT_CHECK) or self.ui_page_appear(page_island_postmanage)):
+            if (self.is_post_detail_visible() or self.ui_page_appear(page_island_postmanage)):
                 return True
         logger.warning("收取当前岗位产物超时")
         return False
@@ -524,8 +536,7 @@ class Island(SelectCharacter):
                 return True
             if (
                     self.ui_page_appear(page_island_postmanage)
-                    and not self.appear(ISLAND_POST_CHECK, offset=30)
-                    and not self.appear(ISLAND_POST_VACANT_CHECK, offset=30)
+                    and not self.is_post_detail_visible()
             ):
                 return True
         logger.warning("收取并追加岗位派遣超时")
@@ -539,8 +550,7 @@ class Island(SelectCharacter):
                     self.ui_page_appear(page_island_postmanage)
                     and not self.appear(ISLAND_SELECT_PRODUCT_CHECK, offset=1)
                     and not self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1)
-                    and not self.appear(ISLAND_POST_CHECK, offset=1)
-                    and not self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
+                    and not self.is_post_detail_visible()
             ):
                 return True
             if self.appear(ISLAND_GET, offset=30):
@@ -552,7 +562,7 @@ class Island(SelectCharacter):
             if self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1):
                 self.device.click(SELECT_UI_BACK)
                 continue
-            if self.appear(ISLAND_POST_CHECK, offset=1) or self.appear(ISLAND_POST_VACANT_CHECK, offset=1):
+            if self.is_post_detail_visible():
                 self.device.click(POST_CLOSE)
                 continue
 
@@ -561,15 +571,55 @@ class Island(SelectCharacter):
 
     def confirm_post_add_order(self, context="岗位派遣"):
         """材料确认足够后，点击最大数量并确认派遣。"""
-        if self.appear(POST_MAX):
-            self.device.click(POST_MAX)
-            self.device.sleep(0.3)
-            self.device.screenshot()
+        clicked = False
+        max_clicked = False
+        button_seen = False
+        left_product_timer = Timer(0.8, count=2).start()
+        retry_confirm_timer = Timer(2, count=4).start()
+        unavailable_timer = Timer(3, count=6).start()
 
-        if self.appear(POST_ADD_ORDER):
-            self.device.click(POST_ADD_ORDER)
-            self.device.sleep(0.5)
-            return True
+        for _ in self.loop(timeout=10, skip_first=False):
+            if self.appear(ERROR1, offset=30):
+                self.device.click(POST_CLOSE)
+                self.island_error = True
+                return False
+
+            in_select_product = self.appear(ISLAND_SELECT_PRODUCT_CHECK, offset=1)
+            if not in_select_product:
+                if left_product_timer.reached():
+                    return True
+                continue
+            left_product_timer.reset()
+
+            if not clicked and not max_clicked and self.appear(POST_MAX):
+                self.device.click(POST_MAX)
+                max_clicked = True
+                unavailable_timer.reset()
+                self.device.sleep(0.3)
+                continue
+
+            if self.appear(POST_ADD_ORDER):
+                button_seen = True
+                unavailable_timer.reset()
+                if not clicked or retry_confirm_timer.reached():
+                    if clicked:
+                        logger.info(f"{context}确认后仍停留在产品选择页，重试确认")
+                    self.device.click(POST_ADD_ORDER)
+                    clicked = True
+                    retry_confirm_timer.reset()
+                continue
+
+            if not clicked and unavailable_timer.reached():
+                current, required = self.ocr_select_product_material_counter()
+                if required and current < required:
+                    logger.warning(f"{context}材料不足，确认按钮不可用: {current}/{required}")
+                else:
+                    logger.warning(f"{context}材料已确认足够，但确认按钮不可用，可能角色体力不足")
+                return False
+
+        if clicked or button_seen:
+            logger.warning(f"{context}确认后仍停留在产品选择页")
+            return False
 
         current, required = self.ocr_select_product_material_counter()
         if required and current < required:

--- a/module/island/island_daily_interact.py
+++ b/module/island/island_daily_interact.py
@@ -315,17 +315,16 @@ class IslandDailyInteract(Island):
         """岛屿对话左上角菜单易受场景光照染色，使用亮度匹配复用 STORY_SKIP_3。"""
         self.device.stuck_record_add(STORY_SKIP_3)
         if interval:
-            if STORY_SKIP_3.name in self.interval_timer:
-                if self.interval_timer[STORY_SKIP_3.name].limit != interval:
-                    self.interval_timer[STORY_SKIP_3.name] = Timer(interval)
-            else:
+            timer = self.interval_timer.get(STORY_SKIP_3.name)
+            if timer is None or timer.limit != interval:
                 self.interval_timer[STORY_SKIP_3.name] = Timer(interval)
-            if not self.interval_timer[STORY_SKIP_3.name].reached():
+                timer = self.interval_timer[STORY_SKIP_3.name]
+            if not timer.reached():
                 return False
 
         appear = STORY_SKIP_3.match_luma(self.device.image, offset=(20, 20), similarity=0.85)
         if appear and interval:
-            self.interval_timer[STORY_SKIP_3.name].reset()
+            timer.reset()
         return appear
 
     def _juu_express_steps(self):

--- a/module/island/island_daily_interact.py
+++ b/module/island/island_daily_interact.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from module.base.timer import Timer
 from module.island.island import Island
 from module.island.assets import *
 from module.base.utils import crop
@@ -288,7 +289,7 @@ class IslandDailyInteract(Island):
         """
         handled = False
         for _ in self.loop(timeout=20, skip_first=False):
-            if self.appear(STORY_SKIP_3, offset=(20, 20), interval=2):
+            if self._appear_story_skip_luma(interval=2):
                 self.device.click(AIR_DROP_SKIP)
                 handled = True
                 continue
@@ -309,6 +310,23 @@ class IslandDailyInteract(Island):
 
         logger.warning('剧情跳过等待超时')
         return handled
+
+    def _appear_story_skip_luma(self, interval=0):
+        """岛屿对话左上角菜单易受场景光照染色，使用亮度匹配复用 STORY_SKIP_3。"""
+        self.device.stuck_record_add(STORY_SKIP_3)
+        if interval:
+            if STORY_SKIP_3.name in self.interval_timer:
+                if self.interval_timer[STORY_SKIP_3.name].limit != interval:
+                    self.interval_timer[STORY_SKIP_3.name] = Timer(interval)
+            else:
+                self.interval_timer[STORY_SKIP_3.name] = Timer(interval)
+            if not self.interval_timer[STORY_SKIP_3.name].reached():
+                return False
+
+        appear = STORY_SKIP_3.match_luma(self.device.image, offset=(20, 20), similarity=0.85)
+        if appear and interval:
+            self.interval_timer[STORY_SKIP_3.name].reset()
+        return appear
 
     def _juu_express_steps(self):
         from module.island_daily_interact.assets import (

--- a/module/island/island_pearl_sell.py
+++ b/module/island/island_pearl_sell.py
@@ -28,6 +28,7 @@ class IslandPearlSell(Island):
     PRICE_RETRY = 3
     TRADE_COUNT_RETRY = 4
     TRADE_COUNT_MAX_CLICKS = 40
+    SELL_UNTIL_ZERO_MAX_ROUNDS = 5
     BUY_MAX_ATTEMPTS = 2
     RANK_FIXED_SWIPE_COUNT = 10
     RANK_FIXED_SWIPE_DISTANCE = 450
@@ -259,7 +260,7 @@ class IslandPearlSell(Island):
         else:
             logger.info(f"本岛价格满足售卖要求: {sell_price}")
 
-        if not self.trade_pearl(action="sell", count=current_pearl):
+        if not self.sell_all_current_pearls(current_pearl):
             if in_friend_island:
                 self.back_to_pearl_shop_or_map()
                 self.exit_friend_island()
@@ -640,6 +641,24 @@ class IslandPearlSell(Island):
             return ""
 
     # ==================== 交易数量与确认 ====================
+
+    def sell_all_current_pearls(self, current_pearl):
+        """售卖后复检珍珠数量，直到识别为 0 或达到最大轮次。"""
+        for round_index in range(1, self.SELL_UNTIL_ZERO_MAX_ROUNDS + 1):
+            logger.info(f"珍珠售卖轮次 {round_index}: {current_pearl}")
+            if current_pearl <= 0:
+                return True
+            if not self.trade_pearl(action="sell", count=current_pearl):
+                return False
+
+            current_pearl = self.ocr_current_pearl_count()
+            if current_pearl <= 0:
+                return True
+            if round_index < self.SELL_UNTIL_ZERO_MAX_ROUNDS:
+                logger.warning(f"珍珠售卖后剩余数量为 {current_pearl}，继续售卖")
+
+        logger.warning("珍珠售卖复检超过最大轮次，停止售卖")
+        return False
 
     def trade_pearl(self, action, count):
         """执行购买或售卖。"""

--- a/module/island/island_rancher.py
+++ b/module/island/island_rancher.py
@@ -291,7 +291,7 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
                 add_opened = True
                 continue
             in_vacant_post = self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
-            if self.appear(ISLAND_POST_SELECT, offset=1) and self.appear_then_click(ISLAND_POST_SELECT, offset=1):
+            if self.appear_then_click(ISLAND_POST_SELECT, offset=1):
                 add_opened = True
                 logger.info(f"牧场岗位{post_id}进入派遣选择")
                 self.device.sleep(0.5)
@@ -341,11 +341,8 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
                 add_opened = True
                 continue
             in_vacant_post = self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
-            if (
-                    self.appear(ISLAND_POST_SELECT, offset=1)
-                    and (add_opened or in_vacant_post or not self.appear(ISLAND_WORKING))
-                    and self.appear_then_click(ISLAND_POST_SELECT, offset=1)
-            ):
+            can_select_post = add_opened or in_vacant_post or not self.appear(ISLAND_WORKING)
+            if can_select_post and self.appear_then_click(ISLAND_POST_SELECT, offset=1):
                 if in_vacant_post and not add_opened:
                     logger.info(f"牧场岗位{post_id}为空闲岗位，直接进入派遣")
                 elif not add_opened:

--- a/module/island/island_rancher.py
+++ b/module/island/island_rancher.py
@@ -76,6 +76,11 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
         }
         self.ranch_last_finish_time = None
 
+    def raise_if_island_error(self):
+        if self.island_error:
+            from module.exception import GameBugError
+            raise GameBugError("检测到岛屿ERROR1，需要重启")
+
     def process_mill_item(self, mill_item, quantity=None):
         mill_config = self.name_to_config[mill_item]
         mill_button = mill_config['mill']
@@ -215,8 +220,7 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
                     self.ui_page_appear(page_island_postmanage)
                     and not self.appear(ISLAND_SELECT_PRODUCT_CHECK, offset=1)
                     and not self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1)
-                    and not self.appear(ISLAND_POST_CHECK, offset=1)
-                    and not self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
+                    and not self.is_post_detail_visible()
             ):
                 return True
             if self.appear(ISLAND_SHOP_GET):
@@ -287,7 +291,9 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
                 add_opened = True
                 continue
             in_vacant_post = self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
-            if (add_opened or in_vacant_post) and self.appear_then_click(ISLAND_POST_SELECT, offset=1):
+            if self.appear(ISLAND_POST_SELECT, offset=1) and self.appear_then_click(ISLAND_POST_SELECT, offset=1):
+                add_opened = True
+                logger.info(f"牧场岗位{post_id}进入派遣选择")
                 self.device.sleep(0.5)
                 continue
             if (
@@ -335,9 +341,16 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
                 add_opened = True
                 continue
             in_vacant_post = self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
-            if (add_opened or in_vacant_post) and self.appear_then_click(ISLAND_POST_SELECT, offset=1):
+            if (
+                    self.appear(ISLAND_POST_SELECT, offset=1)
+                    and (add_opened or in_vacant_post or not self.appear(ISLAND_WORKING))
+                    and self.appear_then_click(ISLAND_POST_SELECT, offset=1)
+            ):
                 if in_vacant_post and not add_opened:
                     logger.info(f"牧场岗位{post_id}为空闲岗位，直接进入派遣")
+                elif not add_opened:
+                    logger.info(f"牧场岗位{post_id}通过再次委派进入派遣")
+                add_opened = True
                 self.device.sleep(0.5)
                 continue
             if self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1):
@@ -383,8 +396,7 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
                 return True
             if (
                     self.appear(ISLAND_POSTMANAGE_CHECK, offset=1)
-                    and not self.appear(ISLAND_POST_CHECK)
-                    and not self.appear(ISLAND_POST_VACANT_CHECK, offset=1)
+                    and not self.is_post_detail_visible()
             ):
                 return True
         logger.warning(f"牧场岗位{post_id}收取并追加派遣超时")
@@ -550,6 +562,7 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
 
         logger.info("\n[3/5] 检查并补充牧场饲料和面粉...")
         processed_mill_items = self.process_mill_supplements(feed_target_quantity=50)
+        self.raise_if_island_error()
         if processed_mill_items:
             logger.info(f"本次运行补充了 {len(processed_mill_items)} 个磨坊项目: {processed_mill_items}")
         else:
@@ -580,7 +593,9 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
                         break
 
                 if time_var_name:
-                    if not self.ranch_post(post_id, time_var_name):
+                    success = self.ranch_post(post_id, time_var_name)
+                    self.raise_if_island_error()
+                    if not success:
                         logger.warning(f"牧场岗位 {post_id} 执行失败，跳过")
                 else:
                     logger.warning(f"未找到岗位 {post_id} 对应的时间变量名")
@@ -603,9 +618,7 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
             logger.error(f"渔场任务执行失败: {e}")
             raise
 
-        if self.island_error:
-            from module.exception import GameBugError
-            raise GameBugError("检测到岛屿ERROR1，需要重启")
+        self.raise_if_island_error()
 
 if __name__ == "__main__":
     az = IslandRancher('alas', task='Alas')


### PR DESCRIPTION
## Summary

Close #386

本 PR 包含 3 个岛屿相关修复：

- 修复牧场“再次委派”状态在部分设备上被误判，导致岗位派遣失败或不记录计时器
- 修复珍珠售卖后仍有剩余数量时未继续售卖的问题
- 优化岛屿对话跳过识别，降低场景光照染色导致无法识别跳过按钮的概率

## Changes

### 牧场再次委派

- 统一岗位详情弹窗识别，避免详情弹窗覆盖在岗位管理页上时被误判为已返回
- 支持牧场黄色“再次委派”状态，通过 `ISLAND_POST_SELECT` 进入派遣流程
- 派遣确认后等待产品选择页真正离开，避免不同设备截图/渲染时序导致提前判定失败
- 牧场阶段检测到岛屿 `ERROR1` 后立即抛出 `GameBugError`，避免继续执行后续流程扩大状态污染

### 珍珠售卖

- 售卖后复检当前珍珠数量，仍大于 0 时继续售卖
- 增加最大复卖轮次，避免 OCR 异常导致无限循环
- 保留原有交易失败后的延时处理路径

### 岛屿对话跳过

- 使用亮度通道匹配复用 `STORY_SKIP_3`
- 避免岛屿场景光照染色导致剧情对话跳过识别失败
- 保留原有 2 秒 `interval` 防连点逻辑，仍点击现有 `AIR_DROP_SKIP` 跳过按钮

## Cause

牧场问题的主要原因是旧逻辑依赖 `POST_ADD`、`ISLAND_POST_CHECK` 和 `ISLAND_POST_VACANT_CHECK` 判断岗位状态，但“再次委派”页面没有蓝色 `POST_ADD`，且岗位详情会覆盖在岗位管理页上，导致部分设备因截图时序和渲染差异提前误判。

珍珠售卖问题是售卖后没有对剩余数量做完整复检，部分情况下会出现仍有珍珠但流程已结束。

岛屿对话跳过问题是按钮识别受岛屿场景光照染色影响，原有颜色匹配在部分画面下不稳定。

## Summary by Sourcery

修复了围绕牧场岗位委派、珍珠出售和岛屿剧情跳过等多处自动化相关问题。

Bug 修复：
- 改进牧场岗位详情检测逻辑，以正确处理空岗、工作中和重新委派等状态，避免在不同设备上错误判断岗位关闭或完成。
- 通过等待商品选择页面实际退出来稳定牧场派遣确认流程，并在出现岛屿错误 `ERROR1` 时干净中止。
- 确保珍珠出售过程能反复检查剩余数量，并持续出售直到为 0 或达到配置的安全上限，防止过早终止或陷入无限循环。
- 通过对跳过按钮使用基于亮度的匹配方式，使岛屿剧情跳过检测在光照与色彩变化下更可靠，同时保留原有的防连点机制。

增强项：
- 将牧场岛屿 `ERROR1` 错误处理集中封装为可复用的辅助方法，在牧场关键流程阶段统一抛出游戏 Bug 错误。
- 将岗位详情可见性检查统一到共享辅助方法中，以简化并强化岗位管理流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix multiple island automation issues around ranch post delegation, pearl selling, and island dialogue skipping.

Bug Fixes:
- Improve ranch post detail detection to handle both vacant, working, and re-delegation states and avoid misjudging post closure or completion on different devices.
- Stabilize ranch dispatch confirmation by waiting for the product selection page to actually exit and aborting cleanly when island ERROR1 occurs.
- Ensure pearl selling repeatedly rechecks the remaining quantity and continues selling until zero or a configured safety limit is reached, preventing premature termination or infinite loops.
- Make island story skip detection more robust against lighting and color shifts by using brightness-based matching for the skip button while preserving anti-double-click behavior.

Enhancements:
- Centralize ranch island ERROR1 handling into a reusable helper that raises a game bug error at key ranch workflow stages.
- Unify post detail visibility checks into a shared helper to simplify and harden post management flows.

</details>