### PR TITLE
fix(os): 修复大世界进入储物仓误进入全球地图后卡死的问题

### DIFF
--- a/module/os_handler/storage.py
+++ b/module/os_handler/storage.py
@@ -64,6 +64,13 @@ class StorageHandler(GlobeOperation, ZoneManager):
                 time.sleep(wait_seconds)
                 continue
 
+            if self.is_in_globe():
+                logger.info('[大世界-仓库] 误进入全球地图，尝试返回海域')
+                self.os_globe_goto_map()
+                wait_seconds += 1
+                time.sleep(wait_seconds)
+                continue
+
             if self.appear_then_click(STORAGE_ENTER, offset=(200, 5), interval=3):
                 continue
             # A game bug that AUTO_SEARCH_REWARD from the last cleared zone popups


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 检测在访问仓库时意外进入全球地图的情况，并返回海域以避免卡死。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Detect accidental entry into the global map during warehouse access and navigate back to the sea area to avoid a freeze.

</details>