### PR TITLE
更新 MuMu 模拟器路径处理，增加对 MuMuNxMain.exe 的支持

### DIFF
--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -1825,7 +1825,7 @@
     },
     "CustomFilter": {
       "name": "自定义过滤器",
-      "help": "使用自定义过滤器需将“活动商店过滤器”设置为“自定义”，并阅读 https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/filter_string_cn，自己瞎几把设置过滤器出问题了别叫"
+      "help": "使用自定义过滤器需将“活动商店过滤器”设置为“自定义”，并使用 https://filter.nanoda.work/ 生成过滤器，自己瞎几把设置过滤器出问题了别叫"
     }
   },
   "Commission": {
@@ -1849,7 +1849,7 @@
     },
     "CustomFilter": {
       "name": "自定义委托过滤器",
-      "help": "使用自定义过滤器需将 \"委托过滤器\" 设置为 \"自定义\"，并阅读 https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/filter_string_cn ，自己瞎几把设置过滤器漏委托了别叫"
+      "help": "使用自定义过滤器需将 \"委托过滤器\" 设置为 \"自定义\"，并使用 https://filter.nanoda.work/ 生成过滤器 ，自己瞎几把设置过滤器漏委托了别叫"
     },
     "DoMajorCommission": {
       "name": "做主要委托（1200油/1000油委托）",
@@ -1999,7 +1999,7 @@
     },
     "CustomFilter": {
       "name": "自定义科研过滤器",
-      "help": "使用自定义过滤器需将 \"科研过滤器\" 设置为 \"自定义\"，并阅读 https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/filter_string_cn ，自己瞎几把设置过滤器出问题了别叫"
+      "help": "使用自定义过滤器需将 \"科研过滤器\" 设置为 \"自定义\"，并使用 https://filter.nanoda.work/ 生成过滤器 ，自己瞎几把设置过滤器出问题了别叫"
     }
   },
   "Dorm": {
@@ -3031,7 +3031,7 @@
     },
     "CustomFilter": {
       "name": "自定义过滤器",
-      "help": "使用自定义过滤器需将 \"港口商店过滤器\" 设置为 \"自定义\"，并阅读 https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/filter_string_cn ，自己瞎几把设置过滤器出问题了别叫"
+      "help": "使用自定义过滤器需将 \"港口商店过滤器\" 设置为 \"自定义\"，并使用 https://filter.nanoda.work/ 生成过滤器，自己瞎几把设置过滤器出问题了别叫"
     },
     "DisableBeforeDate": {
       "name": "每月 X 号前，不购买大世界商店",

--- a/module/device/platform/emulator_windows.py
+++ b/module/device/platform/emulator_windows.py
@@ -171,6 +171,7 @@ class Emulator(EmulatorBase):
             yield exe.replace('MuMuMultiPlayer.exe', 'MuMuPlayer.exe')
         elif 'MuMuManager.exe' in exe:
             yield exe.replace('MuMuManager.exe', 'MuMuPlayer.exe')
+            yield exe.replace('MuMuManager.exe', 'MuMuNxMain.exe')
         elif 'MEmuConsole.exe' in exe:
             yield exe.replace('MEmuConsole.exe', 'MEmu.exe')
         else:
@@ -341,7 +342,7 @@ class Emulator(EmulatorBase):
                             name=name,
                             path=self.path,
                         )
-                        if instance.MuMuPlayer12_id:
+                        if instance.MuMuPlayer12_id is not None:
                             instance.serial = f'127.0.0.1:{16384 + 32 * instance.MuMuPlayer12_id}'
                             yield instance
         elif self == Emulator.MEmuPlayer:
@@ -595,9 +596,10 @@ class EmulatorManager(EmulatorManagerBase):
                 if Emulator.is_emulator(file) and os.path.exists(file):
                     exe.add(file)
             # MuMu 特定目录
-            for file in iter_folder(abspath(os.path.join(os.path.dirname(uninstall), 'EmulatorShell')), ext='.exe'):
-                if Emulator.is_emulator(file) and os.path.exists(file):
-                    exe.add(file)
+            for folder in ['EmulatorShell', 'nx_main']:
+                for file in iter_folder(abspath(os.path.join(os.path.dirname(uninstall), folder)), ext='.exe'):
+                    if Emulator.is_emulator(file) and os.path.exists(file):
+                        exe.add(file)
 
         # 正在运行的模拟器
         for file in EmulatorManager.iter_running_emulator():


### PR DESCRIPTION
## Summary by Sourcery

扩展 Windows 上的模拟器发现与实例处理，以支持更多 MuMu 变体。

增强内容：
- 将 MuMuManager 可执行文件同时视为 MuMuPlayer 和 MuMuNxMain，以支持较新的 MuMu Nx 启动器。
- 在 Windows 上定位 MuMu 模拟器可执行文件时，同时扫描 EmulatorShell 和 nx_main 目录。
- 通过在分配串口前显式检查 ID 是否为非 None，来澄清 MuMuPlayer12 实例过滤逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend Windows emulator discovery and instance handling for additional MuMu variants.

Enhancements:
- Treat MuMuManager executables as both MuMuPlayer and MuMuNxMain to support the newer MuMu Nx launcher.
- Scan both EmulatorShell and nx_main directories when locating MuMu emulator executables on Windows.
- Clarify MuMuPlayer12 instance filtering by explicitly checking for non-None IDs before assigning serial ports.

</details>