### PR TITLE
fix(island): 修复岛屿生产选角与制造工坊排产回退问题

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -1926,7 +1926,7 @@
     },
     "Commission": {
       "PresetFilter": "cube",
-      "DynamicProgramming": false,
+      "DynamicProgramming": true,
       "TierValueRatio": 2.0,
       "DelayHalfLife": 100.0,
       "FilterValueFloor": 0.6,

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -630,7 +630,7 @@ Commission:
       - chip_24h
       - oil
       - custom
-  DynamicProgramming: false
+  DynamicProgramming: true
   TierValueRatio:
     type: input
     value: 2.0

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -341,7 +341,7 @@ class GeneratedConfig:
 
     # 配置组 `Commission`
     Commission_PresetFilter = 'cube'  # cube, cube_24h, chip, chip_24h, oil, custom
-    Commission_DynamicProgramming = False
+    Commission_DynamicProgramming = True
     Commission_TierValueRatio = 2.0
     Commission_DelayHalfLife = 100.0
     Commission_FilterValueFloor = 0.6

--- a/module/island/island.py
+++ b/module/island/island.py
@@ -461,27 +461,7 @@ class Island(SelectCharacter):
             self.device.click(SELECT_PRODUCT_INERTIA_STOP, control_check=False)
             self.device.sleep(0.2)
 
-        # 向上搜索失败后列表已停留在底部，先把列表滚动回顶部再返回 False，
-        # 避免后续产品（如制造工坊的皮革回退）从底部继续向上滑动而永远找不到。
-        self._reset_product_list_scroll()
         return False
-
-    def _reset_product_list_scroll(self):
-        """把产品选择列表滚动回顶部。
-
-        产品选择列表的搜索只向上滑动，失败后列表停留在底部；
-        若直接尝试下一个产品，继续向上滑动只会越滑越深。
-        每次滑动前清理同名滑动记录，避免连续滑动触发 GameTooManyClickError。
-        """
-        logger.info("[岛屿] 重置产品选择列表滚动位置到顶部")
-        for _ in range(_SELECT_PRODUCT_MAX_SWIPES * 2):
-            # 滑动本身会计入 click_record，逐次清理避免超过单按钮 12 次阈值
-            self.device.click_record_remove(SELECTION_UP_SWIPE_NAME)
-            self.device.swipe_vector(vector=(0, 200), box=(333, 142, 431, 602), name=SELECTION_UP_SWIPE_NAME)
-            self.device.sleep(0.3)
-            self.device.click(SELECT_PRODUCT_INERTIA_STOP, control_check=False)
-            self.device.sleep(0.2)
-        self.device.click_record_remove(SELECTION_UP_SWIPE_NAME)
 
     def _handle_select_product_failure(self, product):
         """select_product 失败时的统一处理：记录警告、关闭岗位面板、返回 False"""

--- a/module/island/island.py
+++ b/module/island/island.py
@@ -461,7 +461,27 @@ class Island(SelectCharacter):
             self.device.click(SELECT_PRODUCT_INERTIA_STOP, control_check=False)
             self.device.sleep(0.2)
 
+        # 向上搜索失败后列表已停留在底部，先把列表滚动回顶部再返回 False，
+        # 避免后续产品（如制造工坊的皮革回退）从底部继续向上滑动而永远找不到。
+        self._reset_product_list_scroll()
         return False
+
+    def _reset_product_list_scroll(self):
+        """把产品选择列表滚动回顶部。
+
+        产品选择列表的搜索只向上滑动，失败后列表停留在底部；
+        若直接尝试下一个产品，继续向上滑动只会越滑越深。
+        每次滑动前清理同名滑动记录，避免连续滑动触发 GameTooManyClickError。
+        """
+        logger.info("[岛屿] 重置产品选择列表滚动位置到顶部")
+        for _ in range(_SELECT_PRODUCT_MAX_SWIPES * 2):
+            # 滑动本身会计入 click_record，逐次清理避免超过单按钮 12 次阈值
+            self.device.click_record_remove(SELECTION_UP_SWIPE_NAME)
+            self.device.swipe_vector(vector=(0, 200), box=(333, 142, 431, 602), name=SELECTION_UP_SWIPE_NAME)
+            self.device.sleep(0.3)
+            self.device.click(SELECT_PRODUCT_INERTIA_STOP, control_check=False)
+            self.device.sleep(0.2)
+        self.device.click_record_remove(SELECTION_UP_SWIPE_NAME)
 
     def _handle_select_product_failure(self, product):
         """select_product 失败时的统一处理：记录警告、关闭岗位面板、返回 False"""

--- a/module/island/island_juu_coffee.py
+++ b/module/island/island_juu_coffee.py
@@ -158,6 +158,8 @@ class IslandJuuCoffee(IslandShopBase):
             # 大帝不可选（未找到/体力不足），回退普通厨师；先回到列表顶部再按配置选择
             self._swipe_character_list_to_top()
             return self.select_character(self.chef_config)
+        # 普通餐品：先回到列表顶部再按配置选择，避免上个岗位遗留的滚动位置导致找不到黄鸡
+        self._swipe_character_list_to_top()
         return self.select_character(self.chef_config)
     def deduct_materials(self, product, number):
         """覆盖：扣除前置材料，包括牛奶和套餐原材料"""

--- a/module/island/island_juu_coffee.py
+++ b/module/island/island_juu_coffee.py
@@ -142,54 +142,23 @@ class IslandJuuCoffee(IslandShopBase):
             logger.info(f"[岛屿-啾咖啡]   {product} 牛奶限制: 可用{milk_available}, 每批{milk_needed_per_batch}, 最大{max_by_milk}")
         return batch_size
 
-    def _is_friedrich_available(self):
-        """
-        只读检查大帝(Friedrich)是否可用于生产（空闲且有体力），不进行任何选择操作。
-        仅匹配 Friedrich 的模板，不做全量角色扫描。
-        """
-        screenshot = self.device.screenshot()
-        target_characters = self.recognize_target_characters(screenshot, ["Friedrich"])
-        for char_info in target_characters:
-            if char_info["character_name"] == "Friedrich":
-                available = not char_info["is_working"] and char_info["has_stamina"]
-                logger.info(f"[岛屿-啾咖啡] 大帝(Friedrich)状态: working={char_info['is_working']}, stamina={char_info['has_stamina']}, 可用={available}")
-                return available
-        logger.info("[岛屿-啾咖啡] 大帝(Friedrich)不在角色列表中")
-        return False
-
-    def post_produce(self, post_id, product, number, time_var_name, product2=None):
-        """
-        覆盖父类 post_produce：
-        醒神套餐(wake_up_call)若大帝(Friedrich)不可用则跳过烹饪。
-        """
-        if product == 'wake_up_call' and self.special_character:
-            post_button = self.posts[post_id]['button']
-            self.post_close()
-            self.post_open(post_button)
-            self.device.sleep(0.5)
-            while 1:
-                self.device.screenshot()
-                if self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1):
-                    break
-                if self.appear_then_click(ISLAND_POST_SELECT, offset=1):
-                    self.device.sleep(0.5)
-                    continue
-            if not self._is_friedrich_available():
-                logger.warning(f"[岛屿-啾咖啡] 醒神套餐({product})需要大帝(Friedrich)但不可用，跳过生产")
-                self.device.click(ISLAND_BACK)
-                self.device.sleep(0.5)
-                self.post_close()
-                return 0
-            self.device.click(ISLAND_BACK)
-            self.device.sleep(0.5)
-            self.post_close()
-        return super().post_produce(post_id, product, number, time_var_name, product2)
-
     def select_special_character(self,product):
