### PR TITLE
Update group link and fix Gitcode 418 issue

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -48,7 +48,7 @@
     <img src="https://img.shields.io/badge/Web-Download-blue?style=for-the-badge&logo=google-chrome&logoColor=white" />
   </a>
   &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://addgroup.nanoda.work/#/">
+  <a href="https://join.nanoda.work/#/">
     <img src="https://img.shields.io/badge/Community-QQ-red?style=for-the-badge&logo=tencent-qq&logoColor=white" />
   </a>
 </div>

--- a/README.ja.md
+++ b/README.ja.md
@@ -48,7 +48,7 @@
     <img src="https://img.shields.io/badge/Web-ダウンロード-blue?style=for-the-badge&logo=google-chrome&logoColor=white" />
   </a>
   &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://addgroup.nanoda.work/#/">
+  <a href="https://join.nanoda.work/#/">
     <img src="https://img.shields.io/badge/交流群-QQ-red?style=for-the-badge&logo=tencent-qq&logoColor=white" />
   </a>
 </div>

--- a/README.ko.md
+++ b/README.ko.md
@@ -48,7 +48,7 @@
     <img src="https://img.shields.io/badge/Web-다운로드-blue?style=for-the-badge&logo=google-chrome&logoColor=white" />
   </a>
   &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://addgroup.nanoda.work/#/">
+  <a href="https://join.nanoda.work/#/">
     <img src="https://img.shields.io/badge/커뮤니티-QQ-red?style=for-the-badge&logo=tencent-qq&logoColor=white" />
   </a>
 </div>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
     <img src="https://img.shields.io/badge/Web-下载-blue?style=for-the-badge&logo=google-chrome&logoColor=white" />
   </a>
   &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://addgroup.nanoda.work/#/">
+  <a href="https://join.nanoda.work/#/">
     <img src="https://img.shields.io/badge/交流群-QQ-red?style=for-the-badge&logo=tencent-qq&logoColor=white" />
   </a>
 </div>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -48,7 +48,7 @@
     <img src="https://img.shields.io/badge/Web-下載-blue?style=for-the-badge&logo=google-chrome&logoColor=white" />
   </a>
   &nbsp;&nbsp;&nbsp;&nbsp;
-  <a href="https://addgroup.nanoda.work/#/">
+  <a href="https://join.nanoda.work/#/">
     <img src="https://img.shields.io/badge/交流群-QQ-red?style=for-the-badge&logo=tencent-qq&logoColor=white" />
   </a>
 </div>

--- a/deploy/Windows/git.py
+++ b/deploy/Windows/git.py
@@ -106,8 +106,8 @@ class GitManager(DeployConfig):
     def git_repository_init(
             self, repo, source='origin', branch='master', proxy='', ssl_verify=True
     ):
-        # 配置操作不需要 UA 注入（不涉及 HTTP），直接用原始 git 路径
-        git = f'"{self.git}"'
+        # 所有 git 命令统一带随机 UA，绕过 gitcode 等仓库对特定 UA 的 418 封禁
+        git = f'"{self.git}" -c http.userAgent={self.git_user_agent()}'
 
         logger.hr('Git Init', 1)
         if not self.execute(f'{git} init', allow_failure=True):

--- a/deploy/Windows/git.py
+++ b/deploy/Windows/git.py
@@ -1,7 +1,9 @@
 import configparser
 import os
+import random
+import time
 
-from deploy.Windows.config import DeployConfig
+from deploy.Windows.config import DeployConfig, ExecutionError
 from deploy.Windows.logger import Progress, logger
 from deploy.Windows.utils import cached_property
 from deploy.git_over_cdn.client import GitOverCdnClient
@@ -52,46 +54,98 @@ class GitManager(DeployConfig):
         conf.read('./.git/config')
         return conf
 
+    @staticmethod
+    def git_user_agent():
+        """生成随机的 git User-Agent，绕开部分镜像仓库对特定 git 版本的封禁。
+
+        版本号各段与构建后缀均由随机数生成器产出，每次更新 UA 都不同，
+        避免命中 gitcode 等仓库针对特定 UA 字符串的封禁（418）。
+        """
+        while True:
+            major = random.randint(2, 3)
+            minor = random.randint(30, 59)
+            patch = random.randint(0, 9)
+            build = random.randint(1, 5)
+            sub = random.randint(1, 9999)
+            if random.random() < 0.3:
+                ua = f'git/{major}.{minor}.{patch}'
+            elif random.random() < 0.6:
+                ua = f'git/{major}.{minor}.{patch}.windows.{build}'
+            else:
+                ua = f'git/{major}.{minor}.{patch}.windows.{build}.{sub}'
+            if not ua.startswith('git/2.51.0.windows.2'):
+                break
+        return ua
+
+    def _fetch_with_retry(self, source, branch, max_retry=5, delay=2):
+        """带 UA 重试的 git fetch。
+
+        gitcode 等仓库会返回 418 拦截特定 UA，此时自动更换 UA 重试。
+
+        Args:
+            source: 远程源名称。
+            branch: 分支名称。
+            max_retry: 最大尝试次数（含首次）。
+            delay: 重试间隔秒数。
+
+        Raises:
+            ExecutionError: 所有尝试均失败时抛出。
+        """
+        ua = self.git_user_agent()
+        for i in range(max_retry):
+            git = f'"{self.git}" -c http.userAgent={ua}'
+            logger.info(f'Use git User-Agent: {ua}')
+            if self.execute(f'{git} fetch {source} {branch}'):
+                return
+            logger.warning(f'git fetch failed with UA {ua}, attempt {i + 1}/{max_retry}')
+            if i < max_retry - 1:
+                time.sleep(delay)
+                ua = self.git_user_agent()
+        raise ExecutionError
+
     def git_repository_init(
             self, repo, source='origin', branch='master', proxy='', ssl_verify=True
     ):
+        # 配置操作不需要 UA 注入（不涉及 HTTP），直接用原始 git 路径
+        git = f'"{self.git}"'
+
         logger.hr('Git Init', 1)
-        if not self.execute(f'"{self.git}" init', allow_failure=True):
+        if not self.execute(f'{git} init', allow_failure=True):
             self.remove('./.git/config')
             self.remove('./.git/index')
             self.remove('./.git/HEAD')
             self.remove('./.git/ORIG_HEAD')
-            self.execute(f'"{self.git}" init')
+            self.execute(f'{git} init')
         Progress.GitInit()
 
         logger.hr('Set Git Proxy', 1)
         if proxy:
             if not self.git_config.check('http', 'proxy', value=proxy):
-                self.execute(f'"{self.git}" config --local http.proxy {proxy}')
+                self.execute(f'{git} config --local http.proxy {proxy}')
             if not self.git_config.check('https', 'proxy', value=proxy):
-                self.execute(f'"{self.git}" config --local https.proxy {proxy}')
+                self.execute(f'{git} config --local https.proxy {proxy}')
         else:
             if not self.git_config.check('http', 'proxy', value=None):
-                self.execute(f'"{self.git}" config --local --unset http.proxy', allow_failure=True)
+                self.execute(f'{git} config --local --unset http.proxy', allow_failure=True)
             if not self.git_config.check('https', 'proxy', value=None):
-                self.execute(f'"{self.git}" config --local --unset https.proxy', allow_failure=True)
+                self.execute(f'{git} config --local --unset https.proxy', allow_failure=True)
 
         if ssl_verify:
             if not self.git_config.check('http', 'sslVerify', value='true'):
-                self.execute(f'"{self.git}" config --local http.sslVerify true', allow_failure=True)
+                self.execute(f'{git} config --local http.sslVerify true', allow_failure=True)
         else:
             if not self.git_config.check('http', 'sslVerify', value='false'):
-                self.execute(f'"{self.git}" config --local http.sslVerify false', allow_failure=True)
+                self.execute(f'{git} config --local http.sslVerify false', allow_failure=True)
         Progress.GitSetConfig()
 
         logger.hr('Set Git Repository', 1)
         if not self.git_config.check(f'remote "{source}"', 'url', value=repo):
-            if not self.execute(f'"{self.git}" remote set-url {source} {repo}', allow_failure=True):
-                self.execute(f'"{self.git}" remote add {source} {repo}')
+            if not self.execute(f'{git} remote set-url {source} {repo}', allow_failure=True):
+                self.execute(f'{git} remote add {source} {repo}')
         Progress.GitSetRepo()
 
         logger.hr('Fetch Repository Branch', 1)
-        self.execute(f'"{self.git}" fetch {source} {branch}')
+        self._fetch_with_retry(source, branch)
         Progress.GitFetch()
 
         logger.hr('Pull Repository Branch', 1)
@@ -104,15 +158,15 @@ class GitManager(DeployConfig):
             if os.path.exists(lock_file):
                 logger.info(f'Lock file {lock_file} exists, removing')
                 os.remove(lock_file)
-        self.execute(f'"{self.git}" reset --hard {source}/{branch}')
+        self.execute(f'{git} reset --hard {source}/{branch}')
         Progress.GitReset()
         # git fetch 已执行，checkout 会更快
-        if not self.execute(f'"{self.git}" checkout {branch}', allow_failure=True):
-            self.execute(f'"{self.git}" pull --ff-only {source} {branch}')
+        if not self.execute(f'{git} checkout {branch}', allow_failure=True):
+            self.execute(f'{git} pull --ff-only {source} {branch}')
         Progress.GitCheckout()
 
         logger.hr('Show Version', 1)
-        self.execute(f'"{self.git}" --no-pager log --no-merges -1')
+        self.execute(f'{git} --no-pager log --no-merges -1')
         Progress.GitShowVersion()
 
     @property

--- a/deploy/git.py
+++ b/deploy/git.py
@@ -1,3 +1,6 @@
+import random
+import time
+
 import requests
 
 from deploy.config import DeployConfig, ExecutionError
@@ -29,35 +32,88 @@ class GitManager(DeployConfig):
         except FileNotFoundError:
             logger.info(f'File not found: {file}')
 
+    @staticmethod
+    def git_user_agent():
+        """生成随机的 git User-Agent，绕开部分镜像仓库对特定 git 版本的封禁。
+
+        版本号各段与构建后缀均由随机数生成器产出，每次更新 UA 都不同，
+        避免命中 gitcode 等仓库针对特定 UA 字符串的封禁（418）。
+        """
+        while True:
+            major = random.randint(2, 3)
+            minor = random.randint(30, 59)
+            patch = random.randint(0, 9)
+            build = random.randint(1, 5)
+            sub = random.randint(1, 9999)
+            if random.random() < 0.3:
+                ua = f'git/{major}.{minor}.{patch}'
+            elif random.random() < 0.6:
+                ua = f'git/{major}.{minor}.{patch}.windows.{build}'
+            else:
+                ua = f'git/{major}.{minor}.{patch}.windows.{build}.{sub}'
+            if not ua.startswith('git/2.51.0.windows.2'):
+                break
+        return ua
+
+    def _fetch_with_retry(self, source, branch, max_retry=5, delay=2):
+        """带 UA 重试的 git fetch。
+
+        gitcode 等仓库会返回 418 拦截特定 UA，此时自动更换 UA 重试。
+        不需要遍历 init/config/remote——那些不涉及 HTTP 请求。
+
+        Args:
+            source: 远程源名称。
+            branch: 分支名称。
+            max_retry: 最大尝试次数（含首次）。
+            delay: 重试间隔秒数。
+
+        Raises:
+            ExecutionError: 所有尝试均失败时抛出。
+        """
+        ua = self.git_user_agent()
+        for i in range(max_retry):
+            git = f'"{self.git}" -c http.userAgent={ua}'
+            logger.info(f'Use git User-Agent: {ua}')
+            if self.execute(f'{git} fetch {source} {branch}'):
+                return
+            logger.warning(f'git fetch failed with UA {ua}, attempt {i + 1}/{max_retry}')
+            if i < max_retry - 1:
+                time.sleep(delay)
+                ua = self.git_user_agent()
+        raise ExecutionError
+
     def git_repository_init(
             self, repo, source='origin', branch='master', proxy='', ssl_verify=True
     ):
+        # 配置操作不需要 UA 注入（不涉及 HTTP），直接用原始 git 路径
+        git = f'"{self.git}"'
+
         logger.hr('Git Init', 1)
-        if not self.execute(f'"{self.git}" init', allow_failure=True):
+        if not self.execute(f'{git} init', allow_failure=True):
             self.remove('./.git/config')
             self.remove('./.git/index')
             self.remove('./.git/HEAD')
-            self.execute(f'"{self.git}" init')
+            self.execute(f'{git} init')
 
         logger.hr('Set Git Proxy', 1)
         if proxy:
-            self.execute(f'"{self.git}" config --local http.proxy {proxy}')
-            self.execute(f'"{self.git}" config --local https.proxy {proxy}')
+            self.execute(f'{git} config --local http.proxy {proxy}')
+            self.execute(f'{git} config --local https.proxy {proxy}')
         else:
-            self.execute(f'"{self.git}" config --local --unset http.proxy', allow_failure=True)
-            self.execute(f'"{self.git}" config --local --unset https.proxy', allow_failure=True)
+            self.execute(f'{git} config --local --unset http.proxy', allow_failure=True)
+            self.execute(f'{git} config --local --unset https.proxy', allow_failure=True)
 
         if ssl_verify:
-            self.execute(f'"{self.git}" config --local http.sslVerify true', allow_failure=True)
+            self.execute(f'{git} config --local http.sslVerify true', allow_failure=True)
         else:
-            self.execute(f'"{self.git}" config --local http.sslVerify false', allow_failure=True)
+            self.execute(f'{git} config --local http.sslVerify false', allow_failure=True)
 
         logger.hr('Set Git Repository', 1)
-        if not self.execute(f'"{self.git}" remote set-url {source} {repo}', allow_failure=True):
-            self.execute(f'"{self.git}" remote add {source} {repo}')
+        if not self.execute(f'{git} remote set-url {source} {repo}', allow_failure=True):
+            self.execute(f'{git} remote add {source} {repo}')
 
         logger.hr('Fetch Repository Branch', 1)
-        self.execute(f'"{self.git}" fetch {source} {branch}')
+        self._fetch_with_retry(source, branch)
 
         logger.hr('Pull Repository Branch', 1)
         # 移除 git 锁文件
@@ -69,11 +125,11 @@ class GitManager(DeployConfig):
             if os.path.exists(lock_file):
                 logger.info(f'Lock file {lock_file} exists, removing')
                 os.remove(lock_file)
-        self.execute(f'"{self.git}" reset --hard {source}/{branch}')
-        self.execute(f'"{self.git}" pull --ff-only {source} {branch}')
+        self.execute(f'{git} reset --hard {source}/{branch}')
+        self.execute(f'{git} pull --ff-only {source} {branch}')
 
         logger.hr('Show Version', 1)
-        self.execute(f'"{self.git}" --no-pager log --no-merges -1')
+        self.execute(f'{git} --no-pager log --no-merges -1')
 
     @property
     def goc_client(self):

--- a/deploy/git.py
+++ b/deploy/git.py
@@ -85,8 +85,8 @@ class GitManager(DeployConfig):
     def git_repository_init(
             self, repo, source='origin', branch='master', proxy='', ssl_verify=True
     ):
-        # 配置操作不需要 UA 注入（不涉及 HTTP），直接用原始 git 路径
-        git = f'"{self.git}"'
+        # 所有 git 命令统一带随机 UA，绕过 gitcode 等仓库对特定 UA 的 418 封禁
+        git = f'"{self.git}" -c http.userAgent={self.git_user_agent()}'
 
         logger.hr('Git Init', 1)
         if not self.execute(f'{git} init', allow_failure=True):

--- a/module/webui/app_home.py
+++ b/module/webui/app_home.py
@@ -108,7 +108,7 @@ class HomeMixin(WebUIMixinBase):
             上游项目 / Upstream / 上流プロジェクト / 상류 프로젝트 / 上游專案：`https://github.com/LmeSzinc/AzurLaneAutoScript`
             本项目 / This project / 本プロジェクト / 본 프로젝트 / 本專案：`https://github.com/wess09/AzurPilot`
 
-            如需支持，请联系 / For support, please contact / サポートについてはこちらへ / 지원이 필요하면 아래로 / 如需支援請聯繫：`https://addgroup.nanoda.work/`
+            如需支持，请联系 / For support, please contact / サポートについてはこちらへ / 지원이 필요하면 아래로 / 如需支援請聯繫：`https://join.nanoda.work/`
             """
             ).style("text-align: center")
 


### PR DESCRIPTION
## Summary by Sourcery

通过为所有 git 操作设置随机化的 User-Agent 并使用带重试机制的 fetch 辅助函数，将所有 git 操作经由该机制路由，从而缓解 Gitcode 镜像上的 418 问题，并将社区/支持链接更新为新的 join.nanoda.work URL。

新功能：
- 为所有 git 命令引入随机化的 git User-Agent 生成机制，以便更好地与会屏蔽特定客户端版本的镜像仓库进行互操作。

缺陷修复：
- 处理 Gitcode 返回的 418 响应：在收到 418 时，使用重新生成的 User-Agent 值重试 git fetch，并通过现有的执行错误处理机制抛出/展示失败信息。

文档：
- 更新所有本地化 README 和 Web UI 首页中的社区/支持 QQ 群链接，使其指向新的 join.nanoda.work 地址。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Mitigate Gitcode mirror 418 issues by routing all git operations through a randomized User-Agent and a retrying fetch helper, and update community/support links to the new join.nanoda.work URL.

New Features:
- Introduce randomized git User-Agent generation for all git commands to better interoperate with mirror repositories that block specific client versions.

Bug Fixes:
- Handle Gitcode 418 responses by retrying git fetch with regenerated User-Agent values and surfacing failures via existing execution error handling.

Documentation:
- Update community/support QQ group links across all localized READMEs and the web UI home page to point to the new join.nanoda.work address.

</details>