### PR TITLE
Dev

### DIFF
--- a/bin/ocr_models/README.md
+++ b/bin/ocr_models/README.md
@@ -44,7 +44,7 @@ v3 zh-cn
 
 ## ncnn
 `ncnn/` 目录保存从现有 ONNX 识别模型转换得到的运行时模型。
-当前 `azur_lane`、`azur_lane_jp`、`cn`、`jp`、`tw` 单行识别已迁移到
+当前 `azur_lane`、`azur_lane_jp`、`ppocr_v6`、`cn`、`jp`、`tw` 单行识别已迁移到
 ncnn CPU / Vulkan。模型通过 pnnx 从 ONNX 转换，固定输入 shape 为
 `[1,3,48,320]`，运行时输入 blob 为 `in0`，输出 blob 为 `out0`。
 

--- a/module/commission/project.py
+++ b/module/commission/project.py
@@ -157,7 +157,7 @@ class Commission:
         # 名称识别——EN 服名称较长，使用更宽的裁剪区域
         area = area_offset((131, 23, 409, 53), self.area[0:2])
         button = Button(area=area, color=(), button=area, name='COMMISSION')
-        ocr = Ocr(button, lang='cnocr')
+        ocr = Ocr(button, lang='ppocr_v6')
         self.button = button
         result = ocr.ocr(self.image).upper()
         # 修正常见 OCR 识别错误

