### PR TITLE
feat(commission)：新增委托钻石奖励通知（通知内容仅适配中文）

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -1846,7 +1846,9 @@
       "PresetFilter": "cube",
       "AddShortest": true,
       "CustomFilter": "DailyEvent > Gem-4 > Gem-2 > Gem-8 > ExtraCube-0:30\n> UrgentCube-1:30 > UrgentCube-1:45 > UrgentCube-3\n> ExtraDrill-5:20 > ExtraDrill-2 > ExtraDrill-3:20\n> UrgentCube-2:15 > UrgentCube-4\n> ExtraDrill-1 > UrgentCube-6 > ExtraCube-1:30\n> ExtraDrill-2:40 > ExtraDrill-0:20\n> expire\n> Major > DailyChip > DailyResource\n> ExtraPart-0:30 > ExtraOil-1 > UrgentBox-6\n> ExtraCube-3 > ExtraPart-1 > UrgentBox-3\n> ExtraCube-4 > ExtraPart-1:30 > ExtraOil-4\n> UrgentBox-1 > ExtraCube-5 > UrgentBox-1\n> ExtraCube-8 > ExtraOil-8\n> UrgentDrill-4 > UrgentDrill-2:40 > UrgentDrill-2\n> UrgentDrill-1 > UrgentDrill-1:30 > UrgentDrill-1:10\n> Extra-0:20 > Extra-0:30 > Extra-1:00 > Extra-1:30 > Extra-2:00\n> shortest",
