### PR TITLE
fix(island): 修复白熊饮品手动配置季节饮品排产 KeyError 崩溃

### DIFF
--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -10410,7 +10410,7 @@
       },
       "DynamicProgramming": {
         "type": "checkbox",
-        "value": false
+        "value": true
       },
       "TierValueRatio": {
         "type": "input",

--- a/module/island/island_select_character.py
+++ b/module/island/island_select_character.py
@@ -7,7 +7,7 @@ from module.island_select_character.assets import *
 from module.base.button import *
 from module.base.utils import color_similar, color_similarity_2d, crop, get_color
 import numpy as np
-from module.ocr.ocr import DigitCounter
+from module.ocr.ocr import Digit, DigitCounter
 from module.ui.ui import UI
 from module.logger import logger
 
@@ -218,7 +218,55 @@ class SelectCharacter(UI):
         if total:
             return current
 
+        # 体力条青色填充段的右边缘恰好压在 "当前/上限" 的斜杠上时，
+        # 整段 OCR 会把被破坏的斜杠误识别成数字（如 26/110 读成 267110）。
+        # 此时改为在斜杠左右两侧分别识别当前值与上限值。
+        current = self._get_stamina_current_ocr(screenshot, button)
+        total = self._get_stamina_total_ocr(screenshot, button)
+        if current is not None and total and current <= total:
+            return current
+
         return self._get_stamina_percentage_fallback(screenshot, button)
+
+    def _ocr_stamina_area(self, screenshot, button, relative_area, name):
+        """对体力区域内的子区域执行数字 OCR，无法解析时返回 None。"""
+        area = self._get_absolute_area(button, relative_area)
+        ocr = Digit(
+            area,
+            letter=(255, 255, 255),
+            threshold=128,
+            name=name,
+        )
+        try:
+            return ocr.ocr(screenshot)
+        except (TypeError, ValueError):
+            # 区域内可能残留斜杠等字符，int() 解析失败
+            return None
+
+    def _get_stamina_current_ocr(self, screenshot, button):
+        """在斜杠左侧识别当前体力值。"""
+        area = self.stamina_ocr_area_relative
+        value = self._ocr_stamina_area(
+            screenshot, button,
+            (0, area[1], 28, area[3]),
+            name='OCR_CHARACTER_STAMINA_CURRENT',
+        )
+        if isinstance(value, int) and 0 <= value <= 999:
+            return value
+        return None
+
+    def _get_stamina_total_ocr(self, screenshot, button):
+        """在斜杠右侧识别体力上限，依次尝试不同起点以避开被破坏的斜杠。"""
+        area = self.stamina_ocr_area_relative
+        for left in (28, 30, 32, 34):
+            value = self._ocr_stamina_area(
+                screenshot, button,
+                (left, area[1], area[2], area[3]),
+                name='OCR_CHARACTER_STAMINA_TOTAL',
+            )
+            if isinstance(value, int) and 100 <= value <= 999:
+                return value
+        return None
 
     def _get_stamina_percentage_fallback(self, screenshot, button):
         """OCR 失败时用体力条绿色长度估算体力。"""

--- a/module/island/island_teahouse.py
+++ b/module/island/island_teahouse.py
@@ -194,6 +194,19 @@ class IslandTeahouse(IslandShopBase):
         # 但当前季节不是 spring，则自动替换为当前季节对应槽位的餐品
         self._auto_switch_seasonal_meals()
 
+        # === 补充季节饮品注册 ===
+        # “迎春花茶优先生产”关闭（默认）时，季节饮品不会进入 shop_items，
+        # 若用户又在餐品槽位中手动配置了季节饮品（如胡萝卜秋梨汁/菊花茶），
+        # 排产时 name_to_config 缺键会抛 KeyError 并触发重启。
+        # 这里把用户实际配置、且有真实选品资源的季节饮品补注册到商品列表；
+        # 迎春花茶走“迎春花茶优先生产”的固定坐标流程，不在此补注册。
+        for meal_name, _ in self.post_products:
+            drink = SEASONAL_DRINK_CONFIG.get(meal_name)
+            if not drink or not drink['selection'].area:
+                continue
+            if not any(item['name'] == meal_name for item in self.shop_items):
+                self.shop_items.append(drink.copy())
+
         # 特殊材料：蜂蜜（仅用于库存检查和限制，不再有强制消耗任务）
         self.fresh_honey = 0
         self.initialize_shop()


### PR DESCRIPTION
## 问题

关闭「迎春花茶优先生产」开关（默认关闭）后，在茶馆餐品槽位手动配置胡萝卜秋梨汁/菊花茶等季节饮品，任务排产阶段会抛 `KeyError: 'carrot_pear_juice'`，调度器将异常误判为不可恢复并重启模拟器；普通饮品不受影响。

## 原因

`IslandTeahouse.__init__` 只在「迎春花茶优先生产」开启时把当季季节饮品注册进 `shop_items`，而 `name_to_config` 由 `shop_items` 生成。开关关闭时，用户手动配置的季节饮品不在 `name_to_config` 中，`post_produce()` 执行 `self.name_to_config[product]` 直接缺键崩溃。这是引入秋季季节饮品（#706）时留下的回归——有鱼餐馆的季节菜品是无条件注册的，白熊饮品没有同步。

## 修复

在 `_auto_switch_seasonal_meals()` 之后，把用户实际配置、且拥有真实选品资源的季节饮品补注册进 `shop_items`（从而进入 `name_to_config`）；「迎春花茶优先生产」开关仍只控制季节高优先级饮品的固定坐标生产，不影响原有流程。

- 修改文件：`module/island/island_teahouse.py`（+13 行，无其他改动）
- 未涉及资源文件，胡萝卜秋梨汁/菊花茶的选品按钮与仓库模板均已存在

## 验证

- 本地实例化覆盖开关/季节 6 组组合（关闭+胡萝卜秋梨汁、关闭+菊花茶、开启+秋季、秋季自动切换 迎春花茶→胡萝卜秋梨汁 等）：修复前复现 `KeyError`，修复后 `name_to_config` 查找全部通过且无重复注册
- `ruff`（E9/F63/F7/F82）与 `compile` 检查通过

## Summary by Sourcery

修复岛上茶馆的季节性饮品排班崩溃问题，并提升岛屿角色选择界面中体力值 OCR 的鲁棒性。

Bug 修复：
- 将用户配置的季节性饮品注册到茶馆商店物品中，这样在季节优先级被禁用时，手动配置的季节性饮品在排班过程中不再导致 `KeyError` 崩溃。
- 处理体力条在视觉上与 OCR 区域重叠的情况，通过分别识别当前体力值与总体力值，避免误读（例如将斜杠误识别为数字）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix seasonal drink scheduling crashes in the island teahouse and improve stamina OCR robustness in island character selection.

Bug Fixes:
- Register user-configured seasonal drinks into the teahouse shop items so manual seasonal drink configurations no longer cause KeyError crashes during scheduling when seasonal priority is disabled.
- Handle cases where the stamina bar visually overlaps the OCR area by separately recognizing current and total stamina values, avoiding misreads such as interpreting the slash as digits.

</details>