### PR TITLE
docs(i18n): update all locale configs for commission notify options

### DIFF
--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -1896,12 +1896,12 @@
       "help": "The 1200 oil commission is now obsolete and the yield is very low. It is recommended to close it."
     },
     "CommissionNotifyReward": {
-      "name": "Commission.CommissionNotifyReward.name",
-      "help": "Commission.CommissionNotifyReward.help"
+      "name": "Commission Reward Push Notification",
+      "help": "Push notification when receiving commission rewards (especially for gems)"
     },
     "CommissionNotifyRewardStatistics": {
-      "name": "Commission.CommissionNotifyRewardStatistics.name",
-      "help": "Commission.CommissionNotifyRewardStatistics.help"
+      "name": "Include Statistics in Push",
+      "help": "Display today/week/month cumulative gem count in notification"
     }
   },
   "Tactical": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -1896,12 +1896,12 @@
       "help": "1200燃料委託は現在では廃止されており、収益が非常に低いです。オフにすることをお勧めします。"
     },
     "CommissionNotifyReward": {
-      "name": "Commission.CommissionNotifyReward.name",
-      "help": "Commission.CommissionNotifyReward.help"
+      "name": "委託報酬プッシュ通知",
+      "help": "委託報酬獲得時に通知を送信（特にダイヤ報酬）"
     },
     "CommissionNotifyRewardStatistics": {
-      "name": "Commission.CommissionNotifyRewardStatistics.name",
-      "help": "Commission.CommissionNotifyRewardStatistics.help"
+      "name": "通知に統計情報を含める",
+      "help": "通知に今日/週間/月間の累積ダイヤ数を表示"
     }
   },
   "Tactical": {

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -1896,12 +1896,12 @@
       "help": "1200油委托现在已经过时，收益很低，建议关闭"
     },
     "CommissionNotifyReward": {
-      "name": "Commission.CommissionNotifyReward.name",
-      "help": "Commission.CommissionNotifyReward.help"
+      "name": "委托奖励推送通知",
+      "help": "获得委托奖励时推送通知（特别关注钻石奖励）"
     },
     "CommissionNotifyRewardStatistics": {
-      "name": "Commission.CommissionNotifyRewardStatistics.name",
-      "help": "Commission.CommissionNotifyRewardStatistics.help"
+      "name": "推送包含统计信息",
+      "help": "在通知中显示今日/本周/本月累计钻石数量"
     }
   },
   "Tactical": {

--- a/module/config/i18n/zh-MIAO.json
+++ b/module/config/i18n/zh-MIAO.json
@@ -1896,12 +1896,12 @@
       "help": "1200油委现已过时收益低，建议关闭喵。 (´・ω・`)"
     },
     "CommissionNotifyReward": {
-      "name": "Commission.CommissionNotifyReward.name",
-      "help": "Commission.CommissionNotifyReward.help"
+      "name": "委托奖励推送通知喵~",
+      "help": "获得委托奖励时推送通知喵（特别关注钻石奖励）！"
     },
     "CommissionNotifyRewardStatistics": {
-      "name": "Commission.CommissionNotifyRewardStatistics.name",
-      "help": "Commission.CommissionNotifyRewardStatistics.help"
+      "name": "推送含统计信息喵~",
+      "help": "通知里会显示今日/本周/本月累计钻石数量喵！"
     }
   },
   "Tactical": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -1896,12 +1896,12 @@
       "help": "1200油委託現在已經過時，收益很低，建議關閉"
     },
     "CommissionNotifyReward": {
-      "name": "Commission.CommissionNotifyReward.name",
-      "help": "Commission.CommissionNotifyReward.help"
+      "name": "委託獎勵推送通知",
+      "help": "獲得委託獎勵時推送通知（特別關注鑽石獎勵）"
     },
     "CommissionNotifyRewardStatistics": {
-      "name": "Commission.CommissionNotifyRewardStatistics.name",
-      "help": "Commission.CommissionNotifyRewardStatistics.help"
+      "name": "推送包含統計資訊",
+      "help": "在通知中顯示今日/本週/本月累計鑽石數量"
     }
   },
   "Tactical": {


### PR DESCRIPTION
替换了所有语言版本的委托奖励推送相关配置的占位文案，补充了清晰的功能说明，统一了各语言的配置描述内容。

## Summary by Sourcery

Documentation:
- 在所有受支持语言的 i18n JSON 配置中更新佣金奖励通知选项文案，使描述更加清晰且一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update commission reward notification option texts in all supported language i18n JSON configs with clearer, consistent descriptions.

</details>