-      "DoMajorCommission": false
+      "DoMajorCommission": false,
+      "CommissionNotifyReward": false,
+      "CommissionNotifyRewardStatistics": true
     },
     "Storage": {
       "Storage": {}

--- a/module/commission/commission.py
+++ b/module/commission/commission.py
@@ -613,6 +613,60 @@ class RewardCommission(UI, InfoHandler):
                 cl1_db.add_commission_income(instance, merged_items, commission_count=1)
                 item_str = ', '.join([f'{k}x{v}' for k, v in merged_items.items()])
                 logger.info(f'Commission income recorded: {item_str} (instance={instance})')
+                if self.config.CommissionNotifyReward:
+                    reward_stats = None
+                    if self.config.CommissionNotifyRewardStatistics:
+                        reward_stats = cl1_db.get_commission_reward_stats(instance)
+                    gem_count = merged_items.get("Gem", 0)
+                    """cube_count = merged_items.get("Cube", 0)"""
+                    tracked = []
+                    if gem_count > 0:
+                        text = f'💎钻石 * {gem_count}'
+
+                        if reward_stats is not None:
+                            text += (
+                                f'\n\n今日累计获取💎钻石 * {reward_stats["today"].get("Gem", 0)}'
+                                f'\n本周累计获取💎钻石 * {reward_stats["week"].get("Gem", 0)}'
+                                f'\n本月累计获取💎钻石 * {reward_stats["month"].get("Gem", 0)}'
+                            )
+
+                        tracked.append(text)
+                    """
+                    if cube_count > 0:
+                        text = f'🧊魔方 * {cube_count}'
+                        if reward_stats is not None:
+                            text += (
+                            f'\n\n今日累计获取🧊魔方 * {reward_stats["today"].get("Cube", 0)}'
+                            f'\n本周累计获取🧊魔方 * {reward_stats["week"].get("Cube", 0)}'
+                            f'\n本月累计获取🧊魔方 * {reward_stats["month"].get("Cube", 0)}'
+                        )
+                        tracked.append(text)
+                    """
+                    if tracked:
+                        msg = '\n'.join(tracked) 
+                        if gem_count >= 50:
+                            title = f"AzurPilot <{instance}> 大成功！！！委托获得顶级奖励喵！"
+                            webui_title = "大成功！！！委托获得顶级奖励喵！"
+                        elif gem_count > 0:
+                            title = f"AzurPilot <{instance}> 委托获得顶级奖励喵！"
+                            webui_title = "委托获得顶级奖励喵！"
+                        """
+                        # 以后恢复 Cube 时
+                        elif cube_count > 0:
+                            title = f"AzurPilot <{instance}> 委托获得高级奖励喵！"
+                            webui_title = "委托获得高级奖励喵！"
+                        """
+                        handle_notify(
+                            self.config.Error_OnePushConfig,
+                            title=title,
+                            content=msg,
+                        )
+
+                        notify_webui(
+                            instance,
+                            title=webui_title,
+                            content=msg,
+                        )
             else:
                 logger.info('Commission income: no known items recognized from all screenshots')
 

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -9988,6 +9988,14 @@
       "DoMajorCommission": {
         "type": "checkbox",
         "value": false
+      },
+      "CommissionNotifyReward": {
+        "type": "checkbox",
+        "value": false
+      },
+      "CommissionNotifyRewardStatistics": {
+        "type": "checkbox",
+        "value": true
       }
     },
     "Storage": {

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -598,6 +598,12 @@ Commission:
     > Extra-0:20 > Extra-0:30 > Extra-1:00 > Extra-1:30 > Extra-2:00
     > shortest
   DoMajorCommission: false
+  CommissionNotifyReward:
+    type: checkbox
+    value: false
+  CommissionNotifyRewardStatistics:
+    type: checkbox
+    value: true
 Tactical:
   TacticalFilter: |-
     SameT4 > SameT3 > SameT2 > SameT1

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -332,7 +332,9 @@ class GeneratedConfig:
     Commission_AddShortest = True
     Commission_CustomFilter = 'DailyEvent > Gem-4 > Gem-2 > Gem-8 > ExtraCube-0:30\n> UrgentCube-1:30 > UrgentCube-1:45 > UrgentCube-3\n> ExtraDrill-5:20 > ExtraDrill-2 > ExtraDrill-3:20\n> UrgentCube-2:15 > UrgentCube-4\n> ExtraDrill-1 > UrgentCube-6 > ExtraCube-1:30\n> ExtraDrill-2:40 > ExtraDrill-0:20\n> expire\n> Major > DailyChip > DailyResource\n> ExtraPart-0:30 > ExtraOil-1 > UrgentBox-6\n> ExtraCube-3 > ExtraPart-1 > UrgentBox-3\n> ExtraCube-4 > ExtraPart-1:30 > ExtraOil-4\n> UrgentBox-1 > ExtraCube-5 > UrgentBox-1\n> ExtraCube-8 > ExtraOil-8\n> UrgentDrill-4 > UrgentDrill-2:40 > UrgentDrill-2\n> UrgentDrill-1 > UrgentDrill-1:30 > UrgentDrill-1:10\n> Extra-0:20 > Extra-0:30 > Extra-1:00 > Extra-1:30 > Extra-2:00\n> shortest'
     Commission_DoMajorCommission = False
-
+    Commission_CommissionNotifyReward = False
+    Commission_CommissionNotifyRewardStatistics = True
+    
     # 配置组 `Tactical`
     Tactical_TacticalFilter = 'SameT4 > SameT3 > SameT2 > SameT1\n> BlueT2 > YellowT2 > RedT2\n> BlueT3 > YellowT3 > RedT3\n> BlueT4 > YellowT4 > RedT4\n> BlueT1 > YellowT1 > RedT1\n> first'
     Tactical_RapidTrainingSlot = 'do_not_use'  # do_not_use, slot_1, slot_2, slot_3, slot_4

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -1842,6 +1842,14 @@
     "DoMajorCommission": {
       "name": "Make the main commission (1200 oil/1000 oil commission)",
       "help": "The 1200 oil commission is now obsolete and the yield is very low. It is recommended to close it."
+    },
+    "CommissionNotifyReward": {
+      "name": "Successful Commission GEM Notification",
+      "help": "After enabling, AzurPilot will send a notification when a commission successfully acquires diamonds."
+    },
+    "CommissionNotifyRewardStatistics": {
+      "name": "GEM Notification Details",
+      "help": "After enabling, AzurPilot will notify the number of diamonds obtained from the current commission, as well as the total diamonds obtained for the day/week/month."
     }
   },
   "Tactical": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -1842,6 +1842,14 @@
     "DoMajorCommission": {
       "name": "主要委託を実行する（1200燃料/1000燃料委託）",
       "help": "1200燃料委託は現在では廃止されており、収益が非常に低いです。オフにすることをお勧めします。"
+    },
+    "CommissionNotifyReward": {
+      "name": "委託成功でダイヤモンド取得通知",
+      "help": "オンにすると、AzurPilotは委託でダイヤモンドを取得した際に通知を送信します"
+    },
+    "CommissionNotifyRewardStatistics": {
+      "name": "ダイヤモンド通知の詳細",
+      "help": "オンにすると、AzurPilotは今回の委託で取得したダイヤモンドの数量と同時に、当日／今週／今月のダイヤモンド取得数量も通知します"
     }
   },
   "Tactical": {

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -1842,6 +1842,14 @@
     "DoMajorCommission": {
       "name": "做主要委托（1200油/1000油委托）",
       "help": "1200油委托现在已经过时，收益很低，建议关闭"
+    },
+    "CommissionNotifyReward": {
+      "name": "委托成功获取钻石推送",
+      "help": "开启后，AzurPilot会在委托成功获取红尖尖时推送通知"
+    },
+    "CommissionNotifyRewardStatistics": {
+      "name": "钻石推送详情",
+      "help": "开启后，AzurPilot在推送本次委托获取钻石数量的同时推送当日/本周/本月的钻石获取数量"
     }
   },
   "Tactical": {

--- a/module/config/i18n/zh-MIAO.json
+++ b/module/config/i18n/zh-MIAO.json
@@ -1842,6 +1842,14 @@
     "DoMajorCommission": {
       "name": "做主要委托 (1200油/1000油)",
       "help": "1200油委现已过时收益低，建议关闭喵。 (´・ω・`)"
+    },
+    "CommissionNotifyReward": {
+      "name": "委托成功获取钻石推送喵",
+      "help": "开启后，AzurPilot会在委托成功获取钻石时推送通知喵"
+    },
+    "CommissionNotifyRewardStatistics": {
+      "name": "钻石推送详情喵",
+      "help": "开启后，AzurPilot在推送本次委托获取钻石数量的同时推送当日/本周/本月的钻石获取数量喵"
     }
   },
   "Tactical": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -1842,6 +1842,14 @@
     "DoMajorCommission": {
       "name": "做主要委託（1200油/1000油委託）",
       "help": "1200油委託現在已經過時，收益很低，建議關閉"
+    },
+    "CommissionNotifyReward": {
+      "name": "委託成功獲取鑽石推送",
+      "help": "開啟後，AzurPilot會在委託成功獲取鑽石時推送通知"
+    },
+    "CommissionNotifyRewardStatistics": {
+      "name": "鑽石推送詳情",
+      "help": "開啟後，AzurPilot在推送本次委託獲取鑽石數量的同時推送當日/本週/本月的鑽石獲取數量"
     }
   },
   "Tactical": {

--- a/module/statistics/cl1_database.py
+++ b/module/statistics/cl1_database.py
@@ -9,7 +9,7 @@ from typing import Dict, Any, List, Optional, Tuple
 from Crypto.Cipher import AES
 from Crypto.Protocol.KDF import PBKDF2
 from Crypto.Hash import SHA256
-
+from collections import defaultdict
 from module.base.device_id import get_device_id, get_old_device_id
 from module.logger import logger
 
@@ -1389,6 +1389,82 @@ class Cl1Database:
             entries = entries[-5000:]
         data["commission_income_entries"] = entries
         self.save_stats(instance, month, data)
+
+    def get_commission_reward_stats(self, instance: str):
+        """
+        获取委托奖励统计
+
+        Returns:
+            {
+                "today": {...},
+                "week": {...},
+                "month": {...},
+            }
+        """
+        now = datetime.now()
+        today = now.date()
+        week_start = today - timedelta(days=today.weekday())
+
+        entries = []
+
+        entries.extend(
+            self.get_commission_income(
+                instance,
+                year=now.year,
+                month=now.month,
+            )
+        )
+
+        # 周跨月
+        if week_start.month != now.month or week_start.year != now.year:
+            prev_month_date = now.replace(day=1) - timedelta(days=1)
+            entries.extend(
+                self.get_commission_income(
+                    instance,
+                    year=prev_month_date.year,
+                    month=prev_month_date.month,
+                )
+            )
+
+        result = {
+            "today": defaultdict(int),
+            "week": defaultdict(int),
+            "month": defaultdict(int),
+        }
+
+        for entry in entries:
+            try:
+                ts = datetime.fromisoformat(entry.get("ts", ""))
+                items = entry.get("items", {})
+
+                if not isinstance(items, dict):
+                    continue
+
+                for item, value in items.items():
+                    value = self._coerce_int(value)
+
+                    if ts.year == now.year and ts.month == now.month:
+                        result["month"][item] += value
+
+                    if ts.date() == today:
+                        result["today"][item] += value
+
+                    if week_start <= ts.date() <= today:
+                        result["week"][item] += value
+
+            except Exception:
+                continue
+
+        # 保留常用字段，兼容旧代码
+        for period in ("today", "week", "month"):
+            result[period].setdefault("Gem", 0)
+            result[period].setdefault("Cube", 0)
+
+        return {
+            "today": dict(result["today"]),
+            "week": dict(result["week"]),
+            "month": dict(result["month"]),
+        }
 
     def get_commission_income(
         self, instance: str, year: int = None, month: int = None


### PR DESCRIPTION
## 一、变更背景

原有系统仅记录委托收益数据，但缺少：

* 委托奖励的即时通知能力
* 对委托奖励通知的周期性统计展示（今日 / 本周 / 本月）
* 对“高价值奖励（大成功）”的区分提示

本次改动在**不改变原有数据结构的前提下**，基于已有流水实现统计与通知能力扩展。

---

## 二、功能设计

### 1. 配置开关设计（新增）

新增两个独立开关：

#### ① CommissionNotifyReward

* 控制是否发送委托奖励通知
* 默认：关闭
* 关闭时完全跳过通知逻辑（不计算、不拼接、不发送）

#### ② CommissionNotifyRewardStatistics

* 控制是否附带统计信息（今日 / 本周 / 本月）
* 默认：开启
* 生效条件：`CommissionNotifyReward=True` 

---

## 三、核心实现变更

### 1. 委托收益统计（基于流水）

新增 `get_commission_reward_stats()`：

* 流水计算 `commission_income_entries` 
* 支持动态统计任意奖励字段（Gem / Cube / 未来扩展项）
* 不再依赖固定字段结构
* 统计范围：

  * 今日
  * 本周（跨月自动补齐）
  * 本月

---

### 2. 通知逻辑重构

委托结算流程调整为：

1. 写入收益流水
2. 判断是否启用通知（CommissionNotifyReward）
3. 可选计算统计（CommissionNotifyRewardStatistics）
4. 生成通知内容
5. 发送 OnePush + WebUI

---

### 3. 奖励分级提示优化

根据本次 Gem 数量区分：

* ≥ 50：大成功奖励
* 1~49：普通高价值奖励
* 0：不触发通知

---

## 四、通知内容变更（重要）

### ⚠️ 本次 PR 仅适配中文通知内容

所有通知输出**仅针对中文环境优化**，包括：

* 标题文案（喵系提示）
* 统计字段（今日 / 本周 / 本月）
* 奖励描述（钻石）

暂不处理：

* 通知内容的英文 / 日文 / 韩文 i18n 自动适配
* 多语言动态模板系统

> 后续如需适配通知内容，将迁移至 i18n 模板层，而不是业务逻辑层。

---

## 五、示例通知

### ① 普通奖励

```
💎钻石 * 30
```

---

### ② 带统计信息

```
💎钻石 * 30

今日累计获取💎钻石 * 180
本周累计获取💎钻石 * 920
本月累计获取💎钻石 * 3510
```

---

### ③ 大成功奖励

```
AzurPilot <instance> 大成功！！！委托获得顶级奖励喵！
```

---

## 六、工程影响

### 1. 无破坏性改动

* 不修改原有数据结构
* 不改变 commission_income_entries 存储格式
* 向后兼容旧统计逻辑

### 2. 自动生成文件更新

已更新：

* `argument.yaml`
* `args.json`
* `config_generated.py`
* `template.json`
* i18n 多语言文件（自动生成）

---

## 七、总结

本次改动实现了：

* 基于流水的动态奖励统计
* 可配置的通知系统
* 中文通知体验优化
* 大成功奖励识别机制
* 完全向后兼容的结构升级

## Summary by Sourcery

引入可配置的佣金奖励通知，包含中文消息和聚合统计数据，同时保持现有收入数据结构不变。

新功能：
- 新增佣金奖励通知流程，在收入记录完成后触发，为 Gem 奖励发送 OnePush 和 WebUI 消息。
- 可选提供今日/本周/本月的佣金奖励统计数据，从现有收入记录中计算并附加到通知中。
- 区分高额佣金奖励，将大额 Gem 发放视为「大成功」，并使用专门的标题和消息文案。

优化：
- 实现数据库辅助工具，用于按条目聚合今日、本周、本月的佣金奖励总额，包括跨月的周统计，同时不改变已有记录的存储格式。
- 增加配置开关，用于启用佣金奖励通知以及控制是否包含统计摘要，并保持向后兼容的默认配置。

构建：
- 更新生成的配置、参数定义、模板和 i18n 文件，以支持新的佣金通知选项和文本内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable commission reward notifications with Chinese messaging and aggregated statistics while preserving existing income data structures.

New Features:
- Add commission reward notification flow triggered after income recording, sending OnePush and WebUI messages for Gem rewards.
- Provide optional today/week/month commission reward statistics computed from existing income entries and appended to notifications.
- Differentiate high-value commission rewards by treating large Gem payouts as "big success" with dedicated titles and messaging.

Enhancements:
- Implement a database helper to aggregate commission reward totals per item for today, this week, and this month, including cross-month weeks, without changing stored entry formats.
- Add configuration switches to enable commission reward notifications and to toggle inclusion of statistical summaries, with backward-compatible defaults.

Build:
- Update generated configuration, argument definitions, templates, and i18n files to include the new commission notification options and texts.

</details>