### PR TITLE
fix(server_checker): 处理API 404时新增本地列表校验 

### DIFF
--- a/module/server_checker.py
+++ b/module/server_checker.py
@@ -73,8 +73,14 @@ class ServerChecker:
                     if self._expired > 3:
                         logger.warning(f'Timestamp {self._timestamp} has not been updated for 3 times.')
             elif resp.status_code == 404:
-                self._state.append(False)
-                raise ScriptError(f'Server "{self._server}" does not exist!')
+                # API 数据库可能未收录新增服务器（如"长弓计划"），
+                # 检查本地服务器列表确认该服务器是否真实存在
+                if self._server_in_local_list():
+                    self._state.append(True)
+                    logger.info(f'Server "{self._server}" is available (local verified, API unknown).')
+                else:
+                    self._state.append(False)
+                    raise ScriptError(f'Server "{self._server}" does not exist!')
             else:
                 raise ScriptError(f'Get status_code {resp.status_code}. Response is {resp.text}')
         except (requests.exceptions.ConnectionError, requests.exceptions.ConnectTimeout) as e:
@@ -127,6 +133,20 @@ class ServerChecker:
             self._state.append(True)
         except Exception as e:
             raise e
+
+    def _server_in_local_list(self) -> bool:
+        """
+        检查服务器名称是否存在于本地 VALID_SERVER_LIST 中。
+
+        当 API 返回 404 时，用于区分"服务器不存在"和"API 数据库未收录"两种情况。
+
+        Returns:
+            bool: 本地列表中存在该服务器时返回 True。
+        """
+        for servers in server_list.values():
+            if self._server in servers:
+                return True
+        return False
 
     def reset(self) -> None:
         self._timestamp = 0


### PR DESCRIPTION
#553 
当API返回404时，区分服务器不存在和API未收录新增服务器的情况，优先使用本地列表进行验证

## Summary by Sourcery

通过根据本地服务器列表验证服务器来处理 API 的 404 响应，以区分不存在的服务器和新添加的服务器。

Bug 修复：
- 当 API 返回 404 时，防止将新添加且在本地已知的服务器误判为不存在。

增强功能：
- 当 API 数据库无法识别某个服务器时，引入基于本地服务器列表的校验作为回退机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle API 404 responses by validating servers against the local list to distinguish non-existent servers from newly added ones.

Bug Fixes:
- Prevent misclassifying newly added, locally known servers as non-existent when the API returns 404.

Enhancements:
- Introduce local server list verification as a fallback when the API database does not recognize a server.

</details>