### PR TITLE
fix(island): 岛屿计划每日任务对话后出现的奖励界面会阻塞下一次地图导航

### DIFF
--- a/module/island/island_daily_interact.py
+++ b/module/island/island_daily_interact.py
@@ -219,6 +219,8 @@ class IslandDailyInteract(Island):
                     label=f'{name}交付互动')
             if interact_status == 'clicked':
                 self.handle_island_story_skip_safely()
+                self.device.sleep(2)
+                self._handle_island_reward_optional()
                 return True
             if interact_status == 'complete':
                 return True


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 处理每日任务对话后可选的岛屿奖励界面，防止其阻碍下一步导航操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle optional island reward screen after daily task dialogue to prevent it from obstructing the next navigation action.

</details>