### PR TITLE
fix: 修复大世界普通海域中处理明石时的死循环问题

### DIFF
--- a/module/os/map.py
+++ b/module/os/map.py
@@ -1555,9 +1555,22 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
                     self._solved_map_event.add("is_akashi")
                     return True
                 else:
-                    logger.info("无法到达明石位置，执行强制移动")
-                    self._execute_fixed_patrol_scan(ExecuteFixedPatrolScan=True)
-                    return False
+                    grids = self.view.select(is_akashi=True)
+                    if "is_akashi" not in self._solved_map_event and grids and grids[0].is_akashi:
+                        grid = grids[0]
+                        fleet = self.convert_radar_to_local((0, 0))
+                        if fleet.distance_to(grid) <= 1:
+                            logger.info(f"Akashi ({grid}) is near current fleet ({fleet})")
+                            self.handle_akashi_supply_buy(grid)
+                            self._solved_map_event.add("is_akashi")
+                            return True
+                        else:
+                            logger.info("无法到达明石位置，执行强制移动")
+                            self._execute_fixed_patrol_scan(ExecuteFixedPatrolScan=True)
+                            return False
+                    else:
+                        logger.info("No map event")
+                        return False
             else:
                 logger.info(f"Akashi ({grid}) is near current fleet ({fleet})")
                 self.handle_akashi_supply_buy(grid)


### PR DESCRIPTION
## 问题

在大世界中，舰队远离明石商人时点击明石，正常情况下游戏会将舰队移动到明石相邻格，并弹出明石商店进入确认界面。

但在每月开荒任务中的普通海域，当舰队移动到的明石相邻格上存在一个如图所示的塞壬装置/增援装置（我也不知道这个叫什么）时，游戏不会弹出明石商店确认界面（如视频所示）。当前程序将这种情况误判为“无法到达明石位置”，随后执行 `_execute_fixed_patrol_scan` 强制移动逻辑。强制移动完成后全图重扫再次发现明石，于是重复点击、失败、强制移动，形成死循环。 

## 如何复现

1. 运行每月开荒任务。
2. 地图中存在明石商人，且相邻位置中存在塞壬装置/增援装置。
3. 当前舰队距离明石超过 1 格，脚本点击明石。
4. 游戏将舰队移动到塞壬装置/增援装置位置处，明石商店确认界面未弹出。
5. 脚本进入“无法到达明石位置，执行强制移动”分支，强制移动结束后重扫再次发现明石，循环重复。

## 相关 Logs
```text
2026-07-01 16:07:37.097 | INFO | Found Akashi on H4
2026-07-01 16:07:37.099 | WARNING | Convert radar to local, but current fleet not found. Assuming camera center is current fleet: E5
2026-07-01 16:07:37.100 | INFO | Radar (0, 0) -> Local E5 (fleet=E5)
2026-07-01 16:07:37.102 | INFO | Click ( 946,  316) @ H4
2026-07-01 16:07:45.425 | INFO | Walk stabled, result:
2026-07-01 16:07:45.429 | INFO | 无法到达明石位置，执行强制移动
2026-07-01 16:07:45.430 | INFO | <<< 执行强制移动 >>>
```

强制移动后再次发现明石：

```text
2026-07-01 16:08:23.872 | INFO | 所有舰队已定点，执行最终全图重扫（双遍检查）
2026-07-01 16:08:27.893 | INFO | Found Akashi on H4
2026-07-01 16:08:36.243 | INFO | Walk stabled, result:
2026-07-01 16:08:36.246 | INFO | 无法到达明石位置，执行强制移动
```

## 截图
<img width="1216" height="688" alt="redroid13_x86_64_only 2026_7_1 18_46_21" src="https://github.com/user-attachments/assets/911f99dc-0764-47b9-8d73-ed8cb437dc89" />


https://github.com/user-attachments/assets/490556c6-aedf-4823-88be-476c1ca65eb6



## 修复

https://github.com/wess09/AzurPilot/blob/4af388e4987cd261d02c5e0449242a2f8dd9403f/module/os/map.py#L1541-L1565

1557行，当`result`为空，即未弹出进入界面时，重新更新`grids`，并判断舰队此时与明石是否相邻，若相邻则复用1562-1565行的进入商店逻辑，若不相邻才判断为不可达

## Summary by Sourcery

Bug Fixes:
- 通过在商店对话框未出现时重新检查舰队与明石的相邻状态，防止在普通海域与明石互动时出现无限强制移动循环。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent infinite forced-movement loops when interacting with Akashi in normal sea areas by rechecking fleet–Akashi adjacency if the shop dialog does not appear.

</details>