### PR TITLE
feat(config,map): 添加跳过编队准备步骤的配置项

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -240,7 +240,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -321,7 +322,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -402,7 +404,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -500,7 +503,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_all_fleet2_standby"
+      "FleetOrder": "fleet1_all_fleet2_standby",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -585,7 +589,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_all_fleet2_standby"
+      "FleetOrder": "fleet1_all_fleet2_standby",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -670,7 +675,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_all_fleet2_standby"
+      "FleetOrder": "fleet1_all_fleet2_standby",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -752,7 +758,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -833,7 +840,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -914,7 +922,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1057,7 +1066,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1267,7 +1277,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1352,7 +1363,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1437,7 +1449,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1522,7 +1535,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1607,7 +1621,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1688,7 +1703,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -1164,6 +1164,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -1585,6 +1589,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -2006,6 +2014,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -2548,6 +2560,10 @@
           "fleet1_standby_fleet2_all"
         ],
         "display": "display"
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -3054,6 +3070,10 @@
           "fleet1_standby_fleet2_all"
         ],
         "display": "display"
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -3547,6 +3567,10 @@
           "fleet1_standby_fleet2_all"
         ],
         "display": "display"
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -3981,6 +4005,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -4418,6 +4446,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -4854,6 +4886,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -5603,6 +5639,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -6948,6 +6988,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -7402,6 +7446,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -7856,6 +7904,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -8310,6 +8362,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -8764,6 +8820,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -9208,6 +9268,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -430,6 +430,8 @@ Fleet:
         fleet1_all_fleet2_standby,
         fleet1_standby_fleet2_all,
       ]
+  SkipPreparation:
+    value: false
 Submarine:
   Fleet:
     value: 0

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -224,6 +224,7 @@ class GeneratedConfig:
     Fleet_Fleet2Mode = 'combat_auto'  # combat_auto, combat_manual, stand_still_in_the_middle, hide_in_bottom_left, hide_in_upper_left
     Fleet_Fleet2Step = 2  # 2, 3, 4, 5
     Fleet_FleetOrder = 'fleet1_mob_fleet2_boss'  # fleet1_mob_fleet2_boss, fleet1_boss_fleet2_mob, fleet1_all_fleet2_standby, fleet1_standby_fleet2_all
+    Fleet_SkipPreparation = False
 
     # 配置组 `Submarine`
     Submarine_Fleet = 0  # 0, 1, 2

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -1376,6 +1376,10 @@
       "fleet1_boss_fleet2_mob": "Fleet 1 Boss, Fleet 2 Mob",
       "fleet1_all_fleet2_standby": "Fleet 1 Clears All, Fleet 2 Standby",
       "fleet1_standby_fleet2_all": "Fleet 1 Standby, Fleet 2 Clears All"
+    },
+    "SkipPreparation": {
+      "name": "Skip Fleet Preparation",
+      "help": "Skip the fleet selection step in the fleet preparation screen and use the game's current pre-selected fleet.\nUseful for accounts that have not unlocked all fleet slots, avoiding dropdown menu detection freeze.\nMake sure you have manually selected Fleet 1 and Fleet 2 in-game before enabling."
     }
   },
   "Submarine": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -1376,6 +1376,10 @@
       "fleet1_boss_fleet2_mob": "第一艦隊BOSS 第二艦隊道中",
       "fleet1_all_fleet2_standby": "第一艦隊全滅 第二艦隊待機",
       "fleet1_standby_fleet2_all": "第一艦隊待機 第二艦隊全滅"
+    },
+    "SkipPreparation": {
+      "name": "Fleet.SkipPreparation.name",
+      "help": "Fleet.SkipPreparation.help"
     }
   },
   "Submarine": {

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -1376,6 +1376,10 @@
       "fleet1_boss_fleet2_mob": "一队boss二队道中",
       "fleet1_all_fleet2_standby": "一队全清二队待机",
       "fleet1_standby_fleet2_all": "一队待机二队全清"
+    },
+    "SkipPreparation": {
+      "name": "跳过编队检测",
+      "help": "开启后将跳过编队界面的舰队选择步骤，直接使用游戏内当前预选的舰队出击\n适用于舰队槽位未完全解锁的账号，避免下拉菜单检测卡死\n开启前请确保游戏内已手动选好舰队1和舰队2"
     }
   },
   "Submarine": {

--- a/module/config/i18n/zh-MIAO.json
+++ b/module/config/i18n/zh-MIAO.json
@@ -1376,6 +1376,10 @@
       "fleet1_boss_fleet2_mob": "一队boss 二队道中喵",
       "fleet1_all_fleet2_standby": "一队全清 二队待机喵",
       "fleet1_standby_fleet2_all": "一队待机 二队全清喵"
+    },
+    "SkipPreparation": {
+      "name": "Fleet.SkipPreparation.name",
+      "help": "Fleet.SkipPreparation.help"
     }
   },
   "Submarine": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -1376,6 +1376,10 @@
       "fleet1_boss_fleet2_mob": "一隊boss二隊道中",
       "fleet1_all_fleet2_standby": "一隊全清二隊待機",
       "fleet1_standby_fleet2_all": "一隊待機二隊全清"
+    },
+    "SkipPreparation": {
+      "name": "Fleet.SkipPreparation.name",
+      "help": "Fleet.SkipPreparation.help"
     }
   },
   "Submarine": {

--- a/module/map/map_fleet_preparation.py
+++ b/module/map/map_fleet_preparation.py
@@ -317,6 +317,13 @@ class FleetPreparation(InfoHandler):
         if self.map_fleet_checked:
             return False
 
+        # 跳过编队检测：信任游戏内当前预选的舰队，不操作下拉菜单
+        # 适用于舰队槽位未完全解锁的账号，避免下拉菜单检测卡死
+        if self.config.Fleet_SkipPreparation:
+            logger.info('Skip fleet preparation (Fleet_SkipPreparation=True), '
+                        'use current pre-selected fleet in game')
+            return True
+
         if self.appear(FLEET_1_CLEAR, offset=FleetOperator.OFFSET):
             AUTO_SEARCH_SET_MOB.load_offset(FLEET_1_CLEAR)
             AUTO_SEARCH_SET_BOSS.load_offset(FLEET_1_CLEAR)


### PR DESCRIPTION
新增Fleet_SkipPreparation配置项，允许用户跳过编队界面的舰队选择步骤，直接使用游戏内已预选的舰队。该功能适用于未解锁全部舰队槽位的账号，可避免下拉菜单检测导致的卡死问题，同时在多国语言文件中补充了对应配置的翻译与说明。

## Summary by Sourcery

添加一个配置选项，用于跳过舰队准备检查并使用当前在游戏中选择的舰队。

新特性：
- 引入 `Fleet_SkipPreparation` 配置，以在准备阶段绕过舰队选择，直接使用游戏内预先选定的舰队。

文档：
- 为新的 `Fleet_SkipPreparation` 配置选项添加多语言描述和标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configuration option to allow skipping fleet preparation checks and using the currently selected in-game fleet.

New Features:
- Introduce Fleet_SkipPreparation config to bypass fleet selection in the preparation step and rely on the in-game preselected fleet.

Documentation:
- Add multilingual descriptions and labels for the new Fleet_SkipPreparation configuration option.

</details>