--- a/module/island/project.py
+++ b/module/island/project.py
@@ -29,6 +29,14 @@ ROLE_SORTING.add_state('Ascending', check_button=ROLE_SORT_ASC, click_button=ROL
 ROLE_SORTING.add_state('Descending', check_button=ROLE_SORT_DESC, click_button=ROLE_SORTING_CLICK)
 
 
+def island_text_ocr_lang():
+    if server.server == 'cn':
+        return 'cnocr'
+    if server.server == 'en':
+        return 'ppocr_v6'
+    return server.server
+
+
 class ProjectNameOcr(Ocr):
     def after_process(self, result):
         result = super().after_process(result)
@@ -88,7 +96,7 @@ class IslandProject:
         dy = {'cn': 0, 'en': 2}[server.server]
         area = (self.x1 - 446, self.y1, self.x1 - dx, self.y2 + dy)
         button = Button(area=area, color=(), button=area, name='PROJECT_NAME')
-        ocr = ProjectNameOcr(button, lang='cnocr')
+        ocr = ProjectNameOcr(button, lang=island_text_ocr_lang())
         self.name = ocr.ocr(self.image)
         if not self.name:
             self.valid = False
@@ -264,7 +272,7 @@ class ProductItem:
     @classmethod
     def from_ocr_results(cls, image, parent_project_id, product_order):
         item = cls.empty(image, parent_project_id)
-        detector = AlOcr(name='zhcn' if server.server == 'cn' else 'en')
+        detector = AlOcr(name='cn' if server.server == 'cn' else 'ppocr_v6')
         try:
             det_results = detector.det(image)
         except Exception as e:
@@ -380,7 +388,7 @@ class ProductItem:
         """
         area = (300, y1 + 14, 440, y2 - 84)
         button = Button(area=area, color=(), button=area, name='ITEM_NAME')
-        ocr = ItemNameOcr(button, lang='cnocr', letter=(70, 70, 70))
+        ocr = ItemNameOcr(button, lang=island_text_ocr_lang(), letter=(70, 70, 70))
         self.name = ocr.ocr(self.image)
         if server.server == 'cn' and (not self.name or self.name not in deep_values(items_data, depth=2)):
             self.valid = False
@@ -637,7 +645,7 @@ class IslandProjectRun(IslandUI):
         target_name = CHARACTER_NAME_MAP.get(character, {}).get(server.server,
                        CHARACTER_NAME_MAP.get(character, {}).get('cn', character))
         target_name_orig = target_name
-        det_ocr = AlOcr(name='zhcn' if server.server == 'cn' else 'en')
+        det_ocr = AlOcr(name='cn' if server.server == 'cn' else 'ppocr_v6')
         for _ in self.loop():
             if timeout.reached():
                 self.ui_ensure_management_page()

--- a/module/island/season_task.py
+++ b/module/island/season_task.py
@@ -16,7 +16,7 @@ from module.ui.page import page_island_season
 if server.server == 'cn':
     lang = 'cnocr'
 elif server.server == 'en':
-    lang = 'azur_lane'
+    lang = 'ppocr_v6'
 else:
     lang = server.server
 TASK_NAME_OCR = Ocr([], lang=lang, letter=(64, 64, 64), name='TASK_NAME_OCR')

--- a/module/ocr/al_ocr.py
+++ b/module/ocr/al_ocr.py
@@ -139,7 +139,7 @@ def _get_onnx_model_params(name):
     返回指定语言的 ONNX 模型参数。
 
     Args:
-        name: 模型名称，如 'azur_lane'、'azur_lane_jp'、'cn'、'jp'、'tw'。
+        name: 模型名称，如 'azur_lane'、'azur_lane_jp'、'ppocr_v6'、'cn'、'jp'、'tw'。
 
     Returns:
         (model_path, rec_keys_path, ocr_version) 三元组。
@@ -154,6 +154,12 @@ def _get_onnx_model_params(name):
         return (
             "bin/ocr_models/azur_lane_jp/ap_azurlane_jp-v6_small_rec_nvidia.onnx",
             "bin/ocr_models/azur_lane_jp/ppocrv6_azurlane_jp_dict.txt",
+            OCRVersion.PPOCRV6,
+        )
+    elif name == "ppocr_v6":
+        return (
+            "bin/ocr_models/ppocr-v6/PP-OCRv6_small_rec.onnx",
+            "bin/ocr_models/ppocr-v6/ppocrv6_dict.txt",
             OCRVersion.PPOCRV6,
         )
     elif name == "cn":

--- a/module/ocr/models.py
+++ b/module/ocr/models.py
@@ -12,6 +12,10 @@ class OcrModel:
         return AlOcr(name='azur_lane_jp')
 
     @cached_property
+    def ppocr_v6(self):
+        return AlOcr(name='ppocr_v6')
+
+    @cached_property
     def cnocr(self):
         return AlOcr(name='cn')
 

--- a/module/ocr/ncnn_ocr.py
+++ b/module/ocr/ncnn_ocr.py
@@ -49,6 +49,14 @@ MODEL_SPECS = {
         output_name=OUTPUT_NAME,
         disable_fp16=True,
     ),
+    "ppocr_v6": NcnnRecModelSpec(
+        name="ppocr_v6",
+        param_path=MODEL_ROOT / "jp.param",
+        bin_path=MODEL_ROOT / "jp.bin",
+        keys_path=REPO_ROOT / "bin/ocr_models/ppocr-v6/ppocrv6_dict.txt",
+        output_name=OUTPUT_NAME,
+        disable_fp16=True,
+    ),
     "cn": NcnnRecModelSpec(
         name="cn",
         param_path=MODEL_ROOT / "cn.param",
@@ -76,6 +84,7 @@ MODEL_SPECS = {
 }
 
 MODEL_ALIASES = {
+    "ppocr-v6": "ppocr_v6",
     "cnocr": "cn",
     "en": "azur_lane",
     "zhcn": "cn",

--- a/module/ocr/ocr.py
+++ b/module/ocr/ocr.py
@@ -28,7 +28,7 @@ class Ocr:
 
         Args:
             buttons: OCR 区域，支持 Button、坐标元组、Button 列表或坐标元组列表。
-            lang: 语言模型，'azur_lane' 或 'cnocr'。
+            lang: 语言模型，如 'azur_lane'、'ppocr_v6'、'cnocr'、'jp'、'tw'。
             letter: 字母 RGB 颜色值元组。
             threshold: 二值化阈值。
             alphabet: 字母白名单。

--- a/module/ocr/rpc.py
+++ b/module/ocr/rpc.py
@@ -54,7 +54,7 @@ class ModelProxy:
         """初始化模型代理。
 
         Args:
-            lang: OCR 模型语言标识，如 'azur_lane'、'cnocr'、'jp'、'tw'。
+            lang: OCR 模型语言标识，如 'azur_lane'、'ppocr_v6'、'cnocr'、'jp'、'tw'。
         """
         self.lang = lang
 
@@ -209,7 +209,7 @@ class ModelProxyFactory:
     """OCR 模型代理工厂。
 
     通过 __getattribute__ 拦截语言模型属性访问，返回对应的 ModelProxy 实例。
-    支持的语言模型：azur_lane、cnocr、jp、tw、azur_lane_jp。
+    支持的语言模型：azur_lane、ppocr_v6、cnocr、jp、tw、azur_lane_jp。
     """
 
     def __getattribute__(self, __name: str) -> ModelProxy:
@@ -221,7 +221,7 @@ class ModelProxyFactory:
         Returns:
             对应语言的 ModelProxy 实例，或父类属性。
         """
-        if __name in ["azur_lane", "cnocr", "jp", "tw", "azur_lane_jp"]:
+        if __name in ["azur_lane", "ppocr_v6", "cnocr", "jp", "tw", "azur_lane_jp"]:
             if ModelProxy.client is None:
                 ModelProxy.init(address=State.deploy_config.OcrClientAddress)
             return ModelProxy(lang=__name)

--- a/module/os/map_operation.py
+++ b/module/os/map_operation.py
@@ -62,7 +62,7 @@ class OSMapOperation(MapOrderHandler, MissionHandler, PortHandler, StorageHandle
     @Config.when(SERVER='en')
     def get_zone_name(self):
         # 仅用于 EN 服务器
-        ocr = Ocr(MAP_NAME, lang='cnocr', letter=(206, 223, 247), threshold=96, name='OCR_OS_MAP_NAME')
+        ocr = Ocr(MAP_NAME, lang='ppocr_v6', letter=(206, 223, 247), threshold=96, name='OCR_OS_MAP_NAME')
         name = ocr.ocr(self.device.image)
         name = "".join(name.split())
         name = name.lower()


### PR DESCRIPTION
## Summary by Sourcery

为 ppocr_v6 OCR 模型添加支持，并在跨岛屿、委托、赛季任务和 OS 地图等功能中，用于 EN 服务器文本识别。

新特性：
- 引入通用的 `island_text_ocr_lang` 辅助函数，根据服务器语言环境选择 OCR 语言。
- 在 ncnn、ONNX、RPC 和模型工厂层中注册 `ppocr_v6` OCR 模型，以实现统一访问。

改进：
- 将 EN 服务器在岛屿项目、委托解析、赛季任务和 OS 地图区域名称中的 OCR 使用，从 `azur_lane/cnocr` 模型切换为 `ppocr_v6`。
- 明确文档与类型提示，以包含新的 `ppocr_v6` OCR 模型选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for the ppocr_v6 OCR model and use it for EN server text recognition across island, commission, season task, and OS map features.

New Features:
- Introduce a generic island_text_ocr_lang helper to select OCR language based on server locale.
- Register the ppocr_v6 OCR model in ncnn, ONNX, RPC, and model factory layers for unified access.

Enhancements:
- Switch EN server OCR usage from azur_lane/cnocr models to ppocr_v6 in island projects, commission parsing, season tasks, and OS map zone names.
- Clarify documentation and type hints to include the new ppocr_v6 OCR model option.

</details>