### PR TITLE
fix(coalition, combat): 修复D评价误判和心情同步问题 

### DIFF
--- a/module/coalition/coalition_scuttle.py
+++ b/module/coalition/coalition_scuttle.py
@@ -89,11 +89,13 @@ class CoalitionScuttleCombat(CoalitionCombat):
                 self._withdraw = True
                 self._is_shipwreck = True
                 break
-            # D评价结算界面：等待OPTS_INFO_D弹窗确认，不立即设置沉船标记
-            # S/A/B评价的动画过渡帧可能误匹配BATTLE_STATUS_D模板
-            # 只有真正的D评价（沉船）才会出现OPTS_INFO_D弹窗
+            # D评价结算界面：S/A/B评价的动画过渡帧可能短暂误匹配D评价模板，
+            # 但只有真正的沉船才会出现OPTS_INFO_D弹窗。
+            # 此处仅break退出循环，不设置沉船标记（未经过OPTS_INFO_D确认）。
+            # 真正的沉船由上方OPTS_INFO_D路径触发并设置_is_shipwreck。
             if self.appear(BATTLE_STATUS_D) or self.appear(EXP_INFO_D):
-                continue
+                self._withdraw = True
+                break
             if confirm_timer.reached():
                 self._withdraw = True
                 self._is_shipwreck = True

--- a/module/coalition/coalition_scuttle.py
+++ b/module/coalition/coalition_scuttle.py
@@ -89,10 +89,11 @@ class CoalitionScuttleCombat(CoalitionCombat):
                 self._withdraw = True
                 self._is_shipwreck = True
                 break
+            # D评价结算界面：等待OPTS_INFO_D弹窗确认，不立即设置沉船标记
+            # S/A/B评价的动画过渡帧可能误匹配BATTLE_STATUS_D模板
+            # 只有真正的D评价（沉船）才会出现OPTS_INFO_D弹窗
             if self.appear(BATTLE_STATUS_D) or self.appear(EXP_INFO_D):
-                self._withdraw = True
-                self._is_shipwreck = True
-                break
+                continue
             if confirm_timer.reached():
                 self._withdraw = True
                 self._is_shipwreck = True

--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -318,12 +318,12 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
                     self.emotion.reduce(fleet_index, shipwreck=True)
                 self._withdraw = True
                 break
-            # 沉船D评价结算界面，作为OPTS_INFO_D未检测到的兜底
+            # D评价结算界面：等待OPTS_INFO_D弹窗确认，不立即扣减
+            # S/A/B评价的动画过渡帧可能误匹配BATTLE_STATUS_D模板
+            # 只有真正的D评价（沉船）才会出现OPTS_INFO_D弹窗
+            # 此处仅作标记，继续循环等待OPTS_INFO_D或S/A/B评价确认
             if self.appear(BATTLE_STATUS_D) or self.appear(EXP_INFO_D):
-                self._withdraw = True
-                if emotion_reduce:
-                    self.emotion.reduce(fleet_index, shipwreck=True)
-                break
+                continue
             if confirm_timer.reached():
                 self._withdraw = True
                 self.device.click(OPTS_INFO_D)

--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -318,12 +318,15 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
                     self.emotion.reduce(fleet_index, shipwreck=True)
                 self._withdraw = True
                 break
-            # D评价结算界面：等待OPTS_INFO_D弹窗确认，不立即扣减
-            # S/A/B评价的动画过渡帧可能误匹配BATTLE_STATUS_D模板
-            # 只有真正的D评价（沉船）才会出现OPTS_INFO_D弹窗
-            # 此处仅作标记，继续循环等待OPTS_INFO_D或S/A/B评价确认
+            # D评价结算界面（BATTLE_STATUS_D / EXP_INFO_D）
+            # S/A/B评价的动画过渡帧可能短暂误匹配D评价模板，
+            # 但只有真正的沉船才会出现OPTS_INFO_D弹窗。
+            # 此处仅break退出循环，不扣减shipwreck心情。
+            # 真正的沉船扣减由上方OPTS_INFO_D路径触发。
+            # 退出后由auto_search_combat_status()中的handle_battle_status()处理结算画面。
             if self.appear(BATTLE_STATUS_D) or self.appear(EXP_INFO_D):
-                continue
+                self._withdraw = True
+                break
             if confirm_timer.reached():
                 self._withdraw = True
                 self.device.click(OPTS_INFO_D)

--- a/module/combat/emotion.py
+++ b/module/combat/emotion.py
@@ -277,7 +277,9 @@ class Emotion:
         仅在心情整数值发生变化时更新 Record 时间戳，
         并将 Record 回扣 fractional_seconds 对应的等效秒数，
         使未满1点的恢复余数可在下次 update() 时继续累积。
-        同时同步 fleet.value 属性，确保下次 update() 基于正确值计算恢复。
+
+        注意：FleetEmotion.value 和 FleetEmotion.record 是 @property，
+        从 self.config 实时读取。setattr 到 config 后属性自动更新，无需手动赋值。
         """
         if self.using_public:
             fleet = self.public_fleet
@@ -293,9 +295,6 @@ class Emotion:
                 with self.config.multi_set():
                     setattr(self.config, fleet.value_name, new_value)
                     setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
-                # 同步属性，确保下次 update() 基于新值计算恢复
-                fleet.value = new_value
-                fleet.record = record_time
             return
 
         with self.config.multi_set():
@@ -309,9 +308,6 @@ class Emotion:
                         record_time = record_time - timedelta(seconds=fractional * 360 / fleet.speed)
                     setattr(self.config, fleet.value_name, new_value)
                     setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
-                    # 同步属性，确保下次 update() 基于新值计算恢复
-                    fleet.value = new_value
-                    fleet.record = record_time
 
     def show(self):
         """显示当前计算的心情值（含时间恢复），而非上次保存值。"""

--- a/module/combat/emotion.py
+++ b/module/combat/emotion.py
@@ -277,6 +277,7 @@ class Emotion:
         仅在心情整数值发生变化时更新 Record 时间戳，
         并将 Record 回扣 fractional_seconds 对应的等效秒数，
         使未满1点的恢复余数可在下次 update() 时继续累积。
+        同时同步 fleet.value 属性，确保下次 update() 基于正确值计算恢复。
         """
         if self.using_public:
             fleet = self.public_fleet
@@ -292,6 +293,9 @@ class Emotion:
                 with self.config.multi_set():
                     setattr(self.config, fleet.value_name, new_value)
                     setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
+                # 同步属性，确保下次 update() 基于新值计算恢复
+                fleet.value = new_value
+                fleet.record = record_time
             return
 
         with self.config.multi_set():
@@ -305,6 +309,9 @@ class Emotion:
                         record_time = record_time - timedelta(seconds=fractional * 360 / fleet.speed)
                     setattr(self.config, fleet.value_name, new_value)
                     setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
+                    # 同步属性，确保下次 update() 基于新值计算恢复
+                    fleet.value = new_value
+                    fleet.record = record_time
 
     def show(self):
         """显示当前计算的心情值（含时间恢复），而非上次保存值。"""


### PR DESCRIPTION
## Summary by Sourcery

调整 D 级战斗结果的处理，避免将临时动画帧误判为实际的舰沉事件，并澄清情绪追踪的行为。

Bug 修复：
- 在标准战斗中，当更高评级的结算动画短暂出现与 D 级结算画面匹配的帧时，防止错误触发舰沉导致的情绪惩罚。
- 在联合自沉流程中，当短暂出现与 D 级结算画面匹配但未实际确认舰沉的情况时，防止错误设置舰沉标记。

增强：
- 明确舰队情绪记录的文档说明，解释基于属性的配置更新机制，避免冗余赋值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust D-rank battle result handling to avoid misclassifying temporary animation frames as actual shipwrecks and clarify emotion tracking behavior.

Bug Fixes:
- Prevent false shipwreck mood penalties in standard combat when D-rank result screens are briefly matched during higher-rank result animations.
- Prevent false shipwreck flags in coalition scuttle flow when D-rank result screens are briefly matched without actual shipwreck confirmation.

Enhancements:
- Clarify documentation for fleet emotion recording to explain property-based config updates and avoid redundant assignments.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整 D 级战斗结果的处理，避免将临时动画帧误判为实际的舰沉事件，并澄清情绪追踪的行为。

Bug 修复：
- 在标准战斗中，当更高评级的结算动画短暂出现与 D 级结算画面匹配的帧时，防止错误触发舰沉导致的情绪惩罚。
- 在联合自沉流程中，当短暂出现与 D 级结算画面匹配但未实际确认舰沉的情况时，防止错误设置舰沉标记。

增强：
- 明确舰队情绪记录的文档说明，解释基于属性的配置更新机制，避免冗余赋值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust D-rank battle result handling to avoid misclassifying temporary animation frames as actual shipwrecks and clarify emotion tracking behavior.

Bug Fixes:
- Prevent false shipwreck mood penalties in standard combat when D-rank result screens are briefly matched during higher-rank result animations.
- Prevent false shipwreck flags in coalition scuttle flow when D-rank result screens are briefly matched without actual shipwreck confirmation.

Enhancements:
- Clarify documentation for fleet emotion recording to explain property-based config updates and avoid redundant assignments.

</details>

</details>