### PR TITLE
修复了一些问题

### DIFF
--- a/module/coalition/coalition_scuttle.py
+++ b/module/coalition/coalition_scuttle.py
@@ -89,11 +89,13 @@ class CoalitionScuttleCombat(CoalitionCombat):
                 self._withdraw = True
                 self._is_shipwreck = True
                 break
-            # D评价结算界面：等待OPTS_INFO_D弹窗确认，不立即设置沉船标记
-            # S/A/B评价的动画过渡帧可能误匹配BATTLE_STATUS_D模板
-            # 只有真正的D评价（沉船）才会出现OPTS_INFO_D弹窗
+            # D评价结算界面：S/A/B评价的动画过渡帧可能短暂误匹配D评价模板，
+            # 但只有真正的沉船才会出现OPTS_INFO_D弹窗。
+            # 此处仅break退出循环，不设置沉船标记（未经过OPTS_INFO_D确认）。
+            # 真正的沉船由上方OPTS_INFO_D路径触发并设置_is_shipwreck。
             if self.appear(BATTLE_STATUS_D) or self.appear(EXP_INFO_D):
-                continue
+                self._withdraw = True
+                break
             if confirm_timer.reached():
                 self._withdraw = True
                 self._is_shipwreck = True

--- a/module/coalition/coalition_scuttle.py
+++ b/module/coalition/coalition_scuttle.py
@@ -89,10 +89,11 @@ class CoalitionScuttleCombat(CoalitionCombat):
                 self._withdraw = True
                 self._is_shipwreck = True
                 break
+            # D评价结算界面：等待OPTS_INFO_D弹窗确认，不立即设置沉船标记
+            # S/A/B评价的动画过渡帧可能误匹配BATTLE_STATUS_D模板
+            # 只有真正的D评价（沉船）才会出现OPTS_INFO_D弹窗
             if self.appear(BATTLE_STATUS_D) or self.appear(EXP_INFO_D):
-                self._withdraw = True
-                self._is_shipwreck = True
-                break
+                continue
             if confirm_timer.reached():
                 self._withdraw = True
                 self._is_shipwreck = True

--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -318,12 +318,12 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
                     self.emotion.reduce(fleet_index, shipwreck=True)
                 self._withdraw = True
                 break
-            # 沉船D评价结算界面，作为OPTS_INFO_D未检测到的兜底
+            # D评价结算界面：等待OPTS_INFO_D弹窗确认，不立即扣减
+            # S/A/B评价的动画过渡帧可能误匹配BATTLE_STATUS_D模板
+            # 只有真正的D评价（沉船）才会出现OPTS_INFO_D弹窗
+            # 此处仅作标记，继续循环等待OPTS_INFO_D或S/A/B评价确认
             if self.appear(BATTLE_STATUS_D) or self.appear(EXP_INFO_D):
-                self._withdraw = True
-                if emotion_reduce:
-                    self.emotion.reduce(fleet_index, shipwreck=True)
-                break
+                continue
             if confirm_timer.reached():
                 self._withdraw = True
                 self.device.click(OPTS_INFO_D)

--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -318,12 +318,15 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
                     self.emotion.reduce(fleet_index, shipwreck=True)
                 self._withdraw = True
                 break
-            # D评价结算界面：等待OPTS_INFO_D弹窗确认，不立即扣减
-            # S/A/B评价的动画过渡帧可能误匹配BATTLE_STATUS_D模板
-            # 只有真正的D评价（沉船）才会出现OPTS_INFO_D弹窗
-            # 此处仅作标记，继续循环等待OPTS_INFO_D或S/A/B评价确认
+            # D评价结算界面（BATTLE_STATUS_D / EXP_INFO_D）
+            # S/A/B评价的动画过渡帧可能短暂误匹配D评价模板，
+            # 但只有真正的沉船才会出现OPTS_INFO_D弹窗。
+            # 此处仅break退出循环，不扣减shipwreck心情。
+            # 真正的沉船扣减由上方OPTS_INFO_D路径触发。
+            # 退出后由auto_search_combat_status()中的handle_battle_status()处理结算画面。
             if self.appear(BATTLE_STATUS_D) or self.appear(EXP_INFO_D):
-                continue
+                self._withdraw = True
+                break
             if confirm_timer.reached():
                 self._withdraw = True
                 self.device.click(OPTS_INFO_D)

--- a/module/combat/emotion.py
+++ b/module/combat/emotion.py
@@ -277,7 +277,9 @@ class Emotion:
         仅在心情整数值发生变化时更新 Record 时间戳，
         并将 Record 回扣 fractional_seconds 对应的等效秒数，
         使未满1点的恢复余数可在下次 update() 时继续累积。
-        同时同步 fleet.value 属性，确保下次 update() 基于正确值计算恢复。
+
+        注意：FleetEmotion.value 和 FleetEmotion.record 是 @property，
+        从 self.config 实时读取。setattr 到 config 后属性自动更新，无需手动赋值。
         """
         if self.using_public:
             fleet = self.public_fleet
@@ -293,9 +295,6 @@ class Emotion:
                 with self.config.multi_set():
                     setattr(self.config, fleet.value_name, new_value)
                     setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
-                # 同步属性，确保下次 update() 基于新值计算恢复
-                fleet.value = new_value
-                fleet.record = record_time
             return
 
         with self.config.multi_set():
@@ -309,9 +308,6 @@ class Emotion:
                         record_time = record_time - timedelta(seconds=fractional * 360 / fleet.speed)
                     setattr(self.config, fleet.value_name, new_value)
                     setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
-                    # 同步属性，确保下次 update() 基于新值计算恢复
-                    fleet.value = new_value
-                    fleet.record = record_time
 
     def show(self):
         """显示当前计算的心情值（含时间恢复），而非上次保存值。"""

--- a/module/combat/emotion.py
+++ b/module/combat/emotion.py
@@ -277,6 +277,7 @@ class Emotion:
         仅在心情整数值发生变化时更新 Record 时间戳，
         并将 Record 回扣 fractional_seconds 对应的等效秒数，
         使未满1点的恢复余数可在下次 update() 时继续累积。
+        同时同步 fleet.value 属性，确保下次 update() 基于正确值计算恢复。
         """
         if self.using_public:
             fleet = self.public_fleet
@@ -292,6 +293,9 @@ class Emotion:
                 with self.config.multi_set():
                     setattr(self.config, fleet.value_name, new_value)
                     setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
+                # 同步属性，确保下次 update() 基于新值计算恢复
+                fleet.value = new_value
+                fleet.record = record_time
             return
 
         with self.config.multi_set():
@@ -305,6 +309,9 @@ class Emotion:
                         record_time = record_time - timedelta(seconds=fractional * 360 / fleet.speed)
                     setattr(self.config, fleet.value_name, new_value)
                     setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
+                    # 同步属性，确保下次 update() 基于新值计算恢复
+                    fleet.value = new_value
+                    fleet.record = record_time
 
     def show(self):
         """显示当前计算的心情值（含时间恢复），而非上次保存值。"""

--- a/module/os_handler/storage.py
+++ b/module/os_handler/storage.py
@@ -5,6 +5,7 @@
 提供维修结果枚举（成功/数量不足/超时）用于状态判断。
 """
 from enum import Enum
+import time
 
 from module.base.timer import Timer
 from module.base.utils import area_offset, crop, rgb2gray
@@ -45,10 +46,23 @@ class StorageHandler(GlobeOperation, ZoneManager):
             out: STORAGE_CHECK
         """
         logger.info('[大世界-仓库] 进入仓库')
+        wait_seconds = 0
         for _ in self.loop():
             # End
             if self.is_in_storage():
                 break
+
+            if self.appear(MISSION_CHECK, offset=(20, 20)):
+                logger.warning('[大世界-仓库] 误进入情报界面，尝试退出')
+                self.ui_click(
+                    MISSION_QUIT,
+                    check_button=self.is_in_map,
+                    offset=(20, 20),
+                    skip_first_screenshot=True
+                )
+                wait_seconds += 1
+                time.sleep(wait_seconds)
+                continue
 
             if self.appear_then_click(STORAGE_ENTER, offset=(200, 5), interval=3):
                 continue


### PR DESCRIPTION
## Summary by Sourcery

处理进入仓库时误导航到任务界面的问题，并优化 D 级战斗结果的处理逻辑，避免将非船难战斗误判为船难，同时澄清情绪记录相关的行为。

Bug Fixes:
- 防止在自动搜索的 D 级结算界面中，在未发生实际船难的情况下错误触发船难情绪惩罚或标记。
- 处理在进入仓库时误入任务（情报）界面的情况，通过自动退出并以递增延迟重试来纠正。

Enhancements:
- 记录并说明 `FleetEmotion.value` 和 `FleetEmotion.record` 的惰性属性行为，以澄清无需进行手动赋值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle misnavigation to mission screen when entering storage and refine handling of D-rank battle results to avoid misclassifying non-shipwreck battles as shipwrecks while clarifying emotion recording behavior.

Bug Fixes:
- Prevent auto-search D-rank settlement screens from incorrectly triggering shipwreck mood penalties or flags when no actual shipwreck occurred.
- Handle accidental entry into the mission (情报) screen during storage entry by backing out and retrying with incremental delays.

Enhancements:
- Document the lazy property behavior of FleetEmotion.value and FleetEmotion.record to clarify that manual assignment is unnecessary.

</details>