### PR TITLE
feat(config,webui): 增加立即运行按钮

### DIFF
--- a/module/config/argument/gui.yaml
+++ b/module/config/argument/gui.yaml
@@ -336,6 +336,7 @@ StartupRun:
 Text:
   InvalidFeedBack:
   Clear:
+  RunNow:
   EnterPassword:
   ChooseFile:
 

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -6232,6 +6232,7 @@
     "Text": {
       "InvalidFeedBack": "Format error. Example: {0}",
       "Clear": "Clear",
+      "RunNow": "Run Now",
       "EnterPassword": "Enter password",
       "ChooseFile": "Select file"
     },

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -6232,6 +6232,7 @@
     "Text": {
       "InvalidFeedBack": "フォーマットエラー。例: {0}",
       "Clear": "クリア",
+      "RunNow": "今すぐ実行",
       "EnterPassword": "パスワードを入力してください",
       "ChooseFile": "ファイルを選択"
     },

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -6232,6 +6232,7 @@
     "Text": {
       "InvalidFeedBack": "格式错误。 示例：{0}",
       "Clear": "清除",
+      "RunNow": "立即运行",
       "EnterPassword": "输入密码",
       "ChooseFile": "选择文件"
     },

--- a/module/config/i18n/zh-MIAO.json
+++ b/module/config/i18n/zh-MIAO.json
@@ -6232,6 +6232,7 @@
     "Text": {
       "InvalidFeedBack": "格式错误喵。示例：{0}",
       "Clear": "清除喵",
+      "RunNow": "立即运行喵",
       "EnterPassword": "输入密码喵",
       "ChooseFile": "选择文件喵"
     },

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -6232,6 +6232,7 @@
     "Text": {
       "InvalidFeedBack": "格式錯誤。 示例：{0}",
       "Clear": "清除",
+      "RunNow": "立即運行",
       "EnterPassword": "輸入密碼",
       "ChooseFile": "選擇檔案"
     },

--- a/module/webui/app_task_config.py
+++ b/module/webui/app_task_config.py
@@ -34,6 +34,7 @@ from module.webui.app_dependencies import (
     put_input,
     put_none,
     put_output,
+    put_row,
     put_scope,
     put_text,
     queue,
@@ -462,9 +463,27 @@ class TaskConfigMixin(WebUIMixinBase):
         ) in self._iter_group_arguments(task, group_name, arg_dict, config):
             output_kwargs = resolved_kwargs.copy()
             if group_name == "Scheduler" and arg_name == "NextRun":
-                output_kwargs["after"] = put_text(self._time_status_text()).style(
-                    "font-size: .75rem; opacity: .68; margin: .2rem .25rem 0;"
-                )
+                # 立即运行按钮：清空 NextRun 触发调度器立即执行该任务
+                run_now_path = f"{task}.Scheduler.NextRun"
+
+                def _run_now(_path=run_now_path):
+                    self.modified_config_queue.put({"name": _path, "value": ""})
+                    toast(t("Gui.Text.RunNow"))
+
+                run_now_btn = put_html(
+                    f'<a href="javascript:void(0)" '
+                    f'style="font-size: .75rem; cursor: pointer;">'
+                    f'{t("Gui.Text.RunNow")}</a>'
+                ).onclick(_run_now)
+                output_kwargs["after"] = put_row(
+                    [
+                        run_now_btn,
+                        put_text(self._time_status_text()).style(
+                            "font-size: .75rem; opacity: .68;"
+                        ),
+                    ],
+                    size="auto 1fr",
+                ).style("margin: .2rem .25rem 0; gap: .5rem;")
             output_kwargs["invalid_feedback"] = t(
                 "Gui.Text.InvalidFeedBack", output_kwargs["value"]
             )


### PR DESCRIPTION
## Summary by Sourcery

在网页界面中为计划任务添加“立即运行”控件，并接入对应的配置和 i18n 条目。

新功能：
- 允许用户通过在网页界面 Scheduler 区域中的新“Run Now”控件清除计划任务的 `NextRun` 字段，从而立即触发该计划任务。

优化：
- 改进 Scheduler 中 NextRun 的显示方式，将“立即运行”控件与现有的时间状态文本组合到同一个样式化的行中进行展示。

杂项：
- 扩展 GUI 文本配置和翻译，新增用于网页界面控件的 `RunNow` 标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a “run now” control for scheduled tasks in the web UI and wire up the corresponding configuration and i18n entries.

New Features:
- Allow users to immediately trigger a scheduled task by clearing its NextRun field via a new Run Now control in the Scheduler section of the web UI.

Enhancements:
- Improve the Scheduler NextRun display by combining the immediate run control with the existing time status text in a single, styled row.

Chores:
- Extend GUI text configuration and translations with a new RunNow label used by the web UI control.

</details>