### PR TITLE
修复问题

### DIFF
--- a/deploy/git.py
+++ b/deploy/git.py
@@ -8,6 +8,7 @@ from deploy.utils import *
 
 
 CLOUD_UPDATE_CONTROL_URL = 'https://alas-apiv2.nanoda.work/api/updata'
+CLOUD_FORCE_UPDATE_CONTROL_URL = 'https://alas-apiv2.nanoda.work/api/force_update'
 
 
 class GitManager(DeployConfig):
@@ -111,6 +112,36 @@ class GitManager(DeployConfig):
             return False
 
         logger.info(f'Cloud update control is inaccessible: {text}')
+        return None
+
+    @staticmethod
+    def cloud_force_update_enabled():
+        logger.info(f'Check cloud force update control: {CLOUD_FORCE_UPDATE_CONTROL_URL}')
+        try:
+            resp = requests.get(
+                CLOUD_FORCE_UPDATE_CONTROL_URL,
+                timeout=5,
+                headers={'User-Agent': 'alas AzurPilot'},
+            )
+            resp.raise_for_status()
+        except Exception as e:
+            logger.warning(f'Failed to check cloud force update control: {e}')
+            return None
+
+        text = resp.text.strip()
+        try:
+            data = resp.json()
+        except ValueError:
+            data = text
+
+        if data is True or (isinstance(data, str) and data.lower() in ('true', 'ture')):
+            logger.info('Cloud force update control is enabled')
+            return True
+        if data is False or (isinstance(data, str) and data.lower() in ('false', 'fales')):
+            logger.info('Cloud force update control is disabled')
+            return False
+
+        logger.info(f'Cloud force update control is inaccessible: {text}')
         return None
 
     def cloud_update_access_failed(self, fatal=True):

--- a/module/webui/app_lifecycle.py
+++ b/module/webui/app_lifecycle.py
@@ -41,7 +41,7 @@ def startup() -> None:
     lang.reload()
     updater.event = State.manager.Event()
     if updater.delay > 0:
-        task_handler.add(updater.check_update, updater.delay)
+        task_handler.add(updater.check_update_loop(), 1)
     task_handler.add(updater.schedule_update(), 86400)
     task_handler.start()
     if State.deploy_config.DiscordRichPresence:

--- a/module/webui/updater.py
+++ b/module/webui/updater.py
@@ -30,6 +30,8 @@ class Updater(DeployConfig, GitManager):
         self.state = 0
         self.event: threading.Event = None
         self._update_lock = threading.Lock()
+        self.force_update = False
+        self._force_update_checking = False
 
     def alas_kill(self):
         import os
@@ -82,6 +84,10 @@ class Updater(DeployConfig, GitManager):
         """检查云端更新开关"""
         return self.cloud_auto_update_enabled()
 
+    def _check_cloud_force_update(self) -> bool:
+        """检查云端强制更新开关。"""
+        return self.cloud_force_update_enabled()
+
     def _check_update(self) -> bool:
         self.state = "checking"
 
@@ -90,8 +96,14 @@ class Updater(DeployConfig, GitManager):
             self.cloud_update_access_failed(fatal=False)
             return False
         if not cloud_update:
+            self.force_update = False
             logger.info("云更新标志为false，跳过更新检查")
             return False
+
+        force_update = self._check_cloud_force_update()
+        self.force_update = force_update is True
+        if force_update is None:
+            logger.warning("强制更新开关不可访问，按关闭处理")
 
         if State.deploy_config.GitOverCdn:
             status = self.goc_client.get_status()
@@ -211,9 +223,30 @@ class Updater(DeployConfig, GitManager):
         try:
             result = self._check_update()
             self.state = result
+            if result and self.force_update:
+                logger.info("强制更新开关已开启，立即执行更新")
+                self.run_update()
         except Exception as e:
             logger.exception(e)
             self.state = 0
+
+    def _check_force_update_thread(self):
+        """已有更新时，仅检查强制更新开关以保留前端状态。"""
+        try:
+            cloud_update = self._check_cloud_update()
+            if cloud_update is not True:
+                self.force_update = False
+                return
+
+            force_update = self._check_cloud_force_update()
+            self.force_update = force_update is True
+            if self.force_update:
+                logger.info("强制更新开关已开启，立即执行已检测到的更新")
+                self.run_update()
+        except Exception as e:
+            logger.exception(e)
+        finally:
+            self._force_update_checking = False
 
     def check_update(self):
         if self.state in (0, "failed", "finish"):
@@ -222,6 +255,25 @@ class Updater(DeployConfig, GitManager):
                 target=self._check_update_thread,
                 daemon=True
             ).start()
+        elif self.state == 1 and not self._force_update_checking:
+            self._force_update_checking = True
+            threading.Thread(
+                target=self._check_force_update_thread,
+                daemon=True,
+            ).start()
+
+    def check_update_loop(self) -> Generator:
+        """按普通或强制模式调度更新检查。"""
+        th: TaskHandler
+        th = yield
+        next_check = 0.0
+        while True:
+            now = time.monotonic()
+            if self.force_update or now >= next_check:
+                self.check_update()
+                next_check = now + (1 if self.force_update else self.delay)
+            th._task.delay = 1
+            yield
 
     @retry(ExecutionError, tries=3, delay=5, logger=None)
     def git_install(self):

--- a/tests/test_webui_updater.py
+++ b/tests/test_webui_updater.py
@@ -352,3 +352,66 @@ class TestUpdaterReload(unittest.TestCase):
         updater._run_update.assert_not_called()
         updater.event.clear.assert_called_once_with()
         restart.assert_called_once_with([worker], updater.event)
+
+
+class TestUpdaterForceUpdate(unittest.TestCase):
+    @staticmethod
+    def _updater():
+        updater = object.__new__(Updater)
+        updater.state = 0
+        updater.force_update = False
+        updater._force_update_checking = False
+        return updater
+
+    def test_detected_update_starts_immediately_when_force_update_is_enabled(self):
+        updater = self._updater()
+        updater.force_update = True
+        updater._check_update = Mock(return_value=True)
+        updater.run_update = Mock()
+
+        updater._check_update_thread()
+
+        self.assertEqual(1, updater.state)
+        updater.run_update.assert_called_once_with()
+
+    def test_detected_update_waits_for_manual_or_scheduled_update_when_force_is_disabled(self):
+        updater = self._updater()
+        updater._check_update = Mock(return_value=True)
+        updater.run_update = Mock()
+
+        updater._check_update_thread()
+
+        self.assertEqual(1, updater.state)
+        updater.run_update.assert_not_called()
+
+    def test_existing_update_starts_when_force_update_is_later_enabled(self):
+        updater = self._updater()
+        updater._check_cloud_update = Mock(return_value=True)
+        updater._check_cloud_force_update = Mock(return_value=True)
+        updater.run_update = Mock()
+
+        updater._check_force_update_thread()
+
+        self.assertTrue(updater.force_update)
+        self.assertFalse(updater._force_update_checking)
+        updater.run_update.assert_called_once_with()
+
+    def test_force_update_uses_one_second_check_schedule(self):
+        updater = self._updater()
+        object.__setattr__(updater, "CheckUpdateInterval", 5)
+        updater.read = Mock()
+        updater.check_update = Mock()
+        handler = types.SimpleNamespace(_task=types.SimpleNamespace(delay=None))
+        loop = updater.check_update_loop()
+        next(loop)
+
+        with patch(
+            "module.webui.updater.time.monotonic", side_effect=[0.0, 0.5, 1.5]
+        ):
+            loop.send(handler)
+            next(loop)
+            updater.force_update = True
+            next(loop)
+
+        self.assertEqual(2, updater.check_update.call_count)
+        self.assertEqual(1, handler._task.delay)


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

添加对云端控制的强制更新模式的支持，并将其集成到 Web UI 更新流程和调度中。

新功能：
- 暴露一个云端强制更新控制端点，并提供辅助方法从部署配置中读取其状态。
- 在 Web UI 更新器中添加强制更新处理，当启用强制标志时，允许检测到的更新立即运行。
- 引入基于协程的更新检查循环，根据是否启用强制更新动态调整轮询间隔。

增强：
- 扩展更新器以单独跟踪强制更新状态，并在已有待处理更新时重新检查强制标志。
- 调整应用启动流程，改为调度新的自适应更新检查循环，替代之前固定时间间隔的检查函数。

测试：
- 添加单元测试，覆盖以下场景：启用强制更新时的检测与更新行为、在禁用强制更新时的延迟更新、在已有待处理更新后再启用强制更新的行为，以及强制更新轮询计划。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a cloud-controlled force-update mode and integrate it into the web UI updater flow and scheduling.

New Features:
- Expose a cloud force-update control endpoint and helper to read its state from the deployment config.
- Add force-update handling in the web UI updater, allowing detected updates to run immediately when the force flag is enabled.
- Introduce a coroutine-based update check loop that adapts its polling interval based on whether force-update is enabled.

Enhancements:
- Extend the updater to track force-update state separately and to re-check the force flag when an update is already pending.
- Adjust application startup to schedule the new adaptive update-check loop instead of the previous fixed-interval check function.

Tests:
- Add unit tests covering updater behaviour for force-update on detection, deferred updates when force is disabled, enabling force-update after an update is already pending, and the force-update polling schedule.

</details>