### PR TITLE
fix: 修复岛屿系统中每日订单紧急委托识别、珍珠采购价格匹配退出、好友岛访问检测的若干问题

### DIFF
--- a/module/island/island_daily_order.py
+++ b/module/island/island_daily_order.py
@@ -580,7 +580,7 @@ class IslandDailyOrder(Island):
         cls._urgent_template_cache = tuple(sorted(templates, key=cls._urgent_template_sort_key))
         return cls._urgent_template_cache
 
-    def _template_match_urgent(self, template, similarity=0.80):
+    def _template_match_urgent(self, template, similarity=0.75):
         """
         获取紧急模板在左侧面板中的匹配位置及尺寸。
 
@@ -599,7 +599,7 @@ class IslandDailyOrder(Island):
         x1, y1, x2, y2 = button.area
         return (x1, y1, x2 - x1, y2 - y1)
 
-    def _template_click_urgent(self, similarity=0.80):
+    def _template_click_urgent(self, similarity=0.75):
         """点击左侧面板中第一个匹配到的紧急模板，返回匹配位置信息。"""
         for name, template in self._urgent_templates():
             match = self._template_match_urgent(template, similarity=similarity)

--- a/module/island/island_pearl_sell.py
+++ b/module/island/island_pearl_sell.py
@@ -531,12 +531,20 @@ class IslandPearlSell(Island):
         )
 
     def click_rank_visit(self, visit_button):
-        """点击好友排名拜访按钮并等待进入好友岛屿。"""
+        """点击好友排名拜访按钮并等待进入好友岛屿。
+
+        检测逻辑分为两个阶段：
+        1. 等待 ISLAND_ACCESS_MAP（右上角地图入口）出现，表示已开始加载好友岛
+        2. 等待 AIR_DROP_RUN_AWAY（顶部"离开"按钮）也出现，确认场景完全加载完毕
+        只有两者同时出现（is_in_friend_island() 为 True），才视为成功进入好友岛屿。
+        """
         click_timer = Timer(3).start()
         self.device.click(visit_button)
+        self.device.sleep(3)
         for _ in self.loop(timeout=30, skip_first=False):
-            if self.appear(ISLAND_ACCESS_MAP, offset=(20, 20)):
+            if self.is_in_friend_island():
                 self._island_expect_friend = True
+                logger.info("[岛屿-珍珠采购] 成功进入好友岛屿")
                 return True
             if self.appear(CANT_ACCESS, offset=(20, 20)):
                 logger.info("[岛屿-珍珠采购] 好友不可访问")

--- a/module/island/island_pearl_sell.py
+++ b/module/island/island_pearl_sell.py
@@ -155,6 +155,7 @@ class IslandPearlSell(Island):
             in_friend_island = True
         else:
             logger.info(f"[岛屿-珍珠采购] 本岛价格命中采购价 {home_price}")
+            self.back_to_pearl_shop_or_map()
 
         if not self._goto_pearl_shop_at("port"):
             if in_friend_island:


### PR DESCRIPTION
问题修复
本次提交包含三个岛屿系统的稳定性修复：

1. 每日订单紧急委托模板匹配阈值调整
[module/island/island_daily_order.py](http://localhost:12345/module/island/island_daily_order.py:583)

截图分析显示 TEMPLATE_DAILY_ORDER_URGENT 在最新 UI 上的实际匹配相似度仅为 0.7729，低于原阈值 0.80，导致紧急委托被漏检。将 _template_match_urgent 和 _template_click_urgent 的 similarity 从 0.80 降至 0.75 以适配 UI 更新。

2. 本岛珍珠价格命中采购价后未退出商店导致导航超时
[module/island/island_pearl_sell.py:158](http://localhost:12345/module/island/island_pearl_sell.py:158)

本岛珍珠价格命中采购价时，代码未调用 back_to_pearl_shop_or_map() 退出商店界面，导致后续导航到港口时的 ui_goto 因起始页面状态错误而超时。添加了退出商店的逻辑。

3. 拜访好友岛时地图切换等待不足导致检测失败
[module/island/island_pearl_sell.py:534](http://localhost:12345/module/island/island_pearl_sell.py:534)

原代码仅检测 ISLAND_ACCESS_MAP（右上角地图入口）来判断是否进入好友岛，但该元素在地图加载中途就会出现，此时场景尚未完全就绪。修复：

改用 is_in_friend_island() 方法，同时检测 ISLAND_ACCESS_MAP 和 AIR_DROP_RUN_AWAY（顶部"离开"按钮），确保好友岛场景完全加载完毕
点击拜访后增加 3 秒等待延迟，给地图切换留足缓冲时间
添加成功/失败日志便于排查

## Summary by Sourcery

调整海岛系统行为，以提升每日订单、珍珠购买和好友海岛访问的稳定性。

Bug 修复：
- 降低紧急每日订单模板匹配阈值，以在更新后的 UI 下恢复检测。
- 确保在家园海岛价格与购买价格匹配后再退出珍珠商店，以防止导航超时。
- 通过等待地图完全加载，并使用更健壮的场景检查以及补充日志，改进好友海岛访问检测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust island system behaviors to improve stability in daily orders, pearl purchasing, and friend island visits.

Bug Fixes:
- Lower the urgent daily order template matching threshold to restore detection under the updated UI.
- Ensure exiting the pearl shop after home island price matches the purchase price to prevent navigation timeouts.
- Improve friend island visit detection by waiting for full map load and using a more robust scene check with additional logging.

</details>