### PR TITLE
fix: 将opencv-python-headless替换为opencv-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "numpy==2.4.3",
     "scipy==1.17.1",
     "pillow==12.2.0",
-    "opencv-python-headless==4.13.0.92",
+    "opencv-python==4.13.0.92",
     "imageio==2.26.0",
     "imageio-ffmpeg==0.6.0",
     "adbutils==0.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ dependencies = [
     { name = "onnxruntime", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'linux'" },
     { name = "onnxruntime-directml", marker = "sys_platform == 'win32'" },
     { name = "openai" },
-    { name = "opencv-python-headless" },
+    { name = "opencv-python" },
     { name = "pillow" },
     { name = "pip" },
     { name = "psutil" },
@@ -163,7 +163,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "sys_platform == 'linux'", specifier = "==1.26.0" },
     { name = "onnxruntime-directml", marker = "sys_platform == 'win32'", specifier = "==1.24.4" },
     { name = "openai", specifier = "==2.30.0" },
-    { name = "opencv-python-headless", specifier = "==4.13.0.92" },
+    { name = "opencv-python", specifier = "==4.13.0.92" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "pip", specifier = "==26.0.1" },
     { name = "psutil", specifier = "==5.9.4" },
@@ -1168,24 +1168,6 @@ wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5" },
     { url = "https://mirrors.aliyun.com/pypi/packages/fb/17/de5458312bcb07ddf434d7bfcb24bb52c59635ad58c6e7c751b48949b009/opencv_python-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:372fe164a3148ac1ca51e5f3ad0541a4a276452273f503441d718fab9c5e5f59" },
     { url = "https://mirrors.aliyun.com/pypi/packages/e9/a5/1be1516390333ff9be3a9cb648c9f33df79d5096e5884b5df71a588af463/opencv_python-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:423d934c9fafb91aad38edf26efb46da91ffbc05f3f59c4b0c72e699720706f5" },
-]
-
-[[package]]
-name = "opencv-python-headless"
-version = "4.13.0.92"
-source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
-dependencies = [
-    { name = "numpy" },
-]
-wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/2d/1e/6f9e38005a6f7f22af785df42a43139d0e20f169eb5787ce8be37ee7fcc9/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/21/76/9417a6aef9def70e467a5bf560579f816148a4c658b7d525581b356eda9e/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/8f/b4/b7bcbf7c874665825a8c8e1097e93ea25d1f1d210a3e20d4451d01da30aa/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/fb/c3/52cfea47cd33e53e8c0fbd6e7c800b457245c1fda7d61660b4ffe9596a7f/opencv_python_headless-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:a7cf08e5b191f4ebb530791acc0825a7986e0d0dee2a3c491184bd8599848a4b" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/4a/90/b338326131ccb2aaa3c2c85d00f41822c0050139a4bfe723cfd95455bd2d/opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:77a82fe35ddcec0f62c15f2ba8a12ecc2ed4207c17b0902c7a3151ae29f37fb6" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

将 OpenCV 无界面依赖替换为标准的 OpenCV 软件包。

Bug 修复：
- 将依赖从 `opencv-python-headless` 切换为 `opencv-python`，以解决与无界面构建相关的环境或运行时问题。

构建：
- 在 `pyproject.toml` 和锁定文件中更新项目依赖，将 `opencv-python-headless` 替换为 `opencv-python`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace OpenCV headless dependency with the standard OpenCV package.

Bug Fixes:
- Switch dependency from opencv-python-headless to opencv-python to resolve environment or runtime issues related to headless builds.

Build:
- Update project dependencies to use opencv-python instead of opencv-python-headless in pyproject.toml and lockfile.

</details>