### PR TITLE
fix

### DIFF
--- a/module/ocr/windowsml.py
+++ b/module/ocr/windowsml.py
@@ -93,7 +93,12 @@ def _device_type_name(device):
     return getattr(device_type, "name", str(device_type)).upper()
 
 
-def windowsml_device_options(ort=None):
+def windowsml_device_options(ort=None, install_missing_ep=False):
+    if ort is None:
+        import onnxruntime as ort
+
+    ensure_windows_ml_execution_providers(ort, install_missing_ep)
+
     options = [("auto", "自动选择最佳硬件")]
     for device in iter_ort_device_candidates("gpu", ort):
         if device.device_type == "CPU" or device.ep_name == CPU_EP:

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -2850,25 +2850,34 @@ class AlasGUI(Frame):
 
         self.task_handler.add(log.put_log(pm), 0.25, True)
 
-    def _windowsml_device_select_options(self, current_value):
+    def _windowsml_device_select_options(self, current_value, install_missing_ep=False):
         current_value = str(current_value or "auto")
         options = []
         labels = []
+        unavailable_text = {
+            "zh-CN": "当前不可用",
+            "zh-MIAO": "当前不可用",
+            "en-US": "Currently unavailable",
+            "ja-JP": "現在利用できません",
+            "zh-TW": "目前不可用",
+        }.get(lang.LANG, "Currently unavailable")
         try:
             from module.ocr.windowsml import windowsml_device_options
 
-            detected_options = windowsml_device_options()
+            detected_options = windowsml_device_options(
+                install_missing_ep=install_missing_ep
+            )
         except Exception as exc:
             logger.warning(f"Failed to detect Windows ML OCR devices: {exc}")
-            detected_options = [("auto", t("Optimization.OcrWindowsMlDevice.auto"))]
+            detected_options = [("auto", t("Optimization.OcrDevice.auto"))]
 
         for value, label in detected_options:
             options.append(value)
-            labels.append(t("Optimization.OcrWindowsMlDevice.auto") if value == "auto" else label)
+            labels.append(t("Optimization.OcrDevice.auto") if value == "auto" else label)
 
         if current_value not in options:
             options.append(current_value)
-            labels.append(f"{current_value} ({t('Optimization.OcrWindowsMlDevice.unavailable')})")
+            labels.append(f"{current_value} ({unavailable_text})")
 
         return options, labels
 
@@ -2910,7 +2919,19 @@ class AlasGUI(Frame):
             options_label = None
             if group_name == "Optimization" and arg_name == "OcrWindowsMlDevice":
                 output_kwargs["widget_type"] = "select"
-                options, options_label = self._windowsml_device_select_options(value)
+                install_missing_ep = deep_get(
+                    config,
+                    [task, group_name, "OcrWindowsMlInstallEp"],
+                    deep_get(
+                        config,
+                        ["Alas", group_name, "OcrWindowsMlInstallEp"],
+                        False,
+                    ),
+                )
+                options, options_label = self._windowsml_device_select_options(
+                    value,
+                    install_missing_ep=bool(install_missing_ep),
+                )
             server = to_server(deep_get(config, "Alas.Emulator.PackageName", "cn"))
             available_events = deep_get(
                 self.ALAS_ARGS, keys=f"{task}.{group_name}.{arg_name}.option_{server}"


### PR DESCRIPTION
## Summary by Sourcery

使 Windows ML OCR 设备选择与可配置的执行提供程序安装以及通用 OCR 选项标签保持一致。

新功能：
- 在填充 OCR 设备选项时，支持可选安装缺失的 Windows ML 执行提供程序。

错误修复：
- 当 Windows ML 设备检测失败或所选设备不可用时，使用通用的 OCR 设备国际化（i18n）键和本地化的回退文本。

增强改进：
- 扩展 Windows ML OCR 设备选项助手，使其接受一个“install-missing-execution-provider”标志，并在枚举设备之前确保执行提供程序可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align Windows ML OCR device selection with configurable execution provider installation and generic OCR option labels.

New Features:
- Support optional installation of missing Windows ML execution providers when populating OCR device options.

Bug Fixes:
- Use generic OCR device i18n keys and localized fallback text when Windows ML device detection fails or the selected device is unavailable.

Enhancements:
- Extend Windows ML OCR device option helper to accept an install-missing-execution-provider flag and ensure providers are available before enumerating devices.

</details>