### PR TITLE
fix(os): 修复大世界进入储物仓界面时误进入情报界面会导致卡死的问题

### DIFF
--- a/module/os_handler/storage.py
+++ b/module/os_handler/storage.py
@@ -5,6 +5,7 @@
 提供维修结果枚举（成功/数量不足/超时）用于状态判断。
 """
 from enum import Enum
+import time
 
 from module.base.timer import Timer
 from module.base.utils import area_offset, crop, rgb2gray
@@ -45,10 +46,23 @@ class StorageHandler(GlobeOperation, ZoneManager):
             out: STORAGE_CHECK
         """
         logger.info('[大世界-仓库] 进入仓库')
+        wait_seconds = 0
         for _ in self.loop():
             # End
             if self.is_in_storage():
                 break
+
+            if self.appear(MISSION_CHECK, offset=(20, 20)):
+                logger.warning('[大世界-仓库] 误进入情报界面，尝试退出')
+                self.ui_click(
+                    MISSION_QUIT,
+                    check_button=self.is_in_map,
+                    offset=(20, 20),
+                    skip_first_screenshot=True
+                )
+                wait_seconds += 1
+                time.sleep(wait_seconds)
+                continue
 
             if self.appear_then_click(STORAGE_ENTER, offset=(200, 5), interval=3):
                 continue


### PR DESCRIPTION
fix #628

## Summary by Sourcery

Bug Fixes:
- 通过检测并在重试前自动退出回到地图界面，处理在访问世界存储期间意外进入情报界面的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle accidental entry into the intel screen during world storage access by detecting it and automatically exiting back to the map before retrying.

</details>