-        if product in ['cheese','wake_up_call',]:
-            return self.select_character("Friedrich")
-        else:
+        """覆盖父类 select_special_character：
+        芝士(cheese)优先大帝(Friedrich)制作，大帝不可选时回退普通厨师；
+        醒神套餐(wake_up_call)必须由大帝制作。
+
+        大帝需通过向下滚动查找（模仿经营模块选角逻辑），且体力必须大于 50；
+        醒神套餐在大帝未找到或体力不足时不重试、不回退其他角色，直接返回 False 跳过生产。
+        """
+        if product == 'wake_up_call':
+            return self.select_specific_character_with_scroll("Friedrich", stamina_threshold=50)
+        if product == 'cheese':
+            if self.select_specific_character_with_scroll("Friedrich", stamina_threshold=50):
+                return True
+            # 大帝不可选（未找到/体力不足），回退普通厨师；先回到列表顶部再按配置选择
+            self._swipe_character_list_to_top()
             return self.select_character(self.chef_config)
+        return self.select_character(self.chef_config)
     def deduct_materials(self, product, number):
         """覆盖：扣除前置材料，包括牛奶和套餐原材料"""
         # 先调用父类方法扣除套餐原材料

--- a/module/island/island_manufacture.py
+++ b/module/island/island_manufacture.py
@@ -229,8 +229,13 @@ class IslandManufacture(IslandShopBase):
                     logger.info(f"[岛屿-制造业] 尝试选择产品: {product_name}")
 
                     # 点击产品选择按钮
-                    self.select_product(selection, selection_check)
+                    selected = self.select_product(selection, selection_check)
                     self.device.sleep(0.5)
+
+                    if not selected:
+                        # 基类失败时已把列表滚动回顶部，直接尝试下一个产品
+                        logger.warning(f"[岛屿-制造业] 未能识别到产品选择项: {product_name}，尝试下一个产品")
+                        continue
 
                     # 检查确认按钮状态
                     image = self.device.screenshot()
@@ -251,7 +256,7 @@ class IslandManufacture(IslandShopBase):
                         break  # 跳出产品选择循环
 
                 if not selected_product:
