### PR TITLE
fix(handler): 游戏重启失败3次后观察180秒再升级模拟器重启

### DIFF
--- a/module/device/app_control.py
+++ b/module/device/app_control.py
@@ -4,6 +4,8 @@
 以及 UI 层级结构（hierarchy）的获取和 XPath 元素查询。
 根据控制方法和模拟器类型自动选择 ADB 或 uiautomator2 后端。
 """
+import re
+
 from lxml import etree
 
 from module.base.timer import Timer
@@ -61,6 +63,51 @@ class AppControl(Adb, WSA, Uiautomator2):
         package = self.app_current()
         logger.attr('应用包名', package)
         return package == self.package
+
+    def app_is_running_bounded(self, timeout: int = 10) -> bool:
+        """带固定超时检查目标应用是否在前台。
+
+        恢复流程在模拟器异常时使用，避免 uiautomator2 的重试
+        长时间阻塞游戏重启流程。查询走 ADB shell，单次受 timeout 限制。
+
+        Args:
+            timeout (int): 单次 ADB 查询超时秒数，默认 10 秒。
+
+        Returns:
+            bool: 应用在前台运行返回 True；查询失败或无法判断返回 False。
+        """
+        try:
+            output = self.adb_shell(['dumpsys', 'window', 'windows'], timeout=timeout)
+        except Exception as e:
+            logger.warning(f'[设备-应用] 前台应用检查失败（{timeout}s 超时）: {e}')
+            return False
+
+        _focusedRE = re.compile(
+            r'mCurrentFocus=Window{.*\s+(?P<package>[^\s]+)/(?P<activity>[^\s]+)\}'
+        )
+        m = _focusedRE.search(output or '')
+        if m:
+            package = m.group('package')
+            logger.attr('应用包名', package)
+            return package == self.package
+
+        # 部分设备不输出 mCurrentFocus，回退到 activity top
+        try:
+            output = self.adb_shell(['dumpsys', 'activity', 'top'], timeout=timeout)
+        except Exception as e:
+            logger.warning(f'[设备-应用] 前台 Activity 检查失败（{timeout}s 超时）: {e}')
+            return False
+        _activityRE = re.compile(
+            r'ACTIVITY (?P<package>[^\s]+)/(?P<activity>[^/\s]+) \w+ pid=(?P<pid>\d+)'
+        )
+        packages = [item.group('package') for item in _activityRE.finditer(output or '')]
+        if packages:
+            package = packages[-1]
+            logger.attr('应用包名', package)
+            return package == self.package
+
+        logger.warning('[设备-应用] 无法判断前台应用，按未运行处理')
+        return False
 
     def app_start(self):
         """启动目标应用（碧蓝航线）。

--- a/module/handler/login.py
+++ b/module/handler/login.py
@@ -248,15 +248,15 @@ class LoginHandler(UI):
                 f"进入观察阶段，最多等待 {RESTART_OBSERVE_SECONDS} 秒"
             )
             deadline = time.monotonic() + RESTART_OBSERVE_SECONDS
-            while time.monotonic() < deadline:
+            while 1:
+                if time.monotonic() >= deadline:
+                    break
                 if self.device.app_is_running_bounded():
                     logger.info("[重启] 观察阶段检测到应用恢复运行")
                     is_restart_success = True
                     break
                 remaining = max(0, int(deadline - time.monotonic()))
-                logger.warning(f"[重启] 观察阶段应用仍未恢复，剩余 {remaining} 秒后触发模拟器重启")
-                if remaining <= 0:
-                    break
+                logger.info(f"[重启] 观察阶段应用仍未恢复，剩余 {remaining} 秒后触发模拟器重启")
                 self.device.sleep(min(RESTART_OBSERVE_INTERVAL, remaining))
 
         # 观察阶段仍失败则抛出 EmulatorNotRunningError，

--- a/module/handler/login.py
+++ b/module/handler/login.py
@@ -16,6 +16,8 @@
 # 基于原版 login.py 增加了智能的游戏重启逻辑
 # 用于处理登录流程中的各种弹窗、公告以及在应用崩溃时执行重启恢复操作。
 # 最后更新: 2025-08-25 20:41
+import time
+
 import numpy as np
 from scipy.signal import find_peaks
 # 在导入 adbutils 和 uiautomator2 之前修补 pkg_resources
@@ -36,6 +38,15 @@ from module.map.assets import *
 from module.ui.assets import *
 from module.ui.page import page_campaign_menu
 from module.ui.ui import UI
+
+
+# 应用重启恢复策略：3 次启动失败后进入观察阶段，观察期间仍无恢复则
+# 由上层调度器执行模拟器重启，避免长时间无效重试。
+RESTART_TRIES = 3
+RESTART_FIRST_TRY_WAIT_SECONDS = 30
+RESTART_SUBSEQUENT_TRY_WAIT_SECONDS = 20
+RESTART_OBSERVE_SECONDS = 180
+RESTART_OBSERVE_INTERVAL = 15
 
 
 class LoginHandler(UI):
@@ -205,11 +216,6 @@ class LoginHandler(UI):
 
     def app_restart(self):
         logger.hr('应用重启')
-        # 智能的多次尝试重启逻辑
-        RESTART_TRIES = 4
-        FIRST_TRY_WAIT_SECONDS = 30
-        SUBSEQUENT_TRY_WAIT_SECONDS = 20
-
         is_restart_success = False
 
         clear_cache = getattr(self.config, 'Restart_ClearCache', False)
@@ -220,12 +226,13 @@ class LoginHandler(UI):
                 self.device.app_clear()
             self.device.sleep(3)
             self.device.app_start()
-            wait_seconds = FIRST_TRY_WAIT_SECONDS if i == 0 else SUBSEQUENT_TRY_WAIT_SECONDS
+            wait_seconds = RESTART_FIRST_TRY_WAIT_SECONDS if i == 0 else RESTART_SUBSEQUENT_TRY_WAIT_SECONDS
             logger.info(f"[重启] 等待 {wait_seconds} 秒让应用启动和稳定...")
             self.device.sleep(wait_seconds)
 
-            # 验证应用是否已运行
-            if self.device.app_is_running():
+            # 用带超时的 ADB 检查验证应用是否已运行，
+            # 避免 uiautomator2 重试在模拟器异常时阻塞恢复流程
+            if self.device.app_is_running_bounded():
                 logger.info("[重启] 应用启动成功并正在运行")
                 is_restart_success = True
                 break  # 成功启动，跳出循环
@@ -234,12 +241,37 @@ class LoginHandler(UI):
                 if i < RESTART_TRIES - 1:
                     logger.info("[重启] 重试中...")
 
-        # 所有尝试均失败则抛出 EmulatorNotRunningError，
+        # 连续失败后先进入观察阶段，给慢启动/游戏更新留出恢复时间
+        if not is_restart_success:
+            logger.critical(
+                f"[重启] 应用重启连续失败 {RESTART_TRIES} 次，"
+                f"进入观察阶段，最多等待 {RESTART_OBSERVE_SECONDS} 秒"
+            )
+            deadline = time.monotonic() + RESTART_OBSERVE_SECONDS
+            while time.monotonic() < deadline:
+                if self.device.app_is_running_bounded():
+                    logger.info("[重启] 观察阶段检测到应用恢复运行")
+                    is_restart_success = True
+                    break
+                remaining = max(0, int(deadline - time.monotonic()))
+                logger.warning(f"[重启] 观察阶段应用仍未恢复，剩余 {remaining} 秒后触发模拟器重启")
+                if remaining <= 0:
+                    break
+                self.device.sleep(min(RESTART_OBSERVE_INTERVAL, remaining))
+
+        # 观察阶段仍失败则抛出 EmulatorNotRunningError，
         # 由上层调度器触发模拟器重启流程，而非直接终止。
         if not is_restart_success:
-            logger.critical(f"[重启] 重试 {RESTART_TRIES} 次了！还是死活起不来，你的运行环境是碳基生物能搞出来的？")
+            logger.critical(
+                "[重启] 应用重启连续失败且观察阶段仍未恢复，"
+                "判定模拟器或游戏环境异常，触发模拟器重启"
+            )
             from module.exception import EmulatorNotRunningError
-            raise EmulatorNotRunningError("[重启] 应用重启多次失败，可能模拟器已离线")
+            raise EmulatorNotRunningError(
+                f"[重启] 应用重启连续失败 {RESTART_TRIES} 次，"
+                f"观察 {RESTART_OBSERVE_SECONDS} 秒后仍未恢复，"
+                "判定模拟器或游戏环境异常，触发模拟器重启"
+            )
         self.handle_app_login()
         # self.ensure_no_unfinished_campaign()
 


### PR DESCRIPTION
原 app_restart 固定尝试4次，且 app_is_running() 走 uiautomator2 重试，模拟器失联时可能阻塞约10分钟才触发恢复。现改为3次启动失败后进入180秒观察阶段，使用带10秒超时的ADB前台检查，观察期内恢复则继续登录，仍失败则明确记录原因并抛出 EmulatorNotRunningError 触发模拟器重启。新增 AppControl.app_is_running_bounded 供恢复流程复用，守护模式同样受益。

## Summary by Sourcery

调整游戏重启恢复逻辑，以使用有界的前台检测和观察窗口，在触发模拟器重启前进行判定。

新功能：
- 引入基于 ADB `dumpsys` 输出的有界前台检测函数 `app_is_running_bounded`，用于恢复流程。

错误修复：
- 使用基于 ADB 的限时前台检测，避免在模拟器无响应时，由于 `uiautomator2` 重试导致的重启过程长时间阻塞。

增强改进：
- 调整应用重启策略为：重启 3 次后进入 180 秒观察期，再视情况升级为重启模拟器。
- 在登录处理逻辑中统一标准化初始重启、后续重启以及观察期轮询的时间常量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust game restart recovery to use bounded foreground checks and an observation window before triggering emulator restart.

New Features:
- Introduce a bounded foreground check app_is_running_bounded based on ADB dumpsys output for use in recovery flows.

Bug Fixes:
- Avoid long blocks during restart caused by uiautomator2 retries when the emulator is unresponsive by using a timed ADB-based foreground check.

Enhancements:
- Change app restart strategy to 3 attempts followed by a 180-second observation period before escalating to emulator restart.
- Standardize restart timing constants for initial and subsequent attempts and observation polling in the login handler.

</details>