### PR TITLE
fix(webui): 减少日志刷新导致的托盘恢复卡顿

### DIFF
--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -2841,7 +2841,9 @@ class AlasGUI(Frame):
 
         self.task_handler.add(_update_simulator_figure, 0.5, True)
 
-        self.task_handler.add(log.put_log(pm), 0.25, True)
+        self.task_handler.add(
+            log.put_log(pm, get_visible=lambda: self.visible), 0.25, True
+        )
 
     @use_scope("groups")
     def set_group(self, group, arg_dict, config, task):
@@ -3185,7 +3187,9 @@ class AlasGUI(Frame):
             self.task_handler.add(self.alas_update_dashboard, 10, True)
             self.alas_update_dashboard(True)
         if hasattr(self, "alas") and self.alas is not None:
-            self.task_handler.add(log.put_log(self.alas), 0.25, True)
+            self.task_handler.add(
+                log.put_log(self.alas, get_visible=lambda: self.visible), 0.25, True
+            )
 
     def set_dashboard_display(self, b):
         self._log.set_dashboard_display(b)
@@ -3641,7 +3645,9 @@ class AlasGUI(Frame):
         self.task_handler.add(switch_scheduler.g(), 1, True)
         self.task_handler.add(switch_log_scroll.g(), 1, True)
         if hasattr(self, "alas") and self.alas is not None:
-            self.task_handler.add(log.put_log(self.alas), 0.25, True)
+            self.task_handler.add(
+                log.put_log(self.alas, get_visible=lambda: self.visible), 0.25, True
+            )
 
     @use_scope("menu", clear=True)
     def dev_set_menu(self) -> None:

--- a/module/webui/widgets.py
+++ b/module/webui/widgets.py
@@ -6,6 +6,7 @@ import json
 import pywebio.pin
 import random
 import string
+import time
 from typing import Any, Callable, Dict, Generator, List, Optional, TYPE_CHECKING, Union
 
 from pywebio.exceptions import SessionException
@@ -90,11 +91,16 @@ class ScrollableCode:
 
 
 class RichLog:
+    # run_js 是阻塞的前后端往返，滚动操作需要节流以保持界面响应。
+    LOG_SCROLL_MIN_INTERVAL = 0.5
+
     last_display_time: dict
 
     def __init__(self, scope, font_width="0.559") -> None:
         self.scope = scope
         self.font_width = font_width
+        self._last_scroll_time = 0.0
+        self._sync_dirty = True
         self.console = HTMLConsole(
             force_terminal=False,
             force_interactive=False,
@@ -134,7 +140,7 @@ class RichLog:
         # 调试：打印生成的 HTML
         return html
 
-    def extend(self, text):
+    def extend(self, text, scroll: bool = True):
         if text:
             run_js(
                 """$("#pywebio-scope-{scope}>div").append(text);
@@ -143,8 +149,22 @@ class RichLog:
                 ),
                 text=str(text),
             )
-            if self.keep_bottom:
-                self.scroll()
+            if scroll and self.keep_bottom:
+                self._scroll_throttled()
+
+    def set_content(self, html: str, scroll: bool = True) -> None:
+        if not html:
+            self.reset()
+            return
+        run_js(
+            """$("#pywebio-scope-{scope}>div").html(text);
+        """.format(
+                scope=self.scope
+            ),
+            text=str(html),
+        )
+        if scroll and self.keep_bottom:
+            self._scroll_throttled(force=True)
 
     def set_dashboard_display(self, b: bool) -> None:
         # use for lambda callback function. Copied.
@@ -161,6 +181,12 @@ class RichLog:
                 scope=self.scope
             )
         )
+
+    def _scroll_throttled(self, force: bool = False) -> None:
+        now = time.time()
+        if force or now - self._last_scroll_time >= self.LOG_SCROLL_MIN_INTERVAL:
+            self.scroll()
+            self._last_scroll_time = now
 
     def set_scroll(self, b: bool) -> None:
         # 用于 lambda 回调函数中设置是否保持滚动到底部
@@ -220,25 +246,39 @@ class RichLog:
     #     self._callback_thread = None
     #     self.console.width = int(_width)
 
-    def put_log(self, pm: ProcessManager) -> Generator:
+    def put_log(
+        self,
+        pm: ProcessManager,
+        get_visible: Optional[Callable[[], bool]] = None,
+    ) -> Generator:
         yield
+        last_idx = 0
         try:
             while True:
-                last_idx = len(pm.renderables)
-                html = "".join(map(self.render, pm.renderables[:]))
-                self.reset()
-                self.extend(html)
-                counter = last_idx
-                while counter < pm.renderables_max_length * 2:
-                    yield
-                    idx = len(pm.renderables)
-                    if idx < last_idx:
-                        last_idx -= pm.renderables_reduce_length
+                idx = len(pm.renderables)
+                visible = get_visible() if get_visible else True
+
+                if not visible:
                     if idx != last_idx:
-                        html = "".join(map(self.render, pm.renderables[last_idx:idx]))
-                        self.extend(html)
-                        counter += idx - last_idx
-                        last_idx = idx
+                        self._sync_dirty = True
+                    yield
+                    continue
+
+                if idx < last_idx:
+                    last_idx -= pm.renderables_reduce_length
+                    self._sync_dirty = True
+
+                if self._sync_dirty:
+                    html = "".join(map(self.render, pm.renderables[:]))
+                    self.set_content(html)
+                    last_idx = idx
+                    self._sync_dirty = False
+                elif idx != last_idx:
+                    html = "".join(map(self.render, pm.renderables[last_idx:idx]))
+                    self.extend(html)
+                    last_idx = idx
+
+                yield
         except SessionException:
             pass
 


### PR DESCRIPTION
## 改动
- WebUI 日志刷新支持页面不可见时暂停 DOM 更新，窗口恢复后一次性同步日志内容。
- 日志追加时节流自动滚动，减少 PyWebIO `run_js` 往返导致的输入和托盘恢复卡顿。

## 原因
从托盘恢复窗口时，隐藏期间持续追加的日志会造成大量 DOM 更新和滚动调用，界面容易卡住。这个改动把隐藏状态下的工作压缩为一次恢复同步。

## 验证
- `.\.venv\Scripts\python.exe -m py_compile .\module\webui\widgets.py .\module\webui\app.py`
- `git diff --cached --check`

## Summary by Sourcery

在窗口被隐藏时暂停 WebUI 日志的 DOM 更新，当窗口再次可见时，通过一次同步刷新恢复更新；同时对自动滚动操作进行节流，以在日志追加过程中保持界面响应性。

Enhancements:
- 对日志自动滚动进行节流，减少阻塞性的 `run_js` 往返调用，在大量日志输出时提升 UI 响应能力。
- 基于“脏标记”（dirty flag）为日志增加全量内容重同步和增量追加两种路径，以避免冗余的 DOM 更新。
- 将日志渲染任务与窗口可见性状态关联，使得在窗口隐藏时延迟 DOM 更新，直到窗口重新可见后再执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Pause WebUI log DOM updates while the window is hidden and resume with a single synchronized refresh when visible, while throttling auto-scroll operations to keep the interface responsive during log appends.

Enhancements:
- Throttle log auto-scrolling to reduce blocking run_js round trips and improve UI responsiveness during heavy logging.
- Add full-content resync and incremental append paths for logs based on a dirty flag to avoid redundant DOM updates.
- Wire log rendering tasks to the window visibility state so hidden windows defer DOM updates until they become visible again.

</details>