### PR TITLE
fix增强 ADB 下载逻辑，处理目标路径为空的情况并优化下载目录A

### DIFF
--- a/module/device/connection_attr.py
+++ b/module/device/connection_attr.py
@@ -59,10 +59,16 @@ class ConnectionAttr:
             logger.warning(f'当前平台不支持自动下载 ADB: {sys.platform}')
             return None
 
+        if not target:
+            logger.warning('ADB 下载失败，目标路径为空')
+            return None
+
         target = Path(target).resolve()
-        root = Path.cwd().resolve()
-        tools_dir = root / '.venv' / 'platform-tools'
-        archive = root / '.venv' / 'platform-tools.zip'
+        download_dir = target.parent
+        if target.parent.name in ['Scripts', 'bin'] and target.parent.parent.name == '.venv':
+            download_dir = target.parent.parent
+        tools_dir = download_dir / 'platform-tools'
+        archive = download_dir / 'platform-tools.zip'
         executable = 'adb.exe' if os.name == 'nt' else 'adb'
         source = tools_dir / executable
 
@@ -387,9 +393,9 @@ class ConnectionAttr:
         # deploy.yaml 中的路径是相对于项目根目录的
         deploy_adb = State.deploy_config.AdbExecutable
         root = State.deploy_config.root_filepath
-        file = os.path.abspath(os.path.join(root, deploy_adb)).replace('\\', '/')
-        if os.path.exists(file):
-            return file
+        deploy_adb_file = os.path.abspath(os.path.join(root, deploy_adb)).replace('\\', '/')
+        if os.path.exists(deploy_adb_file):
+            return deploy_adb_file
 
         # Try existing adb.exe in predefined list
         for candidate in self.adb_binary_list:
@@ -407,13 +413,13 @@ class ConnectionAttr:
             return file
 
         # Use adb in system PATH
-        file = shutil.which('adb')
-        if file:
-            return os.path.abspath(file).replace('\\', '/')
+        path_adb = shutil.which('adb')
+        if path_adb:
+            return os.path.abspath(path_adb).replace('\\', '/')
 
         # Download adb only when all local candidates are missing
         # 使用绝对路径下载，确保后续实例能找到文件
-        downloaded = self.download_adb_binary(file)
+        downloaded = self.download_adb_binary(deploy_adb_file)
         if downloaded:
             return downloaded
 


### PR DESCRIPTION
## Summary by Sourcery

改进 ADB 二进制文件的解析逻辑，以及在本地未找到可执行文件时的回退下载行为。

Bug Fixes:
- 当目标路径为空时，阻止尝试下载 ADB，并提前返回同时给出警告。
- 确保 ADB 下载使用来自部署配置的 ADB 路径，而不是使用系统 PATH 中尚未解析的候选路径。

Enhancements:
- 调整 ADB 下载目录的选择逻辑：当目标路径位于 `.venv/Scripts` 或 `.venv/bin` 下时，将 `platform-tools` 放置在虚拟环境旁边，以提高可发现性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve ADB binary resolution and fallback download behavior when no local executable is found.

Bug Fixes:
- Prevent ADB download attempts when the target path is empty, returning early with a warning.
- Ensure ADB download uses the deploy-config ADB path instead of an unresolved candidate from the system PATH.

Enhancements:
- Adjust ADB download directory selection to place platform-tools alongside the virtualenv when the target is under .venv/Scripts or .venv/bin for better discoverability.

</details>