### PR TITLE
chore(pyproject): 移除上海交大pypi镜像源

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ index = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/simple/" },
     { url = "https://mirrors.ustc.edu.cn/pypi/web/simple" },
     { url = "https://pypi.mirrors.ustc.edu.cn/simple/" },
-    { url = "https://mirror.sjtu.edu.cn/pypi/web/simple" },
     { url = "https://mirrors.pku.edu.cn/pypi/web/simple" },
     { url = "https://mirror.nju.edu.cn/pypi/web/simple" },
     { url = "https://mirrors.hust.edu.cn/pypi/web/simple" },


### PR DESCRIPTION
删除冗余的上海交大PyPI镜像源配置，精简依赖安装源列表