### PR TITLE
feat: 大世界自律寻敌时间限制

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -2314,7 +2314,8 @@
       "NotifyOpsiMail": true,
       "LauncherPush": true,
       "IndependentPush": false,
-      "OpsiOnePushConfig": "provider: null"
+      "OpsiOnePushConfig": "provider: null",
+      "AutoSearchTimeLimit": 5
     },
     "Storage": {
       "Storage": {}

--- a/module/base/timer.py
+++ b/module/base/timer.py
@@ -109,7 +109,7 @@ class Timer:
         count = int(limit / speed)
         return cls(limit, count=count)
 
-    def start(self):
+    def start(self) -> Timer:
         """启动计时器。
 
         如果计时器未启动，reached() 始终返回 True，从而实现首次快速尝试：

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -12085,6 +12085,14 @@
         "type": "textarea",
         "value": "provider: null",
         "mode": "yaml"
+      },
+      "AutoSearchTimeLimit": {
+        "type": "input",
+        "value": 5,
+        "validate": [
+          1,
+          240
+        ]
       }
     },
     "Storage": {

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -969,6 +969,9 @@ OpsiGeneral:
     type: textarea
     mode: yaml
     value: "provider: null"
+  AutoSearchTimeLimit:
+    value: 5
+    validate: [1, 240]
 OpsiAshBeacon:
   AttackMode:
     value: current

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -549,6 +549,7 @@ class GeneratedConfig:
     OpsiGeneral_LauncherPush = True
     OpsiGeneral_IndependentPush = False
     OpsiGeneral_OpsiOnePushConfig = 'provider: null'
+    OpsiGeneral_AutoSearchTimeLimit = 5
 
     # 配置组 `OpsiAshBeacon`
     OpsiAshBeacon_AttackMode = 'current'  # current, current_dossier, current_dossier_only

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -2930,6 +2930,10 @@
     "OpsiOnePushConfig": {
       "name": "Operation Siren notifications push settings",
       "help": "The settings will take effect only when the \"Siren Operation Information Independent Push\" function is enabled. Use Onepush to push a message about Corrosion 1 and Short Cat. See the document for configuration method: https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/Onepush-configuration-%5BCN%5D"
+    },
+    "AutoSearchTimeLimit": {
+      "name": "Auto Search Time Limit",
+      "help": "Unit: minutes. During auto search, the script will assume the game is stuck if no event is detected for this period."
     }
   },
   "OpsiAshBeacon": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -2930,6 +2930,10 @@
     "OpsiOnePushConfig": {
       "name": "セイレーン作戦プッシュ通知設定",
       "help": "「塞壬行動信息獨立推送」功能開啟時設置才生效。Onepushを使用して、侵食1と短毛猫に関する情報を1つプッシュします。設定方法はドキュメントを参照してください：https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/Onepush-configuration-%5BCN%5D"
+    },
+    "AutoSearchTimeLimit": {
+      "name": "自動探索時間制限",
+      "help": "単位：分。自動探索中にイベントが一定時間発生しない場合、フリーズと判定されます。"
     }
   },
   "OpsiAshBeacon": {

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -2930,6 +2930,10 @@
     "OpsiOnePushConfig": {
       "name": "大世界推送设置",
       "help": "“大世界信息独立推送”功能开启时设置才生效。使用 Onepush 推送一条关于侵蚀1和短猫的信息。配置方法见文档：https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/Onepush-configuration-%5BCN%5D"
+    },
+    "AutoSearchTimeLimit": {
+      "name": "自律寻敌时间限制",
+      "help": "单位：分钟。自律寻敌时连续多长时间没遇到事件会判定为游戏卡死"
     }
   },
   "OpsiAshBeacon": {

--- a/module/config/i18n/zh-MIAO.json
+++ b/module/config/i18n/zh-MIAO.json
@@ -2930,6 +2930,10 @@
     "OpsiOnePushConfig": {
       "name": "大世界推送设置",
       "help": "“大世界信息独立推送”功能开启时设置才生效喵。使用 Onepush 推送一条关于侵蚀1和短猫的信息喵。配置方法见文档喵：https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/Onepush-configuration-%5BCN%5D"
+    },
+    "AutoSearchTimeLimit": {
+      "name": "自律寻敌时间限制喵~",
+      "help": "单位：分钟。自律寻敌时连续多长时间没遇到事件会判定为游戏卡死喵~"
     }
   },
   "OpsiAshBeacon": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -2930,6 +2930,10 @@
     "OpsiOnePushConfig": {
       "name": "大世界推送設定",
       "help": "”大世界資訊獨立推送”功能開啟時設定才生效。使用 Onepush 推送一條關於侵蝕1和短貓的資訊。配置方法見文檔：https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/Onepush-configuration-%5BCN%5D"
+    },
+    "AutoSearchTimeLimit": {
+      "name": "自律尋敵時間限制",
+      "help": "單位：分鐘。自律尋敵時連續多長時間沒遇到事件會判定為遊戲卡死"
     }
   },
   "OpsiAshBeacon": {

--- a/module/os/map.py
+++ b/module/os/map.py
@@ -12,6 +12,7 @@ from module.config.utils import get_os_reset_remain
 from module.exception import (
     CampaignEnd,
     GameTooManyClickError,
+    GameStuckError,
     MapDetectionError,
     MapWalkError,
     RequestHumanTakeover,
@@ -954,6 +955,7 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
         finished_combat = 0
         died_timer = Timer(1.5, count=3)
         self.hp_reset()
+        auto_search_time_limit_timer = Timer(self.config.OpsiGeneral_AutoSearchTimeLimit * 60, count=1).start()
         for _ in self.loop():
             # 结束条件
             if not unlock_checked and unlock_check_timer.reached():
@@ -986,10 +988,12 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
 
             if self.handle_os_auto_search_map_option(drop=drop, enable=success):
                 unlock_checked = True
+                auto_search_time_limit_timer.reset()
                 continue
             if self.handle_retirement():
                 # 退役会中断自动搜索，需要重试
                 self.ash_popup_canceled = True
+                auto_search_time_limit_timer.reset()
                 continue
             if self.combat_appear():
                 self.on_auto_search_battle_count_add()
@@ -1018,102 +1022,15 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
                     ):
                         success = False
                         logger.warning("Fleet died, stop auto search")
+                        auto_search_time_limit_timer.reset()
                         continue
+                auto_search_time_limit_timer.reset()
             if self.handle_map_event():
                 # 自动搜索无法处理塞壬搜索装置。
+                auto_search_time_limit_timer.reset()
                 continue
-
-        return finished_combat
-
-    def os_auto_search_daemon_until_combat(
-        self, drop=None, strategic=False, interrupt=None, skip_first_screenshot=True
-    ):
-        """
-        自动寻敌，遇到第一次战斗就返回。
-
-        Args:
-            drop (DropRecord): 掉落记录对象。
-            strategic (bool): 是否运行战略搜索。
-            interrupt (callable): 中断回调函数。
-            skip_first_screenshot: 是否跳过第一次截图。
-
-        Returns:
-            int: 完成的战斗次数。
-
-        Raises:
-            CampaignEnd: 自动搜索结束时抛出。
-            RequestHumanTakeover: 没有自动搜索选项时抛出。
-
-        Pages:
-            in: AUTO_SEARCH_OS_MAP_OPTION_OFF
-            out: AUTO_SEARCH_OS_MAP_OPTION_OFF 且 info_bar_count() >= 2（地图上无可清理对象时）。
-                 AUTO_SEARCH_REWARD（获得自动搜索奖励时）。
-        """
-        logger.hr("OS auto search until combat", level=2)
-        self.on_auto_search_battle_count_reset()
-        unlock_checked = False
-        unlock_check_timer = Timer(5, count=10).start()
-        self.ash_popup_canceled = False
-
-        def false_func(*args, **kwargs):
-            return False
-
-        success = True
-        interrupt_confirm = False
-        if callable(interrupt):
-            is_interrupt, not_interrupt = interrupt, false_func
-        elif isinstance(interrupt, list) and len(interrupt) == 2:
-            is_interrupt = interrupt[0] if callable(interrupt[0]) else false_func
-            not_interrupt = interrupt[1] if callable(interrupt[1]) else false_func
-        else:
-            is_interrupt, not_interrupt = false_func, false_func
-        finished_combat = 0
-        died_timer = Timer(1.5, count=3)
-        self.hp_reset()
-        for _ in self.loop():
-            # 结束条件
-            if not unlock_checked and unlock_check_timer.reached():
-                logger.critical("当前海域未解锁自律，请先完成剧情任务。")
-                raise RequestHumanTakeover
-            if self.is_in_map():
-                self.device.stuck_record_clear()
-                if not success:
-                    if died_timer.reached():
-                        logger.warning("Fleet died confirm")
-                        break
-                else:
-                    if not interrupt_confirm and is_interrupt():
-                        interrupt_confirm = True
-                    if interrupt_confirm and not_interrupt():
-                        interrupt_confirm = False
-                    died_timer.reset()
-            else:
-                died_timer.reset()
-
-            if not unlock_checked:
-                if self.appear(AUTO_SEARCH_OS_MAP_OPTION_OFF, offset=(5, 120)):
-                    unlock_checked = True
-                elif self.appear(
-                    AUTO_SEARCH_OS_MAP_OPTION_OFF_DISABLED, offset=(5, 120)
-                ):
-                    unlock_checked = True
-                elif self.appear(AUTO_SEARCH_OS_MAP_OPTION_ON, offset=(5, 120)):
-                    unlock_checked = True
-
-            if self.handle_os_auto_search_map_option(drop=drop, enable=success):
-                unlock_checked = True
-                continue
-            if self.handle_retirement():
-                # 退役会中断自动搜索，需要重试
-                self.ash_popup_canceled = True
-                continue
-            if self.combat_appear():
-                self.on_auto_search_battle_count_add()
-                self.interrupt_auto_search(goto_main=False, end_task=False)
-                return finished_combat
-            if self.handle_map_event():
-                # 自动搜索无法处理塞壬搜索装置。
-                continue
+            if auto_search_time_limit_timer.reached():
+                raise GameStuckError('自律寻敌卡死')
 
         return finished_combat
 
@@ -1503,8 +1420,13 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
                 self.hp_reset()
                 self.hp_get()
                 return True
-            except TaskEnd:
-                # 任务切换，让异常继续向上传播
+            except (
+                TaskEnd,
+                GameStuckError,
+                GameTooManyClickError,
+                RequestHumanTakeover,
+            ):
+                # 任务切换和恢复型异常必须交给上层调度器处理。
                 raise
             except Exception as e:
                 logger.warning(f"Strategic search interrupted: {e}")
@@ -2141,6 +2063,13 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
             for _ in range(2):
                 try:
                     self.map_rescan(rescan_mode="full")
+                except (
+                    TaskEnd,
+                    GameStuckError,
+                    GameTooManyClickError,
+                    RequestHumanTakeover,
+                ):
+                    raise
                 except Exception as e:
                     logger.debug(f"最终全图重扫出现异常，继续重试: {e}", exc_info=True)
                     time.sleep(0.6)
@@ -2150,6 +2079,13 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
         logger.info("执行一次自律寻敌以清理可能的装置")
         try:
             self.run_auto_search(question=True, rescan=None, after_auto_search=True)
+        except (
+            TaskEnd,
+            GameStuckError,
+            GameTooManyClickError,
+            RequestHumanTakeover,
+        ):
+            raise
         except Exception as e:
             logger.warning(f"自律寻敌过程出现异常: {e}")
 

--- a/module/os/tasks/meowfficer_farming.py
+++ b/module/os/tasks/meowfficer_farming.py
@@ -1,6 +1,11 @@
 from module.config.config import TaskEnd
 from module.config.utils import get_os_reset_remain
-from module.exception import RequestHumanTakeover, ScriptError
+from module.exception import (
+    GameStuckError,
+    GameTooManyClickError,
+    RequestHumanTakeover,
+    ScriptError,
+)
 from module.logger import logger
 from module.map.map_grids import SelectedGrids
 from module.os.map import OSMap
@@ -181,7 +186,7 @@ class OpsiMeowfficerFarming(MeowfficerTargetZoneMixin, CoinTaskMixin, OSMap):
         try:
             try:
                 search_completed = self.run_strategic_search()
-            except TaskEnd:
+            except (TaskEnd, GameStuckError, GameTooManyClickError, RequestHumanTakeover):
                 raise
             except Exception as e:
                 logger.warning(f'战略搜索异常: {e}')
@@ -194,6 +199,8 @@ class OpsiMeowfficerFarming(MeowfficerTargetZoneMixin, CoinTaskMixin, OSMap):
 
             try:
                 self.handle_after_auto_search()
+            except (TaskEnd, GameStuckError, GameTooManyClickError, RequestHumanTakeover):
+                raise
             except Exception:
                 logger.exception('handle_after_auto_search 发生异常')
         finally:


### PR DESCRIPTION
## Summary by Sourcery

为 OS 自动搜索添加可配置的时间上限，用于检测并中止卡死的运行，并在策略搜索和喵喵官（Meowfficer）养成流程中传播新的卡死相关异常。

新特性：
- 为 OS 地图引入可配置的自动搜索时间上限（单位：分钟），在超出时抛出卡死错误。

错误修复：
- 确保长时间运行或卡死的 OS 自动搜索能够被中止，而不是无限挂起。

增强优化：
- 更新策略搜索、巡逻扫描以及喵喵官养成逻辑，将 `GameStuckError` 和相关可恢复异常视为任务级信号。
- 使 `Timer.start()` 通过返回 `Timer` 实例实现可链式调用，并清理过时的自动搜索辅助逻辑。

构建：
- 在生成配置和参数配置中添加 `AutoSearchTimeLimit`，并设置校验边界，同时将其接入模板和 i18n 文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable time limit for OS auto-search to detect and abort stuck runs, and propagate the new stuck-related exceptions through strategic search and Meowfficer farming flows.

New Features:
- Introduce a configurable auto-search time limit (in minutes) for OS maps that raises a stuck error when exceeded.

Bug Fixes:
- Ensure long-running or stuck OS auto-search runs are aborted instead of hanging indefinitely.

Enhancements:
- Update strategic search, patrol scan, and Meowfficer farming logic to treat GameStuckError and related recoverable exceptions as task-level signals.
- Make Timer.start() chainable by returning the Timer instance and clean up obsolete auto-search helper logic.

Build:
- Add AutoSearchTimeLimit to the generated and argument configuration, with validation bounds, and wire it into templates and i18n files.

</details>