### PR TITLE
fix: 修复智能调度相关问题

### DIFF
--- a/module/os/map.py
+++ b/module/os/map.py
@@ -994,17 +994,14 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
             if self.combat_appear():
                 self.on_auto_search_battle_count_add()
                 stop_event = self.config.stop_event
-                smart_scheduling = getattr(self, 'is_running_smart_scheduling_task', lambda: False)()
-                if (strategic or smart_scheduling) and stop_event is not None and stop_event.is_set():
+                if strategic and stop_event is not None and stop_event.is_set():
                     self.interrupt_auto_search()
                 elif (
-                    (strategic or smart_scheduling)
+                    strategic
+                    and not getattr(self, 'is_running_smart_scheduling_task', lambda: False)()
                     and self.config.task_switched()
                 ):
-                    if (
-                        self.config.task.command == "OpsiMeowfficerFarming"
-                        and not smart_scheduling
-                    ):
+                    if self.config.task.command == "OpsiMeowfficerFarming":
                         logger.info("Short meow search is running, delay task switch until search finished")
                     else:
                         self.interrupt_auto_search()

--- a/module/os/tasks/scheduling.py
+++ b/module/os/tasks/scheduling.py
@@ -513,7 +513,10 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
         previous_task_switch_owner = getattr(self.config, '_task_switch_owner', None)
         self._smart_scheduling_context = True
         self.config._smart_scheduling_context = True
-        self.config._disable_task_switch = True
+        self.config._disable_task_switch = task_name not in (
+            self.TASK_NAME_HAZARD1_LEVELING,
+            self.TASK_NAME_MEOWFFICER_FARMING,
+        )
         self.config._task_switch_owner = previous_task
         self.config.task = self._make_opsi_task_function(task_name)
         self.config._bind_task_override = task_name

--- a/module/os/tasks/stronghold.py
+++ b/module/os/tasks/stronghold.py
@@ -1,4 +1,4 @@
-﻿from module.config.config import TaskEnd
+from module.config.config import TaskEnd
 from module.logger import logger
 from module.os.fleet import BossFleet
 from module.os.map import OSMap
@@ -35,6 +35,7 @@ class OpsiStronghold(CoinTaskMixin, OSMap):
             zone = self.find_siren_stronghold()
             if zone is None:
                 self.config.OpsiStronghold_HasStronghold = False
+                self.os_globe_goto_map()
                 if self._handle_coin_task_no_content('塞壬要塞', '塞壬要塞没有可执行内容'):
                     return
 
@@ -57,6 +58,7 @@ class OpsiStronghold(CoinTaskMixin, OSMap):
         next_zone = self.find_siren_stronghold()
         if next_zone is None:
             self.config.OpsiStronghold_HasStronghold = False
+            self.os_globe_goto_map()
             if self._handle_coin_task_no_content('塞壬要塞', '塞壬要塞没有更多可执行内容'):
                 return
 


### PR DESCRIPTION
## Summary by Sourcery

调整战斗自动索敌中的智能调度行为，并在无可用内容时优化要塞任务的处理方式。

Bug Fixes:
- 防止智能调度任务在战斗索敌过程中错误地触发自动索敌中断或导致任务切换延迟。
- 确保要塞清理任务在无剩余或无可用要塞内容时，能够正确返回至世界地图。

Enhancements:
- 允许特定智能调度任务（危险等级提升与猫舰长刷取）在运行于 `opsi` 任务上下文时保持任务切换功能启用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust smart scheduling behavior in combat auto-search and refine stronghold task handling when no content is available.

Bug Fixes:
- Prevent smart scheduling tasks from incorrectly triggering auto-search interruption or delayed task switching during combat searches.
- Ensure stronghold clearing tasks correctly return to the global map when no stronghold content remains or is available.

Enhancements:
- Allow specific smart scheduling tasks (hazard leveling and meowfficer farming) to keep task switching enabled while running within the opsi task context.

</details>