### PR TITLE
Revert "fix(coalition): 联盟沉船任务低心情时添加30分钟延迟并终止任务"

### DIFF
--- a/module/coalition/coalition_scuttle.py
+++ b/module/coalition/coalition_scuttle.py
@@ -329,11 +329,6 @@ class CoalitionScuttleRun(Coalition, CoalitionScuttleCombat):
             try:
                 self.coalition_execute_once(event=event, stage=mode, fleet=fleet)
             except ScriptEnd as e:
-                # 心情不足时覆盖短延迟为30分钟，避免低心情频繁启动任务
-                if 'Emotion control' in str(e):
-                    logger.info('Emotion insufficient, delay 30 minutes for CoalitionScuttle')
-                    self.config.task_delay(minute=30)
-                    self.config.task_stop()
                 logger.hr('Script end')
                 logger.info(str(e))
                 break


### PR DESCRIPTION
This reverts commit e1060550a3d6dff97e2b7925ee053eee2e25b978.

## Summary by Sourcery

恢复对联盟清除任务中低情绪 `ScriptEnd` 的常规处理，这样这些任务在情绪不足时将不再强制执行 30 分钟延迟或自动终止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the special handling for low-emotion ScriptEnd in coalition scuttle tasks so that these tasks no longer enforce a 30-minute delay or auto-termination when emotion is insufficient.

</details>