### PR TITLE
修复了一些问题

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -240,7 +240,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -321,7 +322,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -402,7 +404,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -500,7 +503,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_all_fleet2_standby"
+      "FleetOrder": "fleet1_all_fleet2_standby",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -585,7 +589,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_all_fleet2_standby"
+      "FleetOrder": "fleet1_all_fleet2_standby",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -670,7 +675,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_all_fleet2_standby"
+      "FleetOrder": "fleet1_all_fleet2_standby",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -752,7 +758,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -833,7 +840,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -914,7 +922,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1057,7 +1066,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1267,7 +1277,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1352,7 +1363,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1437,7 +1449,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1522,7 +1535,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1607,7 +1621,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,
@@ -1688,7 +1703,8 @@
       "Fleet2Formation": "double_line",
       "Fleet2Mode": "combat_auto",
       "Fleet2Step": 2,
-      "FleetOrder": "fleet1_mob_fleet2_boss"
+      "FleetOrder": "fleet1_mob_fleet2_boss",
+      "SkipPreparation": false
     },
     "Submarine": {
       "Fleet": 0,

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -1164,6 +1164,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -1585,6 +1589,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -2006,6 +2014,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -2548,6 +2560,10 @@
           "fleet1_standby_fleet2_all"
         ],
         "display": "display"
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -3054,6 +3070,10 @@
           "fleet1_standby_fleet2_all"
         ],
         "display": "display"
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -3547,6 +3567,10 @@
           "fleet1_standby_fleet2_all"
         ],
         "display": "display"
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -3981,6 +4005,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -4418,6 +4446,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -4854,6 +4886,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -5603,6 +5639,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -6948,6 +6988,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -7402,6 +7446,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -7856,6 +7904,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -8310,6 +8362,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -8764,6 +8820,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {
@@ -9208,6 +9268,10 @@
           "fleet1_all_fleet2_standby",
           "fleet1_standby_fleet2_all"
         ]
+      },
+      "SkipPreparation": {
+        "type": "checkbox",
+        "value": false
       }
     },
     "Submarine": {

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -430,6 +430,8 @@ Fleet:
         fleet1_all_fleet2_standby,
         fleet1_standby_fleet2_all,
       ]
+  SkipPreparation:
+    value: false
 Submarine:
   Fleet:
     value: 0

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -224,6 +224,7 @@ class GeneratedConfig:
     Fleet_Fleet2Mode = 'combat_auto'  # combat_auto, combat_manual, stand_still_in_the_middle, hide_in_bottom_left, hide_in_upper_left
     Fleet_Fleet2Step = 2  # 2, 3, 4, 5
     Fleet_FleetOrder = 'fleet1_mob_fleet2_boss'  # fleet1_mob_fleet2_boss, fleet1_boss_fleet2_mob, fleet1_all_fleet2_standby, fleet1_standby_fleet2_all
+    Fleet_SkipPreparation = False
 
     # 配置组 `Submarine`
     Submarine_Fleet = 0  # 0, 1, 2

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -1376,6 +1376,10 @@
       "fleet1_boss_fleet2_mob": "Fleet 1 Boss, Fleet 2 Mob",
       "fleet1_all_fleet2_standby": "Fleet 1 Clears All, Fleet 2 Standby",
       "fleet1_standby_fleet2_all": "Fleet 1 Standby, Fleet 2 Clears All"
