### PR TITLE
fix: only write dashboard record once per changed dict update

### DIFF
--- a/module/log_res/log_res.py
+++ b/module/log_res/log_res.py
@@ -20,7 +20,6 @@ class LogRes:
     def __setattr__(self, key, value):
         if key in self.groups:
             _key_group = f'Dashboard.{key}'
-            _mod = False
             original = deep_get(self.config.data, keys=_key_group)
             if isinstance(value, int):
                 if original['Value'] != value:
@@ -37,11 +36,15 @@ class LogRes:
                         except Exception:
                             logger.exception('Failed to save yellow coin snapshot')
             elif isinstance(value, dict):
+                changed = False
                 for value_name, _value in value.items():
-                    if _value == original[value_name]:
+                    original_value = original.get(value_name) if isinstance(original, dict) else None
+                    if _value == original_value:
                         continue
                     _key = _key_group + f'.{value_name}'
                     self.config.modified[_key] = _value
+                    changed = True
+                if changed:
                     _key_time = _key_group + f'.Record'
                     _time = datetime.now().replace(microsecond=0)
                     self.config.modified[_key_time] = _time


### PR DESCRIPTION
## Summary by Sourcery

确保每次字典变更只更新一次仪表板记录，并避免在原始值缺失时出现错误。

错误修复：
- 当在一次操作中更新字典中的多个键时，避免为仪表板记录写入多个时间戳。
- 在将字典条目进行比较、并在标记配置已修改之前，增加保护以防原始值缺失或原始值不是字典。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure dashboard records are only updated once per dict change and avoid errors when original values are missing.

Bug Fixes:
- Avoid writing multiple dashboard record timestamps when several keys in a dict are updated in one operation.
- Guard against missing or non-dict original values when comparing dict entries before marking configuration as modified.

</details>