-                    logger.info("[岛屿-制造业] 所有产品材料都不足，点击返回")
+                    logger.info("[岛屿-制造业] 所有产品都无法选择或材料不足，点击返回")
                     self.device.click(SELECT_UI_BACK)
                     self.device.sleep(0.3)
 

--- a/module/island/island_manufacture.py
+++ b/module/island/island_manufacture.py
@@ -140,6 +140,9 @@ class IslandManufacture(IslandShopBase):
         # 初始化店铺
         self.initialize_shop()
 
+        # 本批生产已确认材料不足的物品（同一批内后续岗位直接跳过）
+        self.unavailable_products = set()
+
     def _init_post_buttons(self):
         """根据配置初始化岗位按钮"""
         post_buttons = {}
@@ -184,8 +187,8 @@ class IslandManufacture(IslandShopBase):
     def select_product(self, product_selection, product_selection_check):
         """
         覆盖父类 select_product：
-        荠菜使用固定坐标点击，不进行模板匹配和滑动。
-        其他产品走父类逻辑（模板匹配 + 滑动查找）。
+        荠菜使用固定坐标点击；其他产品走父类逻辑（向下滑动搜索查找）。
+        靴子等产品位于列表下方，必须向下滑动列表才能找到。
         """
         # 荠菜 → 直接点击固定位置
         if product_selection == FIXED_SELECT_SHEPHERD_PURSE:
@@ -193,126 +196,132 @@ class IslandManufacture(IslandShopBase):
             self.device.sleep(0.5)
             return True
 
-        # 其他产品使用父类逻辑
+        # 其他产品使用父类逻辑（模板匹配 + 向下滑动查找）
         return super().select_product(product_selection, product_selection_check)
 
     def select_product_with_material_check(self, post_id, product_list):
-        """选择产品并检查材料是否充足（覆盖基类方法）"""
+        """选择产品并检查材料是否充足（覆盖基类方法）
+
+        靴子等产品位于列表下方，靠父类向下滑动搜索查找。
+        产品无法制作（材料不足或找不到）时，退出岗位重新进入，
+        重置列表滚动进度后再检测下一个产品。
+        本批内已确认材料不足的物品会记忆下来，后续岗位直接跳过。
+        """
         post_button = self.posts[post_id]['button']
 
-        # 打开岗位
-        self.post_close()
-        self.post_open(post_button)
-        self.device.sleep(0.5)
+        for product_info in product_list:
+            product_name = product_info['name']
+            selection = product_info['selection']
+            selection_check = product_info['selection_check']
 
-        while True:
-            self.device.screenshot()
-            if self.appear_then_click(ISLAND_POST_SELECT, offset=1):
+            # 同一批内前面岗位已确认材料不足的物品，直接跳过
+            if product_name in self.unavailable_products:
+                logger.info(f"[岛屿-制造业] {product_name} 本批已确认材料不足，直接跳过")
+                continue
+
+            # 每个产品：进入岗位搜索并选择；找不到则退出岗位重进重试
+            for attempt in range(self.PRODUCT_SELECT_RETRY_LIMIT):
+                # 打开岗位（首次或重进）
+                self.post_close()
+                self.post_open(post_button)
                 self.device.sleep(0.5)
-                continue
-            if self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1):
-                if self.select_character():
-                    if not self.confirm_selected_character(f"{post_id}制造派遣"):
-                        self.back_to_postmanage_from_dispatch()
-                        return None
-                else:
-                    logger.warning(f"[岛屿-制造业] {post_id}制造派遣无可用角色")
-                    self.back_to_postmanage_from_dispatch()
+
+                entered_product_page = False
+                while True:
+                    self.device.screenshot()
+                    if self.appear_then_click(ISLAND_POST_SELECT, offset=1):
+                        self.device.sleep(0.5)
+                        continue
+                    if self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1):
+                        if self.select_character():
+                            if not self.confirm_selected_character(f"{post_id}制造派遣"):
+                                self.back_to_postmanage_from_dispatch()
+                                return None
+                        else:
+                            logger.warning(f"[岛屿-制造业] {post_id}制造派遣无可用角色")
+                            self.back_to_postmanage_from_dispatch()
+                            return None
+                        continue
+                    if self.appear(ISLAND_SELECT_PRODUCT_CHECK, offset=1):
+                        entered_product_page = True
+                        logger.info(f"[岛屿-制造业] 尝试选择产品: {product_name}")
+                        selected = self.select_product(selection, selection_check)
+                        self.device.sleep(0.5)
+                        break
+
+                if not entered_product_page:
                     return None
-                continue
-            if self.appear(ISLAND_SELECT_PRODUCT_CHECK, offset=1):
-                selected_product = None
-                for product_info in product_list:
-                    product_name = product_info['name']
-                    selection = product_info['selection']
-                    selection_check = product_info['selection_check']
-                    logger.info(f"[岛屿-制造业] 尝试选择产品: {product_name}")
 
