### PR TITLE
fix(ui): 修复ui翻页时可能误判超时的问题

### DIFF
--- a/module/ui/ui.py
+++ b/module/ui/ui.py
@@ -378,7 +378,6 @@ class UI(InfoHandler):
             skip_first_screenshot=False,
             fast=True,
             interval=(0.2, 0.3),
-            stall_tolerance=10,
     ):
         """
         确保翻页到指定索引位置，通过 OCR 识别当前页码并点击翻页按钮。
@@ -391,13 +390,9 @@ class UI(InfoHandler):
             skip_first_screenshot (bool): 是否跳过首次截图。
             fast (bool): 默认为 True。当索引不连续时设为 False。
             interval (tuple, int, float): 两次点击之间的间隔（秒）。
-            stall_tolerance (int): 允许索引连续不变的次数，超过后判定为无法达到目标并退出。
         """
         logger.hr("UI 确保索引")
         retry = Timer(1, count=2)
-        # 进度停滞检测：记录上一次索引值和连续不变次数，防止因游戏端限制导致死循环
-        last_current = None
-        stall_count = 0
         while 1:
             if skip_first_screenshot:
                 skip_first_screenshot = False
@@ -412,17 +407,6 @@ class UI(InfoHandler):
             logger.attr("当前索引", current)
             diff = index - current
             if diff == 0:
-                break
-
-            # 进度停滞检测：当连续stall_tolerance次索引值未变化且diff不为0时退出
-            if current == last_current:
-                stall_count += 1
-            else:
-                stall_count = 0
-                last_current = current
-            if stall_count >= stall_tolerance:
-                logger.warning(f'[UI] 索引停滞在 {current} 已 {stall_count} 次，'
-                               f'无法达到目标 {index}，跳过')
                 break
 
             if retry.reached():


### PR DESCRIPTION
fix: #636

## Summary by Sourcery

Bug Fixes:
- 通过删除 `ui_ensure_index` 中过期的索引停滞检查，修复在切换 UI 页面时可能出现的误判超时问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix potential false timeout detection when turning UI pages by eliminating stale index stall checks in ui_ensure_index.

</details>