### PR TITLE
Fix:智能调度不切换高优先级任务的问题

### DIFF
--- a/module/config/config.py
+++ b/module/config/config.py
@@ -649,7 +649,7 @@ class AzurLaneConfig(ConfigUpdater, ManualConfig, GeneratedConfig, ConfigWatcher
         if self.stop_event is not None:
             if self.stop_event.is_set():
                 return True
-        prev = self.task
+        prev = getattr(self, '_task_switch_owner', self.task)
         self.load()
         new = self.get_next()
         if prev == new:

--- a/module/os/map.py
+++ b/module/os/map.py
@@ -994,14 +994,17 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
             if self.combat_appear():
                 self.on_auto_search_battle_count_add()
                 stop_event = self.config.stop_event
-                if strategic and stop_event is not None and stop_event.is_set():
+                smart_scheduling = getattr(self, 'is_running_smart_scheduling_task', lambda: False)()
+                if (strategic or smart_scheduling) and stop_event is not None and stop_event.is_set():
                     self.interrupt_auto_search()
                 elif (
-                    strategic
-                    and not getattr(self, 'is_running_smart_scheduling_task', lambda: False)()
+                    (strategic or smart_scheduling)
                     and self.config.task_switched()
                 ):
-                    if self.config.task.command == "OpsiMeowfficerFarming":
+                    if (
+                        self.config.task.command == "OpsiMeowfficerFarming"
+                        and not smart_scheduling
+                    ):
                         logger.info("Short meow search is running, delay task switch until search finished")
                     else:
                         self.interrupt_auto_search()

--- a/module/os/tasks/scheduling.py
+++ b/module/os/tasks/scheduling.py
@@ -510,9 +510,11 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
         previous_context = getattr(self, '_smart_scheduling_context', None)
         previous_config_context = getattr(self.config, '_smart_scheduling_context', None)
         previous_disable_task_switch = getattr(self.config, '_disable_task_switch', False)
+        previous_task_switch_owner = getattr(self.config, '_task_switch_owner', None)
         self._smart_scheduling_context = True
         self.config._smart_scheduling_context = True
         self.config._disable_task_switch = True
+        self.config._task_switch_owner = previous_task
         self.config.task = self._make_opsi_task_function(task_name)
         self.config._bind_task_override = task_name
         self.config.bind(task_name)
@@ -533,6 +535,11 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
             else:
                 self.config._smart_scheduling_context = previous_config_context
             self.config._disable_task_switch = previous_disable_task_switch
+            if previous_task_switch_owner is None:
+                if hasattr(self.config, '_task_switch_owner'):
+                    delattr(self.config, '_task_switch_owner')
+            else:
+                self.config._task_switch_owner = previous_task_switch_owner
 
             if previous_bind is None:
                 if hasattr(self.config, '_bind_task_override'):


### PR DESCRIPTION
## Summary by Sourcery

在智能调度和战略任务同时运行时，修复错误的任务切换行为。

Bug 修复：
- 确保当战略任务或智能调度任务请求停止事件时，自动搜索会被中断。
- 防止在智能调度任务触发时，短喵搜索延迟任务切换。
- 追踪并恢复负责切换决策的任务，使得在智能调度上下文中，`task_switched` 能与正确的前一个任务进行比较。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve incorrect task switching behavior when smart scheduling and strategic tasks are running together.

Bug Fixes:
- Ensure auto search is interrupted when either strategic or smart scheduling tasks request a stop event.
- Prevent short meow search from delaying task switches when triggered by smart scheduling tasks.
- Track and restore the task that owns switch decisions so task_switched compares against the correct previous task in smart scheduling context.

</details>