-                    # 点击产品选择按钮
-                    selected = self.select_product(selection, selection_check)
-                    self.device.sleep(0.5)
-
-                    if not selected:
-                        # 基类失败时已把列表滚动回顶部，直接尝试下一个产品
-                        logger.warning(f"[岛屿-制造业] 未能识别到产品选择项: {product_name}，尝试下一个产品")
-                        continue
-
-                    # 检查确认按钮状态
-                    image = self.device.screenshot()
-                    area = (493, 597, 621, 643)
-                    color = get_color(image, area)
-
-                    # 如果确认按钮是灰色（153, 156, 156），表示材料不足
-                    if color_similar(color, (153, 156, 156), 80):
-                        logger.info(f"[岛屿-制造业] 材料不足，跳过产品: {product_name}")
-                        continue
-                    else:
-                        selected_product = product_info
-                        # 点击最大化生产数量
-                        self.appear_then_click(POST_MAX)
-                        # 点击确认生产
-                        self.device.click(POST_ADD_ORDER)
-                        logger.info(f"[岛屿-制造业] 选择产品成功: {product_name}")
-                        break  # 跳出产品选择循环
-
-                if not selected_product:
-                    logger.info("[岛屿-制造业] 所有产品都无法选择或材料不足，点击返回")
+                if not selected:
+                    # 搜索失败：退出岗位重新进入（重置列表滚动进度），重试同一产品
+                    logger.warning(
+                        f"[岛屿-制造业] 未能识别到产品选择项: {product_name}，"
+                        f"退出岗位重进重试 ({attempt + 1}/{self.PRODUCT_SELECT_RETRY_LIMIT})"
+                    )
                     self.device.click(SELECT_UI_BACK)
                     self.device.sleep(0.3)
+                    self.wait_until_appear(ISLAND_POSTMANAGE_CHECK)
+                    self.device.sleep(0.5)
+                    self.post_close()
+                    for _ in range(self.post_manage_swipe_count):
+                        self.post_manage_up_swipe(450)
+                    continue  # 下一轮重进重试同一产品
 
-                    # 清空该岗位的时间变量
-                    post_num = None
-                    for post_key, post_info in self.posts.items():
-                        if post_info['button'] == post_button:
-                            # 提取岗位编号
-                            if 'POST1' in post_key:
-                                post_num = 1
-                            elif 'POST2' in post_key:
-                                post_num = 2
-                            break
+                # 检查确认按钮状态
+                image = self.device.screenshot()
+                color = get_color(image, (493, 597, 621, 643))
 
-                    if post_num is not None:
-                        time_var_name = f'{self.time_prefix}{post_num}'
-                        if hasattr(self, time_var_name):
-                            setattr(self, time_var_name, None)
-                            logger.info(f"[岛屿-制造业] 清空岗位时间变量: {time_var_name}")
+                # 如果确认按钮是灰色（153, 156, 156），表示材料不足
+                if color_similar(color, (153, 156, 156), 80):
+                    # 记忆本批材料不足的物品，后续岗位不再重复尝试
+                    self.unavailable_products.add(product_name)
+                    logger.info(f"[岛屿-制造业] 材料不足，跳过产品: {product_name}")
+                    # 退出岗位，下一个产品重新进入时列表滚动进度已重置
+                    self.device.click(SELECT_UI_BACK)
+                    self.device.sleep(0.3)
+                    self.wait_until_appear(ISLAND_POSTMANAGE_CHECK)
+                    self.device.sleep(0.5)
+                    self.post_close()
+                    for _ in range(self.post_manage_swipe_count):
+                        self.post_manage_up_swipe(450)
+                    break  # 跳出重试循环 -> 下一个产品
 
+                # 材料充足，派遣生产
+                self.appear_then_click(POST_MAX)
+                self.device.click(POST_ADD_ORDER)
+                logger.info(f"[岛屿-制造业] 选择产品成功: {product_name}")
                 self.wait_until_appear(ISLAND_POSTMANAGE_CHECK)
                 self.device.sleep(0.5)
                 self.post_close()
-
                 for _ in range(self.post_manage_swipe_count):
                     self.post_manage_up_swipe(450)
 
-                if selected_product:
-                    self.post_open(post_button)
-                    # 获取生产时间和数量
-                    image = self.device.screenshot()
-                    ocr_post_number = Digit(OCR_POST_NUMBER, letter=(57, 58, 60), threshold=100,
-                                            alphabet='0123456789')
-                    actual_number = ocr_post_number.ocr(image)
-                    time_work = Duration(ISLAND_WORKING_TIME)
-                    time_value = time_work.ocr(self.device.image)
-                    finish_time = current_time() + time_value
+                # 获取生产时间和数量
+                self.post_open(post_button)
+                image = self.device.screenshot()
+                ocr_post_number = Digit(OCR_POST_NUMBER, letter=(57, 58, 60), threshold=100,
+                                        alphabet='0123456789')
+                actual_number = ocr_post_number.ocr(image)
+                time_work = Duration(ISLAND_WORKING_TIME)
+                time_value = time_work.ocr(self.device.image)
+                finish_time = current_time() + time_value
 
-                    # 设置时间变量
-                    # 从post_id中提取数字
-                    import re
-                    match = re.search(r'POST(\d+)', post_id)
-                    if match:
-                        post_num = match.group(1)
-                        time_var_name = f'{self.time_prefix}{post_num}'
-                        setattr(self, time_var_name, finish_time)
+                # 设置时间变量
+                import re
+                match = re.search(r'POST(\d+)', post_id)
+                if match:
+                    post_num = match.group(1)
+                    time_var_name = f'{self.time_prefix}{post_num}'
+                    setattr(self, time_var_name, finish_time)
 
-                    self.posts[post_id]['status'] = 'working'
+                self.posts[post_id]['status'] = 'working'
+                logger.info(f"[岛屿-制造业] 已安排生产：{product_name} x{actual_number}")
+                self.post_close()
+                return product_info
 
-                    logger.info(f"[岛屿-制造业] 已安排生产：{selected_product['name']} x{actual_number}")
-                    self.post_close()
-                    return selected_product
-
-                break  # 跳出循环
-
-        return None  # 正常情况下不会执行到这里
+        # 所有产品都无法选择或材料不足
+        logger.info("[岛屿-制造业] 所有产品都无法选择或材料不足")
+        return None
 
     def schedule_manufacture(self):
         """安排制造业生产（覆盖基类方法）"""
@@ -396,6 +405,8 @@ class IslandManufacture(IslandShopBase):
     def run(self):
         """运行制造业逻辑（完全覆盖基类方法）"""
         self.island_error = False
+        # 每批生产开始时清空“材料不足”记忆，避免跨批沿用旧库存状态
+        self.unavailable_products = set()
 
         # 第一步：检查岗位状态
         self.goto_postmanage()

--- a/module/island/island_select_character.py
+++ b/module/island/island_select_character.py
@@ -498,6 +498,181 @@ class SelectCharacter(UI):
         self.device.sleep(0.3)
         return True
 
+    # ============ 滚动查找指定角色（模仿经营模块选角逻辑） ============
+    # 角色选择列表滑动区域与惯性消除安全区（与经营模块保持一致）
+    CHARACTER_LIST_SCROLL_BOX = (58, 150, 838, 480)
+    CHARACTER_LIST_INERTIA_STOP = (462, 477, 473, 577)
+    # 角色选择列表全区域模板匹配范围（与经营模块保持一致）
+    CHARACTER_LIST_SEARCH_AREA = (55, 139, 878, 463)
+
+    def _swipe_character_list_down(self):
+        """短距离向下滑动角色列表，滑动后点击安全区域消除惯性（模仿经营模块）。"""
+        self.device.swipe_vector(vector=(0, -200), box=self.CHARACTER_LIST_SCROLL_BOX,
+                                 duration=(0.3, 0.5), name="IslandCharSwipe")
+        self.device.click(Button(area=(), color=(), button=self.CHARACTER_LIST_INERTIA_STOP, file={'cn': ''}))
+        self.device.sleep(1.0)
+
+    def _swipe_character_list_to_top(self):
+        """向上滑动角色列表回到顶部，滑动后点击安全区域消除惯性（模仿经营模块）。"""
+        self.device.swipe_vector(vector=(0, 500), box=self.CHARACTER_LIST_SCROLL_BOX,
+                                 duration=(0.3, 0.5), name="IslandCharSwipeReset")
+        self.device.sleep(0.5)
+        self.device.click(Button(area=(), color=(), button=self.CHARACTER_LIST_INERTIA_STOP, file={'cn': ''}))
+        self.device.sleep(1.0)
+
+    def _find_character_button_in_area(self, screenshot, character_names, area=None):
+        """在角色选择列表全区域内模板匹配指定角色，返回 (角色名, Button) 或 None。
+
+        与经营模块 _find_best_character 一致，用于网格未命中（滑动错位）时定位角色。
+        """
+        if area is None:
+            area = self.CHARACTER_LIST_SEARCH_AREA
+        area_img = crop(screenshot, area)
+        best = (None, None, 0.0)  # (角色名, Button, 相似度)
+        for name in character_names:
+            template = self.character_templates.get(name)
+            if template is None:
+                continue
+            sim, btn = template.match_result(area_img)
+            if sim >= 0.8 and sim > best[2]:
+                # 创建新 Button，坐标从裁剪区域偏移回全屏坐标
+                old_area = btn.area
+                new_area = (old_area[0] + area[0], old_area[1] + area[1],
+                            old_area[2] + area[0], old_area[3] + area[1])
+                offset_btn = Button(area=new_area, color=btn.color, button=new_area, file=btn.file)
+                best = (name, offset_btn, sim)
+        if best[0] is not None:
+            return best[0], best[1]
+        return None
+
+    def _snap_button_to_grid_cell(self, portrait_button):
+        """将头像模板匹配结果吸附到最近的网格单元，返回 (row, col, 单元Button)。"""
+        px = (portrait_button.area[0] + portrait_button.area[2]) // 2
+        py = (portrait_button.area[1] + portrait_button.area[3]) // 2
+        best_cell = None
+        best_dist = None
+        for row, col, cell_button in self.select_character_grid.generate():
+            cx = (cell_button.area[0] + cell_button.area[2]) // 2
+            cy = (cell_button.area[1] + cell_button.area[3]) // 2
+            dist = abs(px - cx) + abs(py - cy)
+            if best_dist is None or dist < best_dist:
+                best_cell = (row, col, cell_button)
+                best_dist = dist
+        return best_cell
+
+    def _status_from_cell(self, screenshot, row, col, cell_button, character_name=None):
+        """读取指定网格单元的角色状态。
+
+        character_name 给定时跳过二次身份识别（用于全区域模板匹配已确认身份的场景）。
+        """
+        if character_name is None:
+            status = self._recognize_character_status(screenshot, cell_button)
+            if not status:
+                return None
+            return {**status, "grid_position": (row, col), "button_area": cell_button.area}
+        return {
+            "character_name": character_name,
+            "is_working": self._check_working_status(screenshot, cell_button),
+            "stamina": self._get_stamina_value(screenshot, cell_button),
+            "is_selected": self._check_selected_status(screenshot, cell_button),
+            "grid_position": (row, col),
+            "button_area": cell_button.area,
+        }
+
+    def _check_character_strict(self, char_info, stamina_threshold):
+        """严格检查角色是否可派遣：未工作、未选中、体力大于阈值。任一不满足返回 None。"""
+        if char_info is None:
+            return None
+        char_name = char_info.get("character_name")
+        if char_info.get("is_working"):
+            logger.info(f"[岛屿] {char_name} 正在工作中，不满足派遣条件")
+            return None
+        if char_info.get("is_selected"):
+            logger.info(f"[岛屿] {char_name} 已选中，不满足派遣条件")
+            return None
+        stamina = char_info.get("stamina", 0)
+        if stamina <= stamina_threshold:
+            logger.info(f"[岛屿] {char_name} 体力 {stamina} 不大于 {stamina_threshold}，不满足派遣条件")
+            return None
+        return char_info
+
+    def find_strict_available_character_with_scroll(self, character_list, stamina_threshold=50,
+                                                    max_swipes=5, search_area=None):
+        """
+        滚动查找指定角色（模仿经营模块的选角逻辑）。
+
+        只接受指定角色且体力大于 stamina_threshold；不切换排序、不回退其他角色。
+        找到后返回角色状态字典，未找到或体力不达标返回 None。
+
+        Args:
+            character_list: 角色名或 ">" 分隔的优先级字符串。
+            stamina_threshold: 体力必须大于该阈值。
+            max_swipes: 最多向下滑动次数。
+            search_area: 全区域模板匹配范围，默认 CHARACTER_LIST_SEARCH_AREA。
+
+        Returns:
+            dict | None: 可点击角色状态，找不到或体力不达标返回 None。
+        """
+        characters = self.parse_character_filter(character_list)
+        if not characters:
+            return None
+
+        # 先回到列表顶部，从头开始搜索
+        self._swipe_character_list_to_top()
+
+        for attempt in range(max_swipes):
+            screenshot = self.device.screenshot()
+            # 1) 优先网格识别：直接获得体力/工作/选中状态
+            target_characters = self.recognize_target_characters(screenshot, characters)
+            character_dict = {char_info["character_name"]: char_info for char_info in target_characters}
+            for char_name in characters:
+                char_info = character_dict.get(char_name)
+                if char_info:
+                    return self._check_character_strict(char_info, stamina_threshold)
+            # 2) 网格未命中（滑动错位）时，全区域模板匹配定位（模仿经营模块）
+            found = self._find_character_button_in_area(screenshot, characters, area=search_area)
+            if found:
+                char_name, portrait_button = found
+                snapped = self._snap_button_to_grid_cell(portrait_button)
+                if snapped:
+                    row, col, cell_button = snapped
+                    char_info = self._status_from_cell(
+                        screenshot, row, col, cell_button, character_name=char_name
+                    )
+                    return self._check_character_strict(char_info, stamina_threshold)
+            # 3) 当前视野没有目标角色，向下滑动继续搜索
+            self._swipe_character_list_down()
+
+        logger.info(f"[岛屿] 角色列表滚动 {max_swipes} 次后仍未找到: {characters}")
+        return None
+
+    def select_specific_character_with_scroll(self, character_list, stamina_threshold=50, max_swipes=5):
+        """
+        只选择指定角色（支持向下滚动查找，模仿经营模块选角逻辑）。
+
+        体力不达标或未找到时返回 False，不切换排序、不回退其他角色、不重复尝试。
+        点击后校验是否选中，最多点击 5 次（纯计数有限循环）。
+
+        Returns:
+            bool: 成功选中指定角色返回 True，否则返回 False。
+        """
+        char_info = self.find_strict_available_character_with_scroll(
+            character_list, stamina_threshold=stamina_threshold, max_swipes=max_swipes
+        )
+        if not char_info:
+            return False
+
+        row, col = char_info["grid_position"]
+        button = self.select_character_grid[row, col]
+        target_positions = [(row, col)]
+        for attempt in range(5):
+            screenshot = self.device.screenshot()
+            if self.is_any_character_selected_by_positions(screenshot, target_positions):
+                return True
+            self.device.click(button)
+            self.device.sleep(0.3)
+        return False
+
     def find_specific_character(self, screenshot, character_name="WorkerJuu"):
         """查找指定角色的位置信息，只检查目标角色的模板，不做全量匹配"""
         target_characters = self.recognize_target_characters(screenshot, [character_name])

--- a/module/island/island_select_character.py
+++ b/module/island/island_select_character.py
@@ -23,6 +23,9 @@ class SelectCharacter(UI):
             name="SELECT_CHARACTER_GRID"
         )
 
+        # 本轮已判定不可用的角色（避免同一轮内多次派遣时重复检测）
+        self.unavailable_characters = set()
+
         # 定义状态检测区域（相对于每个角色按钮）
         self.character_area_relative = (25, 10, 125, 72)
         self.working_area_relative = (15, 65, 105, 95)
@@ -617,6 +620,12 @@ class SelectCharacter(UI):
         if not characters:
             return None
 
+        # 本轮已判定不可用的角色直接跳过，不再重复检测
+        for char_name in characters:
+            if char_name in self.unavailable_characters:
+                logger.info(f"[岛屿] {char_name} 本轮已判定不可用，跳过检测")
+                return None
+
         # 先回到列表顶部，从头开始搜索
         self._swipe_character_list_to_top()
 
@@ -628,7 +637,12 @@ class SelectCharacter(UI):
             for char_name in characters:
                 char_info = character_dict.get(char_name)
                 if char_info:
-                    return self._check_character_strict(char_info, stamina_threshold)
+                    checked = self._check_character_strict(char_info, stamina_threshold)
+                    if checked is None:
+                        self.unavailable_characters.add(char_name)
+                        # 失败退出前回到列表顶部，避免影响下一个岗位的选角视野
+                        self._swipe_character_list_to_top()
+                    return checked
             # 2) 网格未命中（滑动错位）时，全区域模板匹配定位（模仿经营模块）
             found = self._find_character_button_in_area(screenshot, characters, area=search_area)
             if found:
@@ -639,11 +653,19 @@ class SelectCharacter(UI):
                     char_info = self._status_from_cell(
                         screenshot, row, col, cell_button, character_name=char_name
                     )
-                    return self._check_character_strict(char_info, stamina_threshold)
+                    checked = self._check_character_strict(char_info, stamina_threshold)
+                    if checked is None:
+                        self.unavailable_characters.add(char_name)
+                        # 失败退出前回到列表顶部，避免影响下一个岗位的选角视野
+                        self._swipe_character_list_to_top()
+                    return checked
             # 3) 当前视野没有目标角色，向下滑动继续搜索
             self._swipe_character_list_down()
 
         logger.info(f"[岛屿] 角色列表滚动 {max_swipes} 次后仍未找到: {characters}")
+        self.unavailable_characters.update(characters)
+        # 失败退出前回到列表顶部，避免影响下一个岗位的选角视野
+        self._swipe_character_list_to_top()
         return None
 
     def select_specific_character_with_scroll(self, character_list, stamina_threshold=50, max_swipes=5):

--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -47,6 +47,9 @@ class IslandShopBase(Island, WarehouseOCR):
         # 特殊材料（子类可覆盖）
         self.special_materials = {}
 
+        # 本轮因无可用角色而跳过生产的餐品（避免严格模式重复尝试）
+        self.chef_unavailable_products = set()
+
         # 套餐组成（子类可覆盖）
         self.meal_compositions = {}
 
@@ -249,6 +252,7 @@ class IslandShopBase(Island, WarehouseOCR):
                         return 0
                 else:
                     logger.warning(f"[岛屿] {product}生产派遣无可用角色: {character_filter}")
+                    self.chef_unavailable_products.add(product)
                     self.back_to_postmanage_from_dispatch()
                     return 0
                 continue
@@ -394,6 +398,9 @@ class IslandShopBase(Island, WarehouseOCR):
                 if name in force_skip:
                     logger.info(f"[岛屿] 槽位{idx + 1} {name} 本轮已尝试失败，强制跳过")
                     continue
+                if name in self.chef_unavailable_products:
+                    logger.info(f"[岛屿] 槽位{idx + 1} {name} 无可用角色，本轮跳过")
+                    continue
                 deficit = target - current
                 # check_materials=True 时严格检查零库存，用于跳过无法生产的缺口
                 if self.get_max_producible(
@@ -419,6 +426,8 @@ class IslandShopBase(Island, WarehouseOCR):
 
     def run(self):
         self.island_error = False
+        self.chef_unavailable_products.clear()
+        self.unavailable_characters.clear()
         self.goto_postmanage()
         self.post_manage_mode(POST_MANAGE_PRODUCTION)
         self.post_close()


### PR DESCRIPTION
## 摘要

修复岛屿生产中两类问题：啾咖啡大帝选角与派遣重试逻辑、制造工坊产品搜索与材料回退。

## 修复内容

### 啾咖啡大帝选角（626175d）
- 芝士改为优先大帝(Friedrich)，不可选时滑回列表顶部按厨师配置回退选择；醒神套餐必须大帝，未找到或体力不大于 50 时直接跳过，不回退、不重试
- 大帝通过向下滚动查找（模仿经营模块选角逻辑），支持网格识别与全区域模板匹配兜底
- 移除 post_produce 预检的重复进出岗位逻辑（含 while 1 循环），统一走父类派遣流程

### 无可用角色时跳过本轮排产（c05e916）
- 派遣失败（无可用角色）的餐品记入本轮跳过集合，需求计算直接落到下一顺位餐品，消除严格模式对同一缺口的重复派遣尝试（醒神套餐未选到大帝不再反复检测）
- 本轮已判定不可用的角色加入缓存，后续岗位/餐品不再重复检测；run() 开始时清空，下次运行恢复尝试

### 制造工坊产品搜索与材料回退（466b8ce、3202cc6）
- 修复鞋子制作失败后皮革回退找不到的问题：进入产品选择页先复位列表滚动位置，select_product 搜索失败后滚动回顶部，并检查产品选择返回值避免误点确认
- 恢复基类 select_product 单轮向下滑动搜索（靴子位于列表下方，必须下滑才能找到），删除向上滚回顶部的复位逻辑
- 制造工坊按产品逐个派遣，材料不足或搜索失败时退出岗位重新进入、重置滚动进度后再检测下一个产品
- 同一批内已确认材料不足的物品记忆下来，后续岗位直接跳过，避免重复尝试

## 影响范围

- module/island/island_juu_coffee.py
- module/island/island_select_character.py
- module/island/island_shop_base.py
- module/island/island_manufacture.py
- module/island/island.py

## Summary by Sourcery

改进咖啡与制造的岛屿产能派工逻辑，通过跳过不可用角色/产品以及增加基于滚动的角色搜索功能。

新功能：
- 为岛屿咖啡生产新增基于滚动的角色搜索，用于选择特定角色（如 Friedrich）。
- 按批次记录在制造过程中缺少材料的产品，以便在后续投放时跳过这些产品。

错误修复：
- 通过始终使用向下滚动搜索并在多次尝试之间重置列表位置，确保能找到如靴子等制造产品。
- 当产品选择或材料检查失败时，重新进入投放界面并重置滚动状态，从而修复制造材料回滚问题。
- 通过缓存被跳过的产品和角色，在没有合适角色可用时避免对餐食进行重复的严格模式派工尝试。

优化改进：
- 优化咖啡生产中的特殊角色选择：`wake_up_call` 严格要求使用有足够体力的 Friedrich，而 `cheese` 优先使用他，但在不可用时回退到配置的厨师。
- 通过网格与全区域模板匹配以及受控列表滚动，使岛屿角色选择行为与业务模块保持一致。
- 在每次生产运行开始时重置缓存的不可用角色和产品，以反映当前库存与体力状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve island production dispatch logic for coffee and manufacture by skipping unavailable roles/products and adding scroll-based character search.

New Features:
- Add scroll-based character search for selecting specific characters like Friedrich in island coffee production.
- Track per-batch manufacture products that lack materials to skip them on subsequent posts.

Bug Fixes:
- Ensure manufacture products like boots can be found by always using downward scroll search and resetting list position between attempts.
- Fix manufacture material rollback by re-entering posts and resetting scroll state when product selection or materials check fails.
- Avoid repeated strict-mode dispatch attempts for meals when no suitable character is available by caching skipped products and characters.

Enhancements:
- Refine special character selection in coffee production so wake_up_call strictly requires Friedrich with sufficient stamina and cheese prefers him but falls back to configured chefs.
- Align island character selection behavior with the business module via grid and full-area template matching plus controlled list scrolling.
- Reset cached unavailable characters and products at the start of each production run to reflect current inventory and stamina state.

</details>