+    },
+    "SkipPreparation": {
+      "name": "Skip Fleet Preparation",
+      "help": "Skip the fleet selection step in the fleet preparation screen and use the game's current pre-selected fleet.\nUseful for accounts that have not unlocked all fleet slots, avoiding dropdown menu detection freeze.\nMake sure you have manually selected Fleet 1 and Fleet 2 in-game before enabling."
     }
   },
   "Submarine": {

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -1376,6 +1376,10 @@
       "fleet1_boss_fleet2_mob": "第一艦隊BOSS 第二艦隊道中",
       "fleet1_all_fleet2_standby": "第一艦隊全滅 第二艦隊待機",
       "fleet1_standby_fleet2_all": "第一艦隊待機 第二艦隊全滅"
+    },
+    "SkipPreparation": {
+      "name": "Fleet.SkipPreparation.name",
+      "help": "Fleet.SkipPreparation.help"
     }
   },
   "Submarine": {

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -1376,6 +1376,10 @@
       "fleet1_boss_fleet2_mob": "一队boss二队道中",
       "fleet1_all_fleet2_standby": "一队全清二队待机",
       "fleet1_standby_fleet2_all": "一队待机二队全清"
+    },
+    "SkipPreparation": {
+      "name": "跳过编队检测",
+      "help": "开启后将跳过编队界面的舰队选择步骤，直接使用游戏内当前预选的舰队出击\n适用于舰队槽位未完全解锁的账号，避免下拉菜单检测卡死\n开启前请确保游戏内已手动选好舰队1和舰队2"
     }
   },
   "Submarine": {

--- a/module/config/i18n/zh-MIAO.json
+++ b/module/config/i18n/zh-MIAO.json
@@ -1376,6 +1376,10 @@
       "fleet1_boss_fleet2_mob": "一队boss 二队道中喵",
       "fleet1_all_fleet2_standby": "一队全清 二队待机喵",
       "fleet1_standby_fleet2_all": "一队待机 二队全清喵"
+    },
+    "SkipPreparation": {
+      "name": "Fleet.SkipPreparation.name",
+      "help": "Fleet.SkipPreparation.help"
     }
   },
   "Submarine": {

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -1376,6 +1376,10 @@
       "fleet1_boss_fleet2_mob": "一隊boss二隊道中",
       "fleet1_all_fleet2_standby": "一隊全清二隊待機",
       "fleet1_standby_fleet2_all": "一隊待機二隊全清"
+    },
+    "SkipPreparation": {
+      "name": "Fleet.SkipPreparation.name",
+      "help": "Fleet.SkipPreparation.help"
     }
   },
   "Submarine": {

--- a/module/island/island_daily_order.py
+++ b/module/island/island_daily_order.py
@@ -55,6 +55,7 @@ class IslandDailyOrder(Island):
     FAST_POPUP_CHECK_INTERVAL = 0.5
     REWARD_POPUP_CHECK_INTERVAL = 2
     REWARD_POPUP_CHECK_LIMIT = 5
+    DAILY_RUN_HOUR = 3
     URGENT_TEMPLATE_PREFIX = 'TEMPLATE_DAILY_ORDER_URGENT'
     _urgent_template_cache = None
 
@@ -301,7 +302,7 @@ class IslandDailyOrder(Island):
                 self._reenter()
                 continue
             elif result == 'next_day':
-                self._delay_to_next_day()
+                self._delay_to_next_daily_run()
                 break
             elif result == 'to_step3':
                 pass  # 进入 ③
@@ -314,7 +315,7 @@ class IslandDailyOrder(Island):
                 self._reenter()
                 continue
             elif result == 'next_day':
-                self._delay_to_next_day()
+                self._delay_to_next_daily_run()
                 break
             elif result == 'to_step2':
                 continue  # 回到 ②（由 _step_right_panel 处理）
@@ -326,7 +327,7 @@ class IslandDailyOrder(Island):
             if result == 'wait':
                 break  # 延时等待
             elif result == 'next_day':
-                self._delay_to_next_day()
+                self._delay_to_next_daily_run()
                 break
             elif result == 'normal':
                 break
@@ -413,7 +414,7 @@ class IslandDailyOrder(Island):
         if self._is_right_panel_empty():
             if self._first_right_panel_check:
                 self._first_right_panel_check = False
-                logger.info('[岛屿-每日订单] 首次进入右侧为空，延时到第二天')
+                logger.info('[岛屿-每日订单] 首次进入右侧为空，延时到下一个 03:00')
                 return 'next_day'
             else:
                 logger.info('[岛屿-每日订单] 右侧为空，退出重进')
@@ -531,7 +532,7 @@ class IslandDailyOrder(Island):
         ④ 退出判断。
 
         Returns:
-            str: 'wait' → OCR 等待; 'next_day' → 第二天; 'normal' → 正常退出
+            str: 'wait' → OCR 等待; 'next_day' → 下一个 03:00; 'normal' → 正常退出
         """
         self.device.screenshot()
 
@@ -547,7 +548,7 @@ class IslandDailyOrder(Island):
                 self.config.task_delay(minute=60)
             return 'wait'
         else:
-            logger.info('[岛屿-每日订单] 右侧不是筹备中，延时到第二天')
+            logger.info('[岛屿-每日订单] 右侧不是筹备中，延时到下一个 03:00')
             return 'next_day'
 
     # ==================== 辅助方法 ====================
@@ -648,13 +649,16 @@ class IslandDailyOrder(Island):
                 continue
             self.device.sleep(0.5)
 
-    def _delay_to_next_day(self):
-        """延时到第二天。"""
-        tomorrow = current_time().replace(
-            hour=0, minute=0, second=0, microsecond=0
-        ) + timedelta(days=1)
-        self.config.task_delay(target=tomorrow)
-        logger.info(f'[岛屿-每日订单] 延时到 {tomorrow}')
+    def _delay_to_next_daily_run(self):
+        """延时到下一个每日运行时间（03:00）。"""
+        now = current_time()
+        target = now.replace(
+            hour=self.DAILY_RUN_HOUR, minute=0, second=0, microsecond=0
+        )
+        if target <= now:
+            target += timedelta(days=1)
+        self.config.task_delay(target=target)
+        logger.info(f'[岛屿-每日订单] 下次每日订单运行时间: {target}')
 
     def _handle_popups(self):
         """处理弹窗。"""

--- a/module/map/map_fleet_preparation.py
+++ b/module/map/map_fleet_preparation.py
@@ -317,6 +317,13 @@ class FleetPreparation(InfoHandler):
         if self.map_fleet_checked:
             return False
 
+        # 跳过编队检测：信任游戏内当前预选的舰队，不操作下拉菜单
+        # 适用于舰队槽位未完全解锁的账号，避免下拉菜单检测卡死
+        if self.config.Fleet_SkipPreparation:
+            logger.info('Skip fleet preparation (Fleet_SkipPreparation=True), '
+                        'use current pre-selected fleet in game')
+            return True
+
         if self.appear(FLEET_1_CLEAR, offset=FleetOperator.OFFSET):
             AUTO_SEARCH_SET_MOB.load_offset(FLEET_1_CLEAR)
             AUTO_SEARCH_SET_BOSS.load_offset(FLEET_1_CLEAR)

--- a/module/os/tasks/meowfficer_farming.py
+++ b/module/os/tasks/meowfficer_farming.py
@@ -50,8 +50,12 @@ class MeowfficerTargetZoneMixin:
         raw_value = self.config.OpsiMeowfficerFarming_TargetZone
         if not tokens:
             if require_target:
-                logger.warning('[大世界-短猫相接] 已启用 StayInZone 但未设置 TargetZone，跳过本次任务')
-                self.config.task_delay(server_update=True)
+                message = '已启用 StayInZone 但未设置 TargetZone'
+                logger.warning(f'[大世界-短猫相接] {message}，跳过本次任务')
+                if self.is_running_smart_scheduling_task():
+                    self._handle_coin_task_no_content('短猫相接', message)
+                    return []
+                self.delay_opsi_active_task(server_update=True)
                 self.config.task_stop()
             return []
 
@@ -234,8 +238,10 @@ class OpsiMeowfficerFarming(MeowfficerTargetZoneMixin, CoinTaskMixin, OSMap):
             .sort_by_clock_degree(center=(1252, 1012), start=self.zone.location)
 
         if not zones:
-            logger.warning(f'[大世界-短猫相接] 普通搜索模式：未找到符合条件的海域 (侵蚀等级 {hazard_level})')
-            return
+            message = f'普通搜索模式未找到符合条件的海域 (侵蚀等级 {hazard_level})'
+            logger.warning(f'[大世界-短猫相接] {message}')
+            self._handle_coin_task_no_content('短猫相接', message)
+            return False
 
         logger.hr(f'OS meowfficer farming, zone_id={zones[0].zone_id}', level=1)
 
@@ -310,6 +316,8 @@ class OpsiMeowfficerFarming(MeowfficerTargetZoneMixin, CoinTaskMixin, OSMap):
         self._meow_target_zone_index = getattr(self, '_meow_target_zone_index', 0)
         if self.config.OpsiMeowfficerFarming_StayInZone:
             self._meow_target_zone_list = self._meow_target_zones(require_target=True, allow_multiple=True)
+            if not self._meow_target_zone_list:
+                return None
         elif target_zone_tokens:
             self._meow_traditional_zone = self._meow_target_zones(require_target=False, allow_multiple=False)[0]
 

--- a/module/os/tasks/prevent_action_point_overflow.py
+++ b/module/os/tasks/prevent_action_point_overflow.py
@@ -200,6 +200,18 @@ class OpsiPreventActionPointOverflow(OpsiScheduling):
                 self.update_prevent_action_point_overflow_schedule(current_ap=current, enable=True)
                 self.config.task_stop()
             except TaskEnd:
+                delay_request = getattr(self, self.RUNTIME_ATTR_PREVENT_OVERFLOW_DELAY, None)
+                if hasattr(self, self.RUNTIME_ATTR_PREVENT_OVERFLOW_DELAY):
+                    delattr(self, self.RUNTIME_ATTR_PREVENT_OVERFLOW_DELAY)
+                if delay_request is not None:
+                    args, kwargs = delay_request
+                    logger.info('[大世界-防溢出] 应用代理子任务请求的延迟时间')
+                    self.config.task_delay(
+                        *args,
+                        task=self.TASK_NAME_PREVENT_AP_OVERFLOW,
+                        **kwargs,
+                    )
+                    raise
                 try:
                     current_ap = self._get_current_action_point_for_overflow()
                 except Exception:

--- a/module/os/tasks/scheduling.py
+++ b/module/os/tasks/scheduling.py
@@ -71,6 +71,12 @@ class CoinTaskMixin:
     CONFIG_PATH_SMART_STATE = 'OpsiScheduling.Storage.Storage'
     STATE_KEY_COIN_REPLENISH_START = 'CoinReplenishStart'
     STATE_KEY_AP_REPLENISH_ACTIVE = 'ApReplenishActive'
+    STATE_KEY_SCHEDULING_MODE = 'SchedulingMode'
+    SCHEDULING_MODE_COIN_TARGET = 'coin_target'
+    SCHEDULING_MODE_ACTION_POINT = 'action_point'
+    RUNTIME_ATTR_LAST_NOTIFIED_COIN_TASK = '_smart_scheduling_last_notified_coin_task'
+    RUNTIME_ATTR_LAST_COIN_TASK_NOTIFICATION_ATTEMPT = '_smart_scheduling_last_coin_task_notification_attempt'
+    RUNTIME_ATTR_PREVENT_OVERFLOW_DELAY = '_prevent_action_point_overflow_delay'
     # 各任务的配置路径常量（集中管理，避免硬编码）
     CONFIG_PATH_MEOW_AP_PRESERVE = 'OpsiMeowfficerFarming.OpsiMeowfficerFarming.ActionPointPreserve'
     CONFIG_PATH_CL1_MIN_AP_RESERVE = 'OpsiHazard1Leveling.OpsiHazard1Leveling.MinimumActionPointReserve'
@@ -111,17 +117,76 @@ class CoinTaskMixin:
         """
         延迟当前实际执行的大世界子任务。
 
-        当 OpsiScheduling 代执行 CL1/短猫时，config.task 会临时同步为
-        实际子任务。此 helper 仍允许显式指定要延迟的任务。
+        当 OpsiScheduling 代执行子任务时，将子任务延迟映射到智能调度；
+        防溢出代跑时由防溢出任务统一更新下次运行时间。
         """
         if self.is_running_smart_scheduling_task():
-            logger.info('[大世界-智能调度] 智能调度代理执行中，跳过对子任务调度时间的修改')
+            self._clear_coin_task_notification_state()
+            if self.is_running_prevent_action_point_overflow_task():
+                kwargs.pop('task', None)
+                setattr(
+                    self,
+                    self.RUNTIME_ATTR_PREVENT_OVERFLOW_DELAY,
+                    (args, kwargs),
+                )
+                logger.info('[大世界-智能调度] 已将子任务延迟请求交给防溢出任务')
+                return
+
+            kwargs.pop('task', None)
+            if kwargs.get('server_update') is True:
+                kwargs['server_update'] = self.config.cross_get(
+                    keys=f'{self.TASK_NAME_SCHEDULING}.Scheduler.ServerUpdate',
+                    default='00:00',
+                )
+            logger.info('[大世界-智能调度] 将子任务延迟映射到智能调度任务')
+            self.config.task_delay(
+                *args,
+                task=self.TASK_NAME_SCHEDULING,
+                **kwargs,
+            )
             return
 
         task = kwargs.pop('task', None)
         if task is None:
             task = self._get_current_coin_task_name()
         self.config.task_delay(*args, task=task, **kwargs)
+
+    def _is_direct_prevent_overflow_coin_task(self):
+        """判断防溢出任务是否正在直接代跑黄币补充任务。"""
+        if not self.is_running_prevent_action_point_overflow_task():
+            return False
+        owner = getattr(self.config, '_task_switch_owner', None)
+        return getattr(owner, 'command', None) == 'OpsiPreventActionPointOverflow'
+
+    def _clear_coin_task_notification_state(self):
+        """清理本轮补币阶段的通知成功和尝试状态。"""
+        for key in (
+            self.RUNTIME_ATTR_LAST_NOTIFIED_COIN_TASK,
+            self.RUNTIME_ATTR_LAST_COIN_TASK_NOTIFICATION_ATTEMPT,
+        ):
+            if hasattr(self.config, key):
+                delattr(self.config, key)
+
+    def _delay_smart_scheduling_to_server_update(self, reason):
+        """将实际运行智能调度的任务延迟到服务器刷新。"""
+        self._clear_coin_task_notification_state()
+        if self.is_running_prevent_action_point_overflow_task():
+            setattr(
+                self,
+                self.RUNTIME_ATTR_PREVENT_OVERFLOW_DELAY,
+                ((), {'server_update': True}),
+            )
+            logger.info(f'[大世界-智能调度] {reason}，防溢出任务延迟到服务器刷新')
+            return
+
+        logger.info(f'[大世界-智能调度] {reason}，智能调度延迟到服务器刷新')
+        self.config.task_delay(
+            server_update=self.config.cross_get(
+                keys=f'{self.TASK_NAME_SCHEDULING}.Scheduler.ServerUpdate',
+                default='00:00',
+            ),
+            task=self.TASK_NAME_SCHEDULING,
+        )
     
     # ==================== 推送通知相关方法 ====================
     
@@ -274,18 +339,23 @@ class CoinTaskMixin:
 
     def _can_send_ap_notification(self, key):
         """
-        限制体力相关推送的最小发送间隔，避免高频通知。
+        限制体力相关推送尝试的最小间隔，避免失败时高频重试。
         """
         now = current_time()
-        last_notify = getattr(self.config, key, None)
+        attempt_key = f'{key}_attempt'
+        last_notify = getattr(self.config, attempt_key, None) or getattr(self.config, key, None)
         min_interval = timedelta(minutes=self.AP_NOTIFY_MIN_INTERVAL_MINUTES)
         if last_notify and now - last_notify < min_interval:
             logger.info(
                 f"Skip AP notification ({key}, last: {last_notify}, wait {self.AP_NOTIFY_MIN_INTERVAL_MINUTES}m)"
             )
             return False
-        setattr(self.config, key, now)
+        setattr(self.config, attempt_key, now)
         return True
+
+    def _mark_ap_notification_sent(self, key):
+        """仅在至少一个通知渠道发送成功后记录成功时间。"""
+        setattr(self.config, key, current_time())
     
     def check_and_notify_action_point_threshold(self):
         """
@@ -299,35 +369,40 @@ class CoinTaskMixin:
 
         instance_name = getattr(self.config, 'config_name', 'default')
         # AP 快照由各任务模块自行管理（如 _record_ap_and_coins），此处仅保留推送逻辑。
-        if self._can_send_ap_notification('_last_ap_notification_time'):
-            previous_ap = None
+        previous_ap = None
+        try:
+            from module.statistics.cl1_database import db as cl1_db
+            last_notification = cl1_db.get_last_ap_notification(instance_name)
+            if isinstance(last_notification, dict):
+                previous_ap = last_notification.get('ap')
+        except Exception:
+            logger.exception('Failed to load last AP notification')
+
+        content = f"总行动力: {total_ap}"
+        if previous_ap is not None:
+            ap_delta = total_ap - previous_ap
+            if ap_delta == 0:
+                logger.info('[大世界-智能调度] 行动力未发生变化，跳过推送通知')
+                return
+            if ap_delta > 0:
+                content = f"总行动力: {total_ap} 上涨{ap_delta}行动力"
+            else:
+                content = f"总行动力: {total_ap} 下跌{abs(ap_delta)}行动力"
+
+        if not self._can_send_ap_notification('_last_ap_notification_time'):
+            return
+
+        pushed = self.notify_push(
+            title="[AzurPilot] 行动力出现变化！",
+            content=content
+        )
+        if pushed:
+            self._mark_ap_notification_sent('_last_ap_notification_time')
             try:
                 from module.statistics.cl1_database import db as cl1_db
-                last_notification = cl1_db.get_last_ap_notification(instance_name)
-                if isinstance(last_notification, dict):
-                    previous_ap = last_notification.get('ap')
+                cl1_db.async_set_last_ap_notification(instance_name, total_ap)
             except Exception:
-                logger.exception('Failed to load last AP notification')
-
-            content = f"总行动力: {total_ap}"
-
-            if previous_ap is not None:
-                ap_delta = total_ap - previous_ap
-                if ap_delta >= 0:
-                    content = f"总行动力: {total_ap} 上涨{ap_delta}行动力"
-                else:
-                    content = f"总行动力: {total_ap} 下跌{abs(ap_delta)}行动力"
-
-            pushed = self.notify_push(
-                title="[AzurPilot] 行动力出现变化！",
-                content=content
-            )
-            if pushed:
-                try:
-                    from module.statistics.cl1_database import db as cl1_db
-                    cl1_db.async_set_last_ap_notification(instance_name, total_ap)
-                except Exception:
-                    logger.exception('Failed to save last AP notification')
+                logger.exception('Failed to save last AP notification')
 
     
     def _get_smart_scheduling_operation_coins_preserve(self):
@@ -494,6 +569,36 @@ class CoinTaskMixin:
             )
         )
 
+    def _sync_smart_scheduling_mode_state(self, coin_target_scheduling):
+        """同步调度模式，并清理另一模式遗留的补黄币状态。"""
+        current_mode = (
+            self.SCHEDULING_MODE_COIN_TARGET
+            if coin_target_scheduling
+            else self.SCHEDULING_MODE_ACTION_POINT
+        )
+        state = self._get_smart_scheduling_state()
+        previous_mode = state.get(self.STATE_KEY_SCHEDULING_MODE)
+        if previous_mode == current_mode:
+            return
+
+        if previous_mode is None:
+            if coin_target_scheduling:
+                state.pop(self.STATE_KEY_AP_REPLENISH_ACTIVE, None)
+            else:
+                state.pop(self.STATE_KEY_COIN_REPLENISH_START, None)
+        else:
+            state.pop(self.STATE_KEY_COIN_REPLENISH_START, None)
+            state.pop(self.STATE_KEY_AP_REPLENISH_ACTIVE, None)
+            self._clear_coin_task_notification_state()
+            logger.info(
+                f'[大世界-智能调度] 调度模式由 {previous_mode} 切换为 {current_mode}，'
+                '已清理旧模式运行状态'
+            )
+
+        state[self.STATE_KEY_SCHEDULING_MODE] = current_mode
+        self.config.modified[self.CONFIG_PATH_SMART_STATE] = state
+        self.config.save()
+
     def _get_effective_cl1_ap_preserve(self):
         """
         获取智能调度下侵蚀 1 使用的行动力保留值。
@@ -564,10 +669,14 @@ class CoinTaskMixin:
             if '没有更多' not in log_message:
                 self._smart_scheduling_no_content_task = task_name
             logger.info(f'[大世界-智能调度] 智能调度代理执行中，{task_display_name}无可执行内容')
+            if self._is_direct_prevent_overflow_coin_task():
+                self.delay_opsi_active_task(server_update=True)
+                self.config.task_stop()
             return True
 
         if self.is_smart_scheduling_enabled():
             logger.info(f'[大世界-智能调度] 智能调度已启用，{task_display_name}无可执行内容')
+            self.config.task_delay(server_update=True)
             self.config.task_stop()
 
         with self.config.multi_set():
@@ -724,16 +833,21 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
                 coin_status = f'黄币 {yellow_coins} 低于补黄币目标 {coin_target}'
             else:
                 coin_status = f'黄币 {yellow_coins} 已达到补黄币阈值 {coin_target}'
-            self.notify_push(
-                title='[AzurPilot] 防止行动力溢出 - 执行短猫',
-                content=(
-                    f'{coin_status}\n'
-                    f'总行动力 {total_ap} 低于补黄币保留 {meow_ap_preserve}\n'
-                    f'由 OpsiScheduling 直接执行短猫清理当前行动力 {current_ap}'
-                )
-            )
             self.handle_first_auto_search(run=True)
-            self._run_scheduled_meowfficer_farming(0)
+            if self._run_scheduled_coin_task_once(self.TASK_NAME_MEOWFFICER_FARMING, 0):
+                self.notify_push(
+                    title='[AzurPilot] 防止行动力溢出 - 已执行短猫',
+                    content=(
+                        f'{coin_status}\n'
+                        f'总行动力 {total_ap} 低于补黄币保留 {meow_ap_preserve}\n'
+                        f'已由 OpsiScheduling 执行一轮短猫清理当前行动力 {current_ap}'
+                    )
+                )
+                return
+
+            logger.warning('[大世界-防溢出] 短猫无可执行内容，无法继续清理当前行动力')
+            self._delay_smart_scheduling_to_server_update('短猫无可执行内容')
+            self.config.task_stop()
             return
 
         self._notify_coins_ap_insufficient(yellow_coins, total_ap, coin_target, meow_ap_preserve)
@@ -802,8 +916,7 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
         """
         logger.warning(f'[大世界-智能调度] 行动力达到最低保留 ({total_ap} <= {min_ap_reserve})')
         self._notify_ap_insufficient(total_ap, min_ap_reserve)
-        logger.info('[大世界-智能调度] 行动力不足，智能调度延迟到下次服务器刷新')
-        self.config.task_delay(server_update=True, task=self.TASK_NAME_SCHEDULING)
+        self._delay_smart_scheduling_to_server_update('行动力不足')
         self.config.task_stop()
 
     def run_smart_scheduling_once(self):
@@ -814,6 +927,7 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
         cl1_ap_preserve = self._get_effective_cl1_ap_preserve()
         meow_ap_preserve = self._get_coin_task_action_point_preserve()
         coin_target_scheduling = self._is_coin_target_scheduling_enabled()
+        self._sync_smart_scheduling_mode_state(coin_target_scheduling)
         coin_replenish_active = self._is_coin_replenish_active()
         ap_replenish_active = self._is_ap_replenish_active()
 
@@ -873,22 +987,31 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
                 if total_ap <= meow_ap_preserve:
                     logger.info(f'[大世界-智能调度] 行动力已达到体力调度阈值 ({total_ap} <= {meow_ap_preserve})，停止补黄币')
                     self._clear_ap_replenish_active()
-                    self._handle_smart_scheduling_no_task(
+                    overflow_cleanup = (
+                        self.is_running_prevent_action_point_overflow_task()
+                        and current_ap > 0
+                    )
+                    if yellow_coins < cl1_preserve or overflow_cleanup:
+                        self._handle_smart_scheduling_no_task(
+                            yellow_coins,
+                            total_ap,
+                            current_ap,
+                            cl1_preserve,
+                            meow_ap_preserve,
+                        )
+                        return
+                    logger.info(
+                        f'[大世界-智能调度] 黄币已补足 ({yellow_coins} >= {cl1_preserve})，'
+                        '恢复侵蚀1练级'
+                    )
+                else:
+                    self._dispatch_coin_task(
                         yellow_coins,
                         total_ap,
-                        current_ap,
                         cl1_preserve,
                         meow_ap_preserve,
                     )
                     return
-
-                self._dispatch_coin_task(
-                    yellow_coins,
-                    total_ap,
-                    cl1_preserve,
-                    meow_ap_preserve,
-                )
-                return
 
             if total_ap <= cl1_ap_preserve:
                 self._delay_smart_scheduling_for_ap_limit(total_ap, cl1_ap_preserve)
@@ -931,13 +1054,15 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
         if not self._can_send_ap_notification('_last_ap_coins_insufficient_notification_time'):
             return
         
-        self.notify_push(
+        pushed = self.notify_push(
             title="[AzurPilot] 智能调度 - 黄币与行动力双重不足",
             content=(
                 f"黄币: {yellow_coins}，补黄币阈值: {coin_target}\n"
                 f"总行动力 {total_ap} 不足 (需要 {meow_ap_preserve})\n推迟任务"
             )
         )
+        if pushed:
+            self._mark_ap_notification_sent('_last_ap_coins_insufficient_notification_time')
     
     def _notify_ap_insufficient(self, total_ap, min_reserve):
         """
@@ -949,10 +1074,12 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
         if not self._can_send_ap_notification('_last_ap_insufficient_notification_time'):
             return
         
-        self.notify_push(
+        pushed = self.notify_push(
             title="[AzurPilot] 智能调度 - 行动力不足",
             content=f"总行动力 {total_ap} 低于最低保留 {min_reserve}，推迟任务"
         )
+        if pushed:
+            self._mark_ap_notification_sent('_last_ap_insufficient_notification_time')
     
     def _dispatch_coin_task(self, yellow_coins, total_ap, coin_target, meow_ap_preserve):
         """
@@ -962,45 +1089,72 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
         """
         all_coin_tasks = self._get_enabled_coin_tasks()
         if not all_coin_tasks:
-            logger.warning('[大世界-智能调度] 智能调度中没有启用任何黄币补充任务，默认执行短猫相接')
-            all_coin_tasks = [self.TASK_NAME_MEOWFFICER_FARMING]
+            logger.error('[大世界-智能调度] 没有启用任何黄币补充任务，停止智能调度')
+            self.notify_push(
+                title='[AzurPilot] 智能调度 - 未启用黄币补充任务',
+                content='请至少启用短猫相接、隐秘海域、深渊海域或塞壬要塞中的一项',
+            )
+            self._delay_smart_scheduling_to_server_update('未启用黄币补充任务')
+            self.config.task_stop()
 
         self.handle_first_auto_search(run=True)
         task_names = '、'.join([self.TASK_NAMES.get(task, task) for task in all_coin_tasks])
         logger.info(f'[大世界-智能调度] 启用的黄币补充任务: {task_names}')
 
         for task_name in all_coin_tasks:
-            self._notify_coin_task_proxy(
-                yellow_coins,
-                total_ap,
-                coin_target,
-                meow_ap_preserve,
-                self.TASK_NAMES.get(task_name, task_name),
-            )
             if self._run_scheduled_coin_task_once(task_name, meow_ap_preserve):
+                self._notify_coin_task_proxy(
+                    yellow_coins,
+                    total_ap,
+                    coin_target,
+                    meow_ap_preserve,
+                    task_name,
+                )
                 return
 
         logger.warning('[大世界-智能调度] 智能调度启用的黄币补充任务均无可执行内容，结束本轮智能调度')
+        self._delay_smart_scheduling_to_server_update('黄币补充任务均无可执行内容')
         self.config.task_stop()
 
-    def _notify_coin_task_proxy(self, yellow_coins, total_ap, coin_target, meow_ap_preserve, task_names):
+    def _notify_coin_task_proxy(self, yellow_coins, total_ap, coin_target, meow_ap_preserve, task_name):
         """
         发送代理执行黄币补充任务的通知。
         """
         if not self.is_smart_scheduling_enabled():
             return
 
-        self.notify_push(
-            title="[AzurPilot] 智能调度 - 代理执行黄币补充任务",
+        state_key = self.RUNTIME_ATTR_LAST_NOTIFIED_COIN_TASK
+        if getattr(self.config, state_key, None) == task_name:
+            return
+
+        attempt_key = self.RUNTIME_ATTR_LAST_COIN_TASK_NOTIFICATION_ATTEMPT
+        last_attempt = getattr(self.config, attempt_key, None)
+        now = current_time()
+        if isinstance(last_attempt, tuple) and len(last_attempt) == 2:
+            attempted_task, attempted_at = last_attempt
+            if (
+                attempted_task == task_name
+                and isinstance(attempted_at, type(now))
+                and now - attempted_at < timedelta(minutes=self.AP_NOTIFY_MIN_INTERVAL_MINUTES)
+            ):
+                return
+        setattr(self.config, attempt_key, (task_name, now))
+
+        task_display = self.TASK_NAMES.get(task_name, task_name)
+        pushed = self.notify_push(
+            title="[AzurPilot] 智能调度 - 已代理执行黄币补充任务",
             content=(f"黄币: {yellow_coins}，补黄币阈值: {coin_target}\n"
                      f"总行动力: {total_ap} (需要 {meow_ap_preserve})\n"
-                     f"代理执行{task_names}获取黄币")
+                     f"已代理执行一轮{task_display}获取黄币")
         )
+        if pushed:
+            setattr(self.config, state_key, task_name)
     
     def _execute_hazard1_leveling(self, yellow_coins, total_ap):
         """
         执行侵蚀1练级任务
         """
+        self._clear_coin_task_notification_state()
         logger.info('[大世界-智能调度] 执行侵蚀1练级任务')
         self._run_scheduled_hazard1_leveling(self._get_effective_cl1_ap_preserve())
     
@@ -1018,4 +1172,6 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
         if not self._can_send_ap_notification('_last_ap_threshold_notification_time'):
             return
         
-        self.notify_push(title=title, content=content)
+        pushed = self.notify_push(title=title, content=content)
+        if pushed:
+            self._mark_ap_notification_sent('_last_ap_threshold_notification_time')

--- a/module/server_checker.py
+++ b/module/server_checker.py
@@ -73,8 +73,14 @@ class ServerChecker:
                     if self._expired > 3:
                         logger.warning(f'Timestamp {self._timestamp} has not been updated for 3 times.')
             elif resp.status_code == 404:
-                self._state.append(False)
-                raise ScriptError(f'Server "{self._server}" does not exist!')
+                # API 数据库可能未收录新增服务器（如"长弓计划"），
+                # 检查本地服务器列表确认该服务器是否真实存在
+                if self._server_in_local_list():
+                    self._state.append(True)
+                    logger.info(f'Server "{self._server}" is available (local verified, API unknown).')
+                else:
+                    self._state.append(False)
+                    raise ScriptError(f'Server "{self._server}" does not exist!')
             else:
                 raise ScriptError(f'Get status_code {resp.status_code}. Response is {resp.text}')
         except (requests.exceptions.ConnectionError, requests.exceptions.ConnectTimeout) as e:
@@ -127,6 +133,20 @@ class ServerChecker:
             self._state.append(True)
         except Exception as e:
             raise e
+
+    def _server_in_local_list(self) -> bool:
+        """
+        检查服务器名称是否存在于本地 VALID_SERVER_LIST 中。
+
+        当 API 返回 404 时，用于区分"服务器不存在"和"API 数据库未收录"两种情况。
+
+        Returns:
+            bool: 本地列表中存在该服务器时返回 True。
+        """
+        for servers in server_list.values():
+            if self._server in servers:
+                return True
+        return False
 
     def reset(self) -> None:
         self._timestamp = 0


### PR DESCRIPTION
## Summary by Sourcery

在操作系统任务、每日岛屿委托和服务器检查中，优化智能调度、溢出预防以及通知行为，使调度更安全、减少噪音，并在各种边缘情况中更加稳健。

Bug 修复：
- 防止在硬币任务或 AP（行动点）耗尽或配置错误时，智能调度和溢出预防任务反复重试或导致延迟错位。
- 修复 AP 变更通知，使其同时考虑尝试时间和成功时间，避免噪音式重试，并正确持久化最后一次 AP 快照。
- 在智能补币任务或喵副官目标区域缺失或无效时，优雅地处理：通过延迟或停止任务来避免执行空工作。
- 避免在远程 API 尚未记录新加入服务器时将其视为无效，改为回退使用本地服务器列表。

改进项：
- 为“硬币目标”与“行动点调度”添加明确的调度模式跟踪，在切换模式时清除不兼容状态。
- 改进智能补币派发流程：在没有启用任何硬币任务时停止调度并通知用户；在所有硬币任务都无工作时延迟至服务器刷新后再尝试。
- 调整硬币任务代理通知，使其具备幂等性并按任务进行速率限制，在回到危害等级（hazard leveling）状态时清除相关状态。
- 改善“防止行动点溢出”委托延迟的处理逻辑，确保子任务的延迟请求在溢出处理运行完成后再应用。
- 调整岛屿每日委托的调度时间，从午夜改为固定每日时间 03:00，并相应更新日志和控制流程。
- 增加配置开关，用于跳过编队准备并直接依赖游戏当前选中的编队，以方便没有完整编队栏位的账号。
- 使 AP 变化通知在 AP 未变更时跳过发送，并在消息内容中包含 AP 增减方向。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine smart scheduling, overflow prevention, and notification behaviors across OS tasks, daily island orders, and server checking to make scheduling safer, less noisy, and more robust to edge cases.

Bug Fixes:
- Prevent smart scheduling and overflow-prevention tasks from repeatedly retrying or misaligning delays when coin tasks or AP are exhausted or misconfigured.
- Fix AP change notifications to respect both attempt and success timestamps, avoiding noisy retries and correctly persisting last-AP snapshots.
- Handle missing or invalid smart coin-replenish tasks and meowfficer target zones gracefully by delaying or stopping tasks instead of running empty work.
- Avoid treating newly added servers as invalid when the remote API has not yet recorded them, by falling back to the local server list.

Enhancements:
- Add explicit scheduling mode tracking for coin-target vs action-point scheduling, clearing incompatible state when switching modes.
- Improve smart coin-replenish dispatch flow to stop scheduling and notify users when no coin tasks are enabled, and to delay to server refresh when all coin tasks have no work.
- Refine coin-task proxy notifications to be idempotent and rate-limited per task, and to clear state when returning to hazard leveling.
- Improve handling of prevent-action-point-overflow delegated delays so that child-task delay requests are applied after overflow runs complete.
- Adjust island daily order scheduling to run at a fixed daily time (03:00) instead of midnight, updating logs and control flow accordingly.
- Add a configuration flag to skip fleet preparation and rely on the game’s currently selected fleet, helping accounts without full fleet slots.
- Make AP-delta notifications skip when AP is unchanged and include up/down changes in the message content.

</details>