### PR TITLE
fix(island): 修复 岛屿-每日补给/珍珠采购 在较慢的设备上工作不正常的问题

### DIFF
--- a/module/device/method/minitouch.py
+++ b/module/device/method/minitouch.py
@@ -718,6 +718,9 @@ class Minitouch(Connection):
         builder.move(*p2).commit().wait(140)
         builder.send()
 
+        builder.up().commit()
+        builder.send()
+
     def island_swipe_hold_minitouch(self, p1, p2, hold_time):
         points = insert_swipe(p0=p1, p3=p2)
         builder = self.minitouch_builder
@@ -725,7 +728,6 @@ class Minitouch(Connection):
         builder.send()
         for point in points[1:]:
             builder.move(*point).commit().wait(10)
-        builder.send()
         builder.wait(hold_time)
         builder.send()
         builder.up().commit()

--- a/module/island/island.py
+++ b/module/island/island.py
@@ -221,6 +221,54 @@ class Island(SelectCharacter):
         access_map = self.appear(ISLAND_ACCESS_MAP, offset=(20, 20))
         return leave and access_map
 
+    def check_visit_friend_island(self, visit_button):
+        """点击好友拜访按钮并等待进入好友岛屿。
+
+        检测逻辑分为两个阶段：
+        1. 等待 ISLAND_ACCESS_MAP（右上角地图入口）出现，表示已开始加载好友岛
+        2. 等待 AIR_DROP_RUN_AWAY（顶部"离开"按钮）也出现，确认场景完全加载完毕
+        只有两者同时出现（is_in_friend_island() 为 True），才视为成功进入好友岛屿。
+        """
+        click_timer = Timer(3).start()
+        self.device.click(visit_button)
+        self.device.sleep(3)
+        for _ in self.loop(timeout=30, skip_first=False):
+            if self.is_in_friend_island():
+                logger.info("[岛屿] 二次检测拜访状态......")
+                # 在等待的过程中, 先后会出现黑底黄鸡loading、UI(一闪而过)、白底沙漏loading
+				# 因此等待1s后进行二次确认, 避免中间UI一闪而过时出现误判
+                self.device.sleep(1)
+                self.device.screenshot()
+                if self.is_in_friend_island():
+                    self._island_expect_friend = True
+                    logger.info("[岛屿] 成功进入好友岛屿")
+                    return True
+            if self.appear(CANT_ACCESS, offset=(20, 20)):
+                logger.info("[岛屿] 好友不可访问")
+                return False
+            if click_timer.reached():
+                self.device.click(visit_button)
+                click_timer.reset()
+            if self.ui_additional():
+                continue
+        logger.warning("[岛屿] 拜访好友超时")
+        return False
+
+    def exit_friend_island(self):
+        """退出好友岛屿。"""
+        logger.info("[岛屿] 退出好友岛屿")
+        self._island_expect_friend = False
+        for _ in self.loop(timeout=30):
+            if self.appear_then_click(AIR_DROP_RUN_AWAY, offset=(20, 20), interval=2):
+                continue
+            if self.appear(ISLAND_GOTO_MAP):
+                logger.info("[岛屿] 成功退出好友岛屿")
+                return True
+            if self.ui_additional():
+                continue
+        logger.warning("[岛屿] 退出好友岛屿超时")
+        return False
+
     def _wait_island_map_entry(self, timeout=3):
         last_status = None
         for _ in self.loop(timeout=timeout, skip_first=False):
@@ -346,6 +394,8 @@ class Island(SelectCharacter):
                     self.appear(ISLAND_CHECK, offset=(20, 20))
                     or (in_friend and self.is_in_friend_island())
             ):
+                self.device.sleep(1)
+                logger.info(f"[岛屿] 岛屿地图进入成功: {destination}")
                 return True
 
         logger.warning(f"[岛屿] 岛屿地图进入目的地超时: {destination}")

--- a/module/island/island_air_drop.py
+++ b/module/island/island_air_drop.py
@@ -154,17 +154,10 @@ class IslandAirDrop(Island):
                 visit_button = self.calculate_visit_position(
                     air_drop_button_x, air_drop_button_y
                 )
-                result = self.check_visit(visit_button)
-                if result == "skip":
-                    logger.info("[岛屿-每日补给] 无法访问，跳过当前补给")
+                if not self.check_visit_friend_island(visit_button):
                     continue
-                elif result == "success":
-                    logger.info("[岛屿-每日补给] 成功进入拜访状态，返回True")
-                    return True
-                elif result == "timeout":
-                    self.island_error = True
-                    return False
                 has_clickable_air_drop = True
+                return True
             # 如果当前页面所有补给都不可用（全部skip或timeout）
             if not has_clickable_air_drop:
                 logger.info("[岛屿-每日补给] 当前页面没有可用补给目标")
@@ -199,21 +192,6 @@ class IslandAirDrop(Island):
         logger.info("[岛屿-每日补给] 未检测到可用补给")
         return False
 
-    def check_visit(self, visit_button):
-        number = 20
-        self.device.click(visit_button)
-        self.device.sleep(5)
-        while number:
-            self.device.screenshot()
-            if self.appear(ISLAND_ACCESS_MAP, offset=1):
-                return "success"
-            if self.appear(CANT_ACCESS, similarity=0.85):
-                return "skip"
-            self.device.sleep(1)
-            self.device.click(visit_button)
-            number -= 1
-        return "timeout"
-
     def calculate_visit_position(self, air_drop_button_x, air_drop_button_y):
 
         visit_button_x1 = air_drop_button_x + 225  # x偏移
@@ -244,15 +222,6 @@ class IslandAirDrop(Island):
         self.device.click(stop_button)
         self.device.click_record_clear()
 
-    def island_access_map_check(self):
-        while True:
-            self.device.screenshot()
-            if self.appear(ISLAND_ACCESS_MAP):
-                return False
-            if self.appear(CANT_ACCESS):
-                return True
-            self.device.sleep(0.5)
-
     def island_air_drop(self):
         self.device.click(ISLAND_AIR_DROP_A)
         sleep(0.1)
@@ -265,6 +234,7 @@ class IslandAirDrop(Island):
         self.device.click(ISLAND_AIR_DROP_B)
         sleep(0.1)
         self.device.click(ISLAND_AIR_DROP_C)
+        sleep(0.5)
 
     def run_and_get(self):
         self.island_up(3000)
@@ -299,7 +269,7 @@ class IslandAirDrop(Island):
                 break
             self.island_down(500)
             self.island_air_drop()
-        self.device.click(AIR_DROP_RUN_AWAY)
+        self.exit_friend_island()
 
     def test(self):
         image = self.device.screenshot()

--- a/module/island/island_pearl_sell.py
+++ b/module/island/island_pearl_sell.py
@@ -361,20 +361,6 @@ class IslandPearlSell(Island):
                 continue
         return False
 
-    def exit_friend_island(self):
-        """退出好友岛屿。"""
-        logger.info("[岛屿-珍珠采购] 退出好友岛屿")
-        self._island_expect_friend = False
-        for _ in self.loop(timeout=20):
-            if self.appear_then_click(AIR_DROP_RUN_AWAY, offset=(20, 20), interval=2):
-                continue
-            if self.appear(ISLAND_ACCESS_MAP, offset=(20, 20)):
-                return True
-            if self.ui_additional():
-                continue
-        logger.warning("[岛屿-珍珠采购] 退出好友岛屿超时")
-        return False
-
     # ==================== 好友排名 ====================
 
     def visit_friend_by_rank(self, mode, threshold):
@@ -399,7 +385,7 @@ class IslandPearlSell(Island):
 
         self._rank_visit_target_selected = True
         logger.info(f"[岛屿-珍珠采购] 选择好友珍珠价格 {target['price']}")
-        return self.click_rank_visit(target["visit_button"])
+        return self.check_visit_friend_island(target["visit_button"])
 
     def switch_to_friend_rank_tab(self):
         """切换到好友排名页签。"""
@@ -529,33 +515,6 @@ class IslandPearlSell(Island):
         return self._area_button(
             area, f"OCR_ISLAND_PEARL_RANK_PRICE_FROM_VISIT_{index}"
         )
-
-    def click_rank_visit(self, visit_button):
-        """点击好友排名拜访按钮并等待进入好友岛屿。
-
-        检测逻辑分为两个阶段：
-        1. 等待 ISLAND_ACCESS_MAP（右上角地图入口）出现，表示已开始加载好友岛
-        2. 等待 AIR_DROP_RUN_AWAY（顶部"离开"按钮）也出现，确认场景完全加载完毕
-        只有两者同时出现（is_in_friend_island() 为 True），才视为成功进入好友岛屿。
-        """
-        click_timer = Timer(3).start()
-        self.device.click(visit_button)
-        self.device.sleep(3)
-        for _ in self.loop(timeout=30, skip_first=False):
-            if self.is_in_friend_island():
-                self._island_expect_friend = True
-                logger.info("[岛屿-珍珠采购] 成功进入好友岛屿")
-                return True
-            if self.appear(CANT_ACCESS, offset=(20, 20)):
-                logger.info("[岛屿-珍珠采购] 好友不可访问")
-                return False
-            if click_timer.reached():
-                self.device.click(visit_button)
-                click_timer.reset()
-            if self.ui_additional():
-                continue
-        logger.warning("[岛屿-珍珠采购] 拜访好友超时")
-        return False
 
     # ==================== OCR ====================
 
@@ -687,6 +646,7 @@ class IslandPearlSell(Island):
             logger.warning(f"[岛屿-珍珠采购] 打开珍珠{self._action_name(action)}弹窗超时")
             return False
 
+        self.device.sleep(0.5)
         if not self.adjust_trade_count(count):
             logger.warning(f"[岛屿-珍珠采购] 珍珠{self._action_name(action)}数量未调整到目标: {count}")
             return False


### PR DESCRIPTION
1. 每日补给合并为使用珍珠采购中的逻辑进入离开好友岛屿, 修复进入较慢时的`Too many click`报错;
2. 访问岛屿添加1s的二次状态检测, 避免加载过程中UI一闪而过时, 被误识别为进入, 同时确保岛屿状态稳定, 避免后续移动丢失;
3. 退出好友岛屿的检测条件`ISLAND_ACCESS_MAP`(好友岛屿)->`ISLAND_GOTO_MAP`(自己岛屿), 超时时间20->30s;
4. 在地图切换成功、补给领取、打开珍珠售卖之后添加额外的等待， 确保状态稳定，避免吞后续触控操作;
5. minitouch的`drag_minitouch()`: 还原疑似在#218, #228 中被误删除的的触摸抬起; 
[之前提交的diff](https://github.com/wess09/AzurPilot/pull/218/changes/b9b4c9264e3cb2ca4779220a932f4a7dff02d817#diff-248e172f4a9d9021e4f1ab3b368c73babe15e22ce5da11c4e8ecc8352658d01aR719)
6. minitouch的`island_swipe_hold_minitouch()`: 合并`builder.wait(hold_time)`到前一次操作, 避免重复打印`Command list empty, sending it may cause unexpected behaviour: w {hold_time}`的警告

## Summary by Sourcery

在每日补给和珍珠购买流程中统一好友岛屿的进入与退出逻辑，并加入更严格的状态检查和等待机制，以提升在低性能设备上的可靠性。

New Features:
- 引入共享的好友岛屿访问辅助方法，在继续执行操作前先验证场景是否完全加载。

Bug Fixes:
- 修复好友岛屿进入与退出检测不稳定的问题，该问题会在低性能设备上导致超时、错误地将问题归类为访问错误，以及触控操作被吞掉。
- 恢复在 minitouch 拖拽操作中的缺失“触控释放”动作，防止滑动操作卡住或表现不一致。
- 移除多余的 minitouch 滑动按住命令，避免触发“Command list empty”警告。

Enhancements:
- 在岛屿地图切换、每日补给交互以及珍珠交易对话框周围加入二次状态校验和更长的超时时间，确保在执行后续操作前 UI 状态稳定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify friend island visit and exit logic across daily supply and pearl purchasing flows, adding more robust state checks and waits to improve reliability on slower devices.

New Features:
- Introduce a shared friend island visit helper that validates full scene load before proceeding.

Bug Fixes:
- Fix unreliable friend island entry and exit detection that caused timeouts, misclassification of access errors, and swallowed touch actions on slower devices.
- Restore missing touch release in minitouch drag operations to prevent stuck or inconsistent swipe behaviour.
- Eliminate redundant minitouch swipe hold commands that triggered "Command list empty" warnings.

Enhancements:
- Add secondary state verification and extended timeouts around island map transitions, daily supply interactions, and pearl trade dialogs to ensure UI stability before subsequent actions.

</details>