### PR TITLE
fix(emotion): 修复情绪恢复计算逻辑

### DIFF
--- a/module/coalition/coalition_scuttle.py
+++ b/module/coalition/coalition_scuttle.py
@@ -329,6 +329,11 @@ class CoalitionScuttleRun(Coalition, CoalitionScuttleCombat):
             try:
                 self.coalition_execute_once(event=event, stage=mode, fleet=fleet)
             except ScriptEnd as e:
+                # 心情不足时覆盖短延迟为30分钟，避免低心情频繁启动任务
+                if 'Emotion control' in str(e):
+                    logger.info('Emotion insufficient, delay 30 minutes for CoalitionScuttle')
+                    self.config.task_delay(minute=30)
+                    self.config.task_stop()
                 logger.hr('Script end')
                 logger.info(str(e))
                 break

--- a/module/combat/emotion.py
+++ b/module/combat/emotion.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from time import sleep
 
 import numpy as np
@@ -133,9 +133,18 @@ class FleetEmotion:
         return DIC_RECOVER_MAX[self.recover]
 
     def update(self):
-        recover_count = int(int(current_time().timestamp()) // 360 - int(self.record.timestamp()) // 360)
-        recover_count = max(recover_count, 0)
-        self.current = min(max(self.value, 0) + self.speed * recover_count, self.max)
+        """根据实际经过时间计算情绪恢复。
+
+        使用连续时间恢复计算，而非离散6分钟区间。
+        原方法使用 // 360 计算恢复次数，当 record() 频繁重置时间戳时
+        （如联盟沉船每2分钟调用一次），恢复永远无法累积。
+        改为按实际秒数计算恢复量，与游戏服务端行为一致。
+        """
+        time_diff = int(current_time().timestamp()) - int(self.record.timestamp())
+        time_diff = max(time_diff, 0)
+        # speed 为每360秒的恢复量，换算为每秒恢复 speed/360 点
+        recovery = self.speed * time_diff / 360
+        self.current = min(max(self.value, 0) + int(recovery), self.max)
 
     def get_recovered(self, expected_reduce=0):
         """计算情绪恢复到控制阈值的时间。
@@ -147,7 +156,7 @@ class FleetEmotion:
             datetime.datetime: 情绪 >= 控制阈值的时间。如果已经恢复，则返回过去的时间。
         """
         if self.control == 'keep_exp_bonus' and self.recover == 'not_in_dormitory':
-            logger.critical(f'[战斗] 舰队 {self.fleet} 的情绪控制设置为”保持开心加成”，且恢复地点设置为”港区”，两者不能同时使用，请检查情绪设置')
+            logger.critical(f'[战斗] 舰队 {self.fleet} 的情绪控制设置为"保持开心加成"，且恢复地点设置为"港区"，两者不能同时使用，请检查情绪设置')
             raise RequestHumanTakeover
         # 在 14-4 使用双倍经验书时，预期情绪减少为 32，无法保持开心加成（>120）
         # 否则会导致无限任务延迟
@@ -156,9 +165,12 @@ class FleetEmotion:
             logger.info(f'Fleet {self.fleet} expected_reduce is limited to 29 '
                         f'when Emotion Control=\"Keep Happy Bonus\"')
 
-        recover_count = (self.limit + expected_reduce - self.current) // self.speed
-        recovered = (int(current_time().timestamp()) // 360 + recover_count + 1) * 360
-        return datetime.fromtimestamp(recovered)
+        emotion_needed = self.limit + expected_reduce - self.current
+        if emotion_needed <= 0:
+            return current_time()
+        # speed 为每360秒的恢复量，换算恢复所需秒数
+        seconds_needed = emotion_needed * 360 / self.speed
+        return current_time() + timedelta(seconds=seconds_needed)
 
 class Emotion:
     total_reduced = 0


### PR DESCRIPTION
将原离散的6分钟区间恢复改为按实际秒数计算，修复频繁重置时间戳时无法正常累积恢复的问题，同时修正了情绪恢复时间计算逻辑，使其与游戏服务端行为一致。
精度也有问题，大概会相差5心情的样子，也修了这个但是没必要改，增加一点容错性

## Summary by Sourcery

调整情绪恢复机制为连续的基于时间的计算方式，使其与服务器行为保持一致，并解决在时间戳频繁重置时的累积问题。

Bug Fixes:
- 通过从离散的 6 分钟区间切换为实际经过的秒数，修复在记录时间戳频繁重置时情绪恢复值错误累积的问题。
- 修正情绪恢复时间计算，以根据所需情绪值和恢复速率返回准确的时间戳。

Enhancements:
- 放宽情绪恢复的精度，以减少轻微偏差，同时保持与游戏服务器行为高度一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust emotion recovery to use continuous time-based calculation aligned with server behavior and resolve accumulation issues when timestamps are frequently reset.

Bug Fixes:
- Fix emotion recovery accumulation when record timestamps are frequently reset by switching from discrete 6-minute intervals to actual elapsed seconds.
- Correct emotion recovery time calculation to return an accurate timestamp based on required emotion and recovery rate.

Enhancements:
- Relax precision of emotion recovery to reduce minor discrepancies while keeping behavior close to the game server.

</details>