### PR TITLE
fix(emotion): 修复舰队心情恢复余数丢失和时间戳漏更新问题

### DIFF
--- a/module/combat/emotion.py
+++ b/module/combat/emotion.py
@@ -170,10 +170,10 @@ class FleetEmotion:
 
         使用连续时间恢复计算，保留浮点恢复量以累积分数部分。
         游戏服务端按实际经过时间精确计算恢复，每6分钟恢复speed点。
-        旧方法用 int() 截断恢复量，每次 record() 重置时间戳后，
-        未满1点的恢复余数被丢弃，长时间运行导致严重低估。
-        现改为 floor() 取整保留整数部分，同时 record() 仅在整数变化时
-        重置时间戳并回扣分数秒，确保余数可跨次累积。
+        使用 int() 截断恢复量的整数部分，未满1点的余数通过
+        _fractional_seconds 保留，由 record() 回扣到 Record 时间戳中，
+        确保余数可跨次累积。int() 截断会导致计算值略低于实际值，
+        符合情绪控制的安全方向（宁可低估也不高估）。
         """
         time_diff = current_time().timestamp() - self.record.timestamp()
         time_diff = max(time_diff, 0)
@@ -274,8 +274,11 @@ class Emotion:
     def record(self):
         """将当前情绪值保存到配置中。
 
-        仅在心情整数值发生变化时更新 Record 时间戳，
-        并将 Record 回扣 fractional_seconds 对应的等效秒数，
+        每次调用都更新 Value 和 Record 时间戳，确保不会因
+        recovery + reduce 恰好使 value 不变时漏更新时间戳，
+        导致下次 update() 从旧时间戳重复计算已消费的恢复量。
+
+        Record 时间戳回扣 fractional_seconds 对应的等效秒数，
         使未满1点的恢复余数可在下次 update() 时继续累积。
 
         注意：FleetEmotion.value 和 FleetEmotion.record 是 @property，
@@ -283,31 +286,26 @@ class Emotion:
         """
         if self.using_public:
             fleet = self.public_fleet
-            old_value = fleet.value
             new_value = fleet.current
-            # 仅在整数变化时重置时间戳，回扣分数秒
-            if new_value != old_value:
-                record_time = current_time().replace(microsecond=0)
-                fractional = getattr(fleet, '_fractional_seconds', 0)
-                if fractional > 0:
-                    # 回扣 fractional_seconds 对应的秒数
-                    record_time = record_time - timedelta(seconds=fractional * 360 / fleet.speed)
-                with self.config.multi_set():
-                    setattr(self.config, fleet.value_name, new_value)
-                    setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
+            record_time = current_time().replace(microsecond=0)
+            fractional = getattr(fleet, '_fractional_seconds', 0)
+            if fractional > 0:
+                # 回扣 fractional_seconds 对应的秒数
+                record_time = record_time - timedelta(seconds=fractional * 360 / fleet.speed)
+            with self.config.multi_set():
+                setattr(self.config, fleet.value_name, new_value)
+                setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
             return
 
         with self.config.multi_set():
             for fleet in self.fleets:
-                old_value = fleet.value
                 new_value = fleet.current
-                if new_value != old_value:
-                    record_time = current_time().replace(microsecond=0)
-                    fractional = getattr(fleet, '_fractional_seconds', 0)
-                    if fractional > 0:
-                        record_time = record_time - timedelta(seconds=fractional * 360 / fleet.speed)
-                    setattr(self.config, fleet.value_name, new_value)
-                    setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
+                record_time = current_time().replace(microsecond=0)
+                fractional = getattr(fleet, '_fractional_seconds', 0)
+                if fractional > 0:
+                    record_time = record_time - timedelta(seconds=fractional * 360 / fleet.speed)
+                setattr(self.config, fleet.value_name, new_value)
+                setattr(self.config, fleet.value_name.replace('Value', 'Record'), record_time)
 
     def show(self):
         """显示当前计算的心情值（含时间恢复），而非上次保存值。"""

--- a/module/device/method/uiautomator_2.py
+++ b/module/device/method/uiautomator_2.py
@@ -104,7 +104,9 @@ def retry(func):
         if func.__name__ in [
             '_app_start_u2_am', '_app_start_u2_monkey',
             'screenshot_uiautomator2',
+            'app_current_uiautomator2',
         ]:
+            # 这些函数失败说明设备连接已断开，应触发重启而非人工介入
             logger.critical(f'[设备-U2] 重试 {func.__name__}() 失败')
             raise EmulatorNotRunningError
 

--- a/module/device/method/utils.py
+++ b/module/device/method/utils.py
@@ -299,6 +299,12 @@ def handle_adb_error(e):
         # Response telling adbd service has reset, client should reconnect
         logger.error(e)
         return True
+    elif text == '':
+        # AdbError('')
+        # 空错误消息，通常是 ADB 连接被模拟器意外关闭（如网络弹窗导致 atx-agent 崩溃）
+        # 断开重连通常可以修复
+        logger.error(e)
+        return True
     else:
         # AdbError()
         logger.exception(e)

--- a/module/map/camera.py
+++ b/module/map/camera.py
@@ -221,6 +221,11 @@ class Camera(MapOperation):
                 logger.warning('[地图-摄像机] 游戏提示导致透视错误')
                 self.device.click(GAME_TIPS)
                 return False
+            elif self.handle_popup_confirm('NETWORK'):
+                # 网络异常弹窗（包含确认按钮的通用弹窗）
+                # 网络弹窗会遮挡地图导致透视检测失败，点击确认后可恢复
+                logger.warning('[地图-摄像机] 网络弹窗或通用弹窗导致透视错误')
+                return False
             elif 'Camera outside map' in str(e):
                 string = str(e)
                 logger.warning(string)

--- a/module/os_ash/meta.py
+++ b/module/os_ash/meta.py
@@ -621,6 +621,9 @@ class OpsiAshBeacon(Meta):
                 MetaReward(self.config, self.device).run(category=meta)
             self._meta_receive = []
             self.config.task_delay(server_update=True)
+        # MetaReward 会导航到 META/档案页面，领取完毕后需返回主界面，
+        # 否则下一个任务启动时游戏仍在 META 页面导致页面识别失败而卡死
+        self.ui_goto_main()
 
 
 class AshBeaconAssist(Meta):
@@ -788,5 +791,8 @@ class AshBeaconAssist(Meta):
         if self._begin_meta_assist():
             MetaReward(self.config, self.device).run()
             self.config.task_delay(server_update=True)
+            # MetaReward 会导航到 META 页面，领取完毕后需返回主界面，
+            # 否则下一个任务启动时游戏仍在 META 页面导致页面识别失败而卡死
+            self.ui_goto_main()
         else:
             self.config.task_delay(minute=(10, 20))

--- a/module/ui/ui.py
+++ b/module/ui/ui.py
@@ -293,6 +293,8 @@ class UI(InfoHandler):
         self.interval_clear(list(Page.iter_check_buttons()))
 
         logger.hr(f"UI 导航到 {destination}")
+        # 导航超时计时器：长时间无法识别页面时触发恢复
+        nav_timeout = Timer(30, count=60).start()
         while 1:
             GOTO_MAIN.clear_offset()
             if skip_first_screenshot:
@@ -323,11 +325,30 @@ class UI(InfoHandler):
                     clicked = True
                     break
             if clicked:
+                nav_timeout.reset()
                 continue
 
             # 处理额外弹窗
             if self.ui_additional(get_ship=get_ship):
+                nav_timeout.reset()
                 continue
+
+            # 导航超时：当前页面无法识别，调用 ui_get_current_page 触发恢复
+            if nav_timeout.reached():
+                logger.warning(f'[UI] 导航到 {destination} 超时，尝试检测当前页面并恢复')
+                Page.clear_connection()
+                current = self.ui_get_current_page(skip_first_screenshot=True)
+                if current == destination:
+                    logger.info(f'[UI] 到达页面: {destination}')
+                    return
+                # 主界面新旧主题互为等价
+                if destination in (page_main, page_main_white) and self.is_in_main():
+                    logger.info(f'[UI] 到达页面: {destination}')
+                    return
+                # 重新初始化导航
+                Page.init_connection(destination)
+                self.interval_clear(list(Page.iter_check_buttons()))
+                nav_timeout.reset()
 
         # 重置页面连接
         Page.clear_connection()


### PR DESCRIPTION
1. 调整情绪恢复计算逻辑，保留小数余数跨次累积
2. 修改record方法，每次调用都更新时间戳，避免情绪值未变化时漏更新
3. 优化注释说明，明确计算安全方向为宁可低估不高估

## Summary by Sourcery

修复情绪恢复的累积与时间戳记录问题，并提升在导航、META 奖励、网络弹窗以及 ADB/uiautomator2 故障情况下的 UI/设备鲁棒性。

Bug Fixes:
- 在更新过程中保留情绪恢复的小数部分，同时让计算结果保持在安全的轻微低估范围内。
- 在保存时始终更新舰队情绪记录的时间戳，防止重复使用过期时间戳并导致恢复量被重复计算。
- 当无法识别目标页面时，增加导航超时和恢复路径，避免 UI 卡死。
- 在领取 META 奖励后确保返回主界面，使后续任务始终从有效页面开始。
- 在地图相机视图中处理网络或通用确认弹窗，以恢复视角检测。
- 将空的 ADB 错误信息视为可重连的连接中断，而不是致命错误。
- 将关键 uiautomator2 设备操作中的重复失败升级为 “模拟器未运行” 状态，以触发自动重启，而无需人工干预。

Enhancements:
- 明确情绪恢复相关注释，记录在计算上优先选择低估而非高估的安全策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix emotion recovery accumulation and timestamp recording, and improve UI/device robustness around navigation, META rewards, network popups, and ADB/uiautomator2 failures.

Bug Fixes:
- Preserve fractional emotion recovery across updates while keeping calculations safely slightly underestimated.
- Always update fleet emotion record timestamps on save to avoid reusing stale timestamps and double-counting recovery.
- Add a navigation timeout and recovery path when the destination page cannot be recognized, preventing UI hangs.
- Ensure returning to the main screen after META reward collection so subsequent tasks start from a valid page.
- Handle network or generic confirmation popups in map camera view to restore perspective detection.
- Treat empty ADB error messages as reconnectable connection drops instead of fatal errors.
- Escalate repeated failures in key uiautomator2 device operations as emulator-not-running to trigger automatic restart instead of manual intervention.

Enhancements:
- Clarify emotion recovery comments to document safety preference for underestimation over overestimation.

</details>