### PR TITLE
Fix：多海域时 短锚的逻辑

### DIFF
--- a/module/os/tasks/cross_month.py
+++ b/module/os/tasks/cross_month.py
@@ -157,14 +157,23 @@ class OpsiCrossMonth(MeowfficerTargetZoneMixin, OSMap):
                 else:
                     zone = traditional_zone
                     logger.hr(f'OS meowfficer farming, zone_id={zone.zone_id}', level=1)
-                self.globe_goto(zone, types='SAFE', refresh=True)
-                self.fleet_set(self.config.OpsiFleet_Fleet)
-                if self.run_strategic_search():
-                    self._solved_map_event = set()
-                    self._solved_fleet_mechanism = False
-                    self.clear_question()
-                    self.map_rescan()
-                self.handle_after_auto_search()
+                if len(target_zones) > 1:
+                    self.globe_goto(zone)
+                    self.fleet_set(self.config.OpsiFleet_Fleet)
+                    self.os_order_execute(
+                        recon_scan=False,
+                        submarine_call=False)
+                    self.run_auto_search()
+                    self.handle_after_auto_search()
+                else:
+                    self.globe_goto(zone, types='SAFE', refresh=True)
+                    self.fleet_set(self.config.OpsiFleet_Fleet)
+                    if self.run_strategic_search():
+                        self._solved_map_event = set()
+                        self._solved_fleet_mechanism = False
+                        self.clear_question()
+                        self.map_rescan()
+                    self.handle_after_auto_search()
             else:
                 zones = self.zone_select(hazard_level=OpsiMeowfficerFarming_HazardLevel) \
                     .delete(SelectedGrids([self.zone])) \

--- a/module/os/tasks/meowfficer_farming.py
+++ b/module/os/tasks/meowfficer_farming.py
@@ -102,7 +102,6 @@ class MeowfficerTargetZoneMixin:
         zone_index = index % len(zones)
         zone = zones[zone_index]
         logger.attr('MeowTargetZoneIndex', f'{zone_index + 1}/{len(zones)}')
-        logger.hr(f'OS meowfficer farming (stay in zone), zone_id={zone.zone_id}', level=1)
         return zone, zone_index + 1
 
 
@@ -277,6 +276,7 @@ class OpsiMeowfficerFarming(MeowfficerTargetZoneMixin, CoinTaskMixin, OSMap):
         self.config.check_task_switch()
 
     def _meow_handle_stay_in_zone(self, zone):
+        logger.hr(f'OS meowfficer farming (stay in zone), zone_id={zone.zone_id}', level=1)
         self.get_current_zone()
         if self.zone.zone_id != zone.zone_id or not self.is_zone_name_hidden:
             self.globe_goto(zone, types='SAFE', refresh=True)
@@ -317,6 +317,24 @@ class OpsiMeowfficerFarming(MeowfficerTargetZoneMixin, CoinTaskMixin, OSMap):
         if self._check_yellow_coins_and_return_to_cl1("循环中", "短猫相接"):
             return True
         return False
+
+    def _meow_handle_target_zone_search(self, zone):
+        """按普通短猫流程清理指定海域。"""
+        logger.hr(f'OS meowfficer farming, zone_id={zone.zone_id}', level=1)
+
+        self.globe_goto(zone)
+
+        self.fleet_set(self.config.OpsiFleet_Fleet)
+        self.os_order_execute(recon_scan=False, submarine_call=self.config.OpsiFleet_Submarine)
+
+        self.meow_search_metrics_start()
+        try:
+            self.run_auto_search()
+            self.handle_after_auto_search()
+        finally:
+            self.meow_search_metrics_end()
+
+        self.config.check_task_switch()
 
     def _meow_handle_normal_search(self):
         hazard_level = self.config.OpsiMeowfficerFarming_HazardLevel
@@ -424,8 +442,13 @@ class OpsiMeowfficerFarming(MeowfficerTargetZoneMixin, CoinTaskMixin, OSMap):
                 if self.config.OpsiMeowfficerFarming_StayInZone:
                     zone, _ = self._meow_target_zone_at(target_zones, target_zone_index)
                     target_zone_index += 1
-                    if self._meow_handle_stay_in_zone(zone):
-                        return
+                    if len(target_zones) == 1:
+                        if self._meow_handle_stay_in_zone(zone):
+                            return
+                    else:
+                        self._meow_handle_target_zone_search(zone)
+                        if not natural_ap_cleanup and self._check_yellow_coins_and_return_to_cl1("循环中", "短猫相接"):
+                            return
                     continue
 
                 # ===== 普通短猫搜索主逻辑 =====


### PR DESCRIPTION
## Summary by Sourcery

当配置了多个目标区域时，调整 meowfficer 农场行为，对每个区域使用独立的短程搜索逻辑，并将其与单一区域的“停留在区域内”处理方式分离。

New Features:
- 为在选择多个目标区域时的 meowfficer 农场行为引入专用的目标区域短程搜索流程。

Bug Fixes:
- 修正多海域情况下的 meowfficer 农场行为，使短锚逻辑按目标区域逐个执行，而不是错误地复用“停留在区域内”的处理方式。

Enhancements:
- 优化与 meowfficer 农场流程相关的日志记录，以区分“停留在区域内”处理与按区域执行的短程搜索运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust meowfficer farming behavior when multiple target zones are configured to use short-search logic per zone and separate it from single-zone stay-in-zone handling.

New Features:
- Introduce a dedicated target-zone short-search flow for meowfficer farming when multiple target zones are selected.

Bug Fixes:
- Correct meowfficer farming behavior with multiple sea zones so that short-anchor logic runs per target zone instead of incorrectly reusing stay-in-zone handling.

Enhancements:
- Refine logging around meowfficer farming flows to distinguish stay-in-zone handling from per-zone short-search runs.

</details>