### PR TITLE
重新生成lock文件

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,21 +61,23 @@ dev = [
 
 [tool.uv]
 index = [
+    # 云厂商镜像（可靠性高，商业运营）
     { url = "https://mirrors.aliyun.com/pypi/simple/" },
     { url = "https://mirrors.cloud.tencent.com/pypi/simple/" },
     { url = "https://repo.huaweicloud.com/repository/pypi/simple/" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/simple" },
-    { url = "https://mirror.nju.edu.cn/pypi/web/simple" },
-    { url = "https://mirrors.pku.edu.cn/pypi/web/simple" },
-    { url = "https://mirrors.njtech.edu.cn/pypi/web/simple" },
-    { url = "https://mirrors.hust.edu.cn/pypi/web/simple" },
-    { url = "https://mirrors.ustc.edu.cn/pypi/web/simple" },
-    { url = "https://mirror.sjtu.edu.cn/pypi/web/simple" },
-    { url = "https://mirrors.sustech.edu.cn/pypi/web/simple" },
-    { url = "https://mirrors.jlu.edu.cn/pypi/web/simple" },
+    # 教育网镜像（按知名度排序）
     { url = "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/simple/" },
+    { url = "https://mirrors.ustc.edu.cn/pypi/web/simple" },
     { url = "https://pypi.mirrors.ustc.edu.cn/simple/" },
+    { url = "https://mirror.sjtu.edu.cn/pypi/web/simple" },
+    { url = "https://mirrors.pku.edu.cn/pypi/web/simple" },
+    { url = "https://mirror.nju.edu.cn/pypi/web/simple" },
+    { url = "https://mirrors.hust.edu.cn/pypi/web/simple" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/simple" },
+    { url = "https://mirrors.jlu.edu.cn/pypi/web/simple" },
+    { url = "https://mirrors.njtech.edu.cn/pypi/web/simple" },
+    { url = "https://mirrors.bfsu.edu.cn/pypi/web/simple" },
 ]
 index-url = "https://pypi.org/simple/"
 package = false

--- a/uv.lock
+++ b/uv.lock
@@ -626,11 +626,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.4"
+version = "3.29.5"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/e3/ee/29c668c50888588c432a702f7c2e8ee8a0c9e5286028d91f170308d6b2e9/filelock-3.29.5.tar.gz", hash = "sha256:6e6034c57a00a020e767f2614a5539863f056de7e7991d6d1473aef7ff73f156" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/4a/e3/f1fae3647d170919c2cf2a898e77e7d1a4e5c7cae0aed7bb4bd3f5ebff6f/filelock-3.29.5-py3-none-any.whl", hash = "sha256:8af830889ba3a0ffcefbd6c7d2af8a54012058103771f2e10848222f476a1693" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

刷新依赖锁文件，并更新 uv 的 PyPI 镜像配置，以优先使用云服务商镜像，并重新整理教育网镜像。

Build:
- 调整 uv 的 PyPI 索引镜像列表顺序和注释，以区分云服务商镜像和教育网镜像。

Chores:
- 重新生成 `uv.lock` 以反映当前的依赖和镜像配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refresh dependency lock file and update PyPI mirror configuration for uv to prioritize cloud provider mirrors and reorganized education network mirrors.

Build:
- Adjust uv PyPI index mirror list ordering and comments to distinguish cloud provider and education network mirrors.

Chores:
- Regenerate uv.lock to reflect current dependencies and mirror configuration.

</details>