### PR TITLE
修复已知问题

### DIFF
--- a/assets/gui/css/advanced-material-alas.css
+++ b/assets/gui/css/advanced-material-alas.css
@@ -34,8 +34,7 @@
 :root {
 	/* === 色彩系统 === */
 	--alas-apple-bg: #f5f5f7;
-	/* 主题样式通过 WebSocket 内联注入，资源路径相对页面解析。 */
-	--alas-apple-bg-image: url("static/assets/gui/css/bj.jpg");
+	--alas-apple-bg-image: url("https://api.yppp.net/api.php");
 	--alas-apple-bg-noise: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
 	--alas-apple-card-bg: rgba(255, 255, 255, 0.72);
 	--alas-apple-card-bg-solid: #ffffff;

--- a/tests/test_webui_static_assets.py
+++ b/tests/test_webui_static_assets.py
@@ -73,7 +73,7 @@ class TestWebUIStaticAssets(unittest.TestCase):
         self.assertIn('href="pywebio_static/css/app.css?v=', response.text)
         self.assertNotIn("cdn.jsdelivr.net", response.text)
 
-    def test_theme_assets_do_not_depend_on_external_font_services(self):
+    def test_theme_keeps_random_background_without_external_font_services(self):
         theme_css = (PROJECT_ROOT / "assets/gui/css/advanced-material-alas.css").read_text(
             encoding="utf-8"
         )
@@ -83,13 +83,6 @@ class TestWebUIStaticAssets(unittest.TestCase):
 
         self.assertNotIn("fonts.googleapis.com", theme_css)
         self.assertNotIn("fonts.gstatic.com", theme_css)
-        self.assertNotIn("api.yppp.net", theme_css)
+        self.assertIn('url("https://api.yppp.net/api.php")', theme_css)
         self.assertNotIn("fonts.googleapis.com", obs_overlay)
         self.assertNotIn("fonts.gstatic.com", obs_overlay)
-        self.assertIn('url("static/assets/gui/css/bj.jpg")', theme_css)
-        self.assertEqual(
-            urljoin(
-                "https://example.test/azur/", "static/assets/gui/css/bj.jpg"
-            ),
-            "https://example.test/azur/static/assets/gui/css/bj.jpg",
-        )


### PR DESCRIPTION
## Summary by Sourcery

将高级材质主题的背景图片切换为外部随机背景图片 API，同时保持字体资源自托管，并更新测试以反映新行为。

Enhancements:
- 将 `advanced-material-alas` 主题更新为使用外部随机背景图片 API，而不是内置的静态背景资源。

Tests:
- 重命名并调整 Web UI 资源测试，用于验证外部随机背景图片 API 的使用，同时继续禁止使用外部字体服务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch the advanced material theme background image to an external random background API while keeping font assets self-hosted and update tests to reflect the new behavior.

Enhancements:
- Update the advanced-material-alas theme to use an external random background image API instead of a bundled static background asset.

Tests:
- Rename and adjust web UI asset tests to verify use of the external random background API while continuing to forbid external font services.

</details>