### PR TITLE
fix(os_shop, ui): 新增购买重试和停滞检测机制，防止死循环

### DIFF
--- a/module/os_shop/shop.py
+++ b/module/os_shop/shop.py
@@ -248,6 +248,9 @@ class OSShop(PortShop, AkashiShop):
             limit = 10
 
         self.interval_clear(AMOUNT_MAX)
+        # amount_max_stall: 记录AMOUNT_MAX点击后数量未变化的次数，防止按钮无效时死循环
+        amount_max_stall = 0
+        amount_max_stall_limit = 5
         while set_to_max:
             if skip_first_screenshot:
                 skip_first_screenshot = False
@@ -257,14 +260,21 @@ class OSShop(PortShop, AkashiShop):
             if self.appear_then_click(AMOUNT_MAX, offset=(50, 50), interval=3):
                 continue
 
-            if OCR_SHOP_AMOUNT.ocr(self.device.image) > 1:
+            current_amount = OCR_SHOP_AMOUNT.ocr(self.device.image)
+            if current_amount > 1:
                 break
 
-        # 仅在已点击AMOUNT_MAX时，才能读取游戏端实际允许的最大数量
-        # set_to_max=False时未点击AMOUNT_MAX，界面数量仍为1，不能作为上限依据
+            # AMOUNT_MAX点击后数量仍为1，说明按钮可能被游戏禁用（如商品只能逐个购买）
+            amount_max_stall += 1
+            if amount_max_stall >= amount_max_stall_limit:
+                logger.info(f'AMOUNT_MAX clicked {amount_max_stall} times but amount still {current_amount}, '
+                            f'skipping to AMOUNT_PLUS')
+                break
+
+        # 仅在已点击AMOUNT_MAX且数量成功增加时，才能读取游戏端实际允许的最大数量
         if set_to_max:
             game_max = OCR_SHOP_AMOUNT.ocr(self.device.image)
-            if game_max > 0 and limit > game_max:
+            if game_max > 1 and limit > game_max:
                 logger.info(f'Calculated limit {limit} exceeds game max {game_max}, using game max')
                 limit = game_max
 

--- a/module/os_shop/shop.py
+++ b/module/os_shop/shop.py
@@ -46,6 +46,9 @@ class OSShop(PortShop, AkashiShop):
             SHOP_CLICK_SAFE_AREA
         ])
         set_amount_retry = 0
+        # 购买重试计数器，防止代币不足时无限重试点击商品和确认按钮
+        buy_retry = 0
+        buy_retry_limit = 3
 
         while True:
             if skip_first_screenshot:
@@ -83,6 +86,10 @@ class OSShop(PortShop, AkashiShop):
                 continue
 
             if not success and self.appear(PORT_SUPPLY_CHECK, offset=(20, 20), interval=5):
+                buy_retry += 1
+                if buy_retry > buy_retry_limit:
+                    logger.warning(f'Buy retry limit reached for {button.name}, likely not enough coins')
+                    break
                 amount_finish = False
                 self.device.click(button)
                 continue
@@ -252,6 +259,12 @@ class OSShop(PortShop, AkashiShop):
 
             if OCR_SHOP_AMOUNT.ocr(self.device.image) > 1:
                 break
+
+        # 读取游戏端实际允许的最大数量，防止计算的limit超过游戏端限制导致ui_ensure_index死循环
+        game_max = OCR_SHOP_AMOUNT.ocr(self.device.image)
+        if game_max > 0 and limit > game_max:
+            logger.info(f'Calculated limit {limit} exceeds game max {game_max}, using game max')
+            limit = game_max
 
         self.ui_ensure_index(limit, letter=OCR_SHOP_AMOUNT, prev_button=AMOUNT_MINUS, next_button=AMOUNT_PLUS,
                              skip_first_screenshot=True)

--- a/module/os_shop/shop.py
+++ b/module/os_shop/shop.py
@@ -260,11 +260,13 @@ class OSShop(PortShop, AkashiShop):
             if OCR_SHOP_AMOUNT.ocr(self.device.image) > 1:
                 break
 
-        # 读取游戏端实际允许的最大数量，防止计算的limit超过游戏端限制导致ui_ensure_index死循环
-        game_max = OCR_SHOP_AMOUNT.ocr(self.device.image)
-        if game_max > 0 and limit > game_max:
-            logger.info(f'Calculated limit {limit} exceeds game max {game_max}, using game max')
-            limit = game_max
+        # 仅在已点击AMOUNT_MAX时，才能读取游戏端实际允许的最大数量
+        # set_to_max=False时未点击AMOUNT_MAX，界面数量仍为1，不能作为上限依据
+        if set_to_max:
+            game_max = OCR_SHOP_AMOUNT.ocr(self.device.image)
+            if game_max > 0 and limit > game_max:
+                logger.info(f'Calculated limit {limit} exceeds game max {game_max}, using game max')
+                limit = game_max
 
         self.ui_ensure_index(limit, letter=OCR_SHOP_AMOUNT, prev_button=AMOUNT_MINUS, next_button=AMOUNT_PLUS,
                              skip_first_screenshot=True)

--- a/module/ui/ui.py
+++ b/module/ui/ui.py
@@ -345,6 +345,7 @@ class UI(InfoHandler):
             skip_first_screenshot=False,
             fast=True,
             interval=(0.2, 0.3),
+            stall_tolerance=10,
     ):
         """
         确保翻页到指定索引位置，通过 OCR 识别当前页码并点击翻页按钮。
@@ -357,9 +358,13 @@ class UI(InfoHandler):
             skip_first_screenshot (bool): 是否跳过首次截图。
             fast (bool): 默认为 True。当索引不连续时设为 False。
             interval (tuple, int, float): 两次点击之间的间隔（秒）。
+            stall_tolerance (int): 允许索引连续不变的次数，超过后判定为无法达到目标并退出。
         """
         logger.hr("UI ensure index")
         retry = Timer(1, count=2)
+        # 进度停滞检测：记录上一次索引值和连续不变次数，防止因游戏端限制导致死循环
+        last_current = None
+        stall_count = 0
         while 1:
             if skip_first_screenshot:
                 skip_first_screenshot = False
@@ -374,6 +379,17 @@ class UI(InfoHandler):
             logger.attr("Index", current)
             diff = index - current
             if diff == 0:
+                break
+
+            # 进度停滞检测：当连续stall_tolerance次索引值未变化且diff不为0时退出
+            if current == last_current:
+                stall_count += 1
+            else:
+                stall_count = 0
+                last_current = current
+            if stall_count >= stall_tolerance:
+                logger.warning(f'Index stuck at {current} for {stall_count} times, '
+                               f'unable to reach target {index}, skipping')
                 break
 
             if retry.reached():


### PR DESCRIPTION
1. 为OSShop购买流程添加购买重试计数器，达到上限后退出防止无限重试
2. 限制商品购买数量不超过游戏实际允许的最大值
3. 为ui_ensure_index添加停滞检测，防止因游戏限制导致死循环
4. Refs #504 #458 #480 #471 #459

## Summary by Sourcery

通过添加重试计数和停滞检测机制，防止在操作系统商店购买流程和 UI 索引导航过程中出现无限循环和卡死。

Bug Fixes:
- 为操作系统商店购买流程添加重试计数器和上限，当硬币不足时避免出现无限重试。
- 将期望的购买数量限制为游戏报告的最大值，避免出现无法达到的数量选择。
- 在 `ui_ensure_index` 中引入停滞检测，当索引不再向目标前进时停止导航。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent infinite loops and stalls in OS shop purchasing and UI index navigation by adding retry and stall detection safeguards.

Bug Fixes:
- Add a retry counter and limit for OS shop purchases to avoid infinite retries when coins are insufficient.
- Cap the desired purchase quantity to the game-reported maximum to avoid unreachable quantity selection.
- Introduce stall detection in ui_ensure_index to stop navigation when the index stops progressing toward the target.

</details>