### PR TITLE
Fix formatting issues and enhance task management in scheduling

### DIFF
--- a/module/os/tasks/scheduling.py
+++ b/module/os/tasks/scheduling.py
@@ -833,11 +833,25 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
             self.config.task_stop()
 
         logger.info('[大世界-智能调度+] 执行一轮耄耋相接')
-        self._run_with_opsi_task_context(
-            self.TASK_NAME_MEOWFFICER_FARMING,
-            self.run_meowfficer_farming_once,
-            ap_preserve=ap_preserve,
-        )
+        # 耄耋相接会通过共享的手动配置项控制本轮行动力下限。
+        # 代跑结束后必须恢复，否则其保留值会泄漏到后续侵蚀 1 调度。
+        with self.config.temporary(
+            OS_ACTION_POINT_PRESERVE=self.config.OS_ACTION_POINT_PRESERVE,
+        ):
+            try:
+                self._run_with_opsi_task_context(
+                    self.TASK_NAME_MEOWFFICER_FARMING,
+                    self.run_meowfficer_farming_once,
+                    ap_preserve=ap_preserve,
+                )
+            except ActionPointLimit as e:
+                if ap_preserve > 0 and getattr(e, 'preserve', None) == ap_preserve:
+                    logger.info(
+                        f'[大世界-智能调度+] 耄耋相接已达到行动力保留值 '
+                        f'({e.total} <= {ap_preserve})，返回智能调度+'
+                    )
+                    return
+                raise
 
     def handle_first_auto_search(self, run):
         """由智能调度+决策是否执行 os_init 阶段跳过的首次自律寻敌。"""

--- a/module/private_quarters/private_quarters.py
+++ b/module/private_quarters/private_quarters.py
@@ -64,9 +64,9 @@ class PrivateQuarters(PQInteract, PQShop):
     # Key: str, server name
     # Value: list[str]
     not_supported_filter = {
-        'cn': ('nakhimov'),
+        'cn': (),
         'en': (),
-        'jp': ('nakhimov'),
+        'jp': ('nakhimov',),
         'tw': ('taihou', 'nakhimov'),
     }
 

--- a/module/private_quarters/private_quarters.py
+++ b/module/private_quarters/private_quarters.py
@@ -64,9 +64,9 @@ class PrivateQuarters(PQInteract, PQShop):
     # Key: str, server name
     # Value: list[str]
     not_supported_filter = {
-        'cn': (),
+        'cn': ('nakhimov'),
         'en': (),
-        'jp': ('nakhimov',),
+        'jp': ('nakhimov'),
         'tw': ('taihou', 'nakhimov'),
     }
 

--- a/tests/test_opsi_scheduling.py
+++ b/tests/test_opsi_scheduling.py
@@ -1,12 +1,13 @@
-from contextlib import nullcontext
-from types import SimpleNamespace
 import unittest
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from module.campaign.os_run import OSCampaignRun
 from module.config.config import TaskEnd
 from module.os.tasks.prevent_action_point_overflow import OpsiPreventActionPointOverflow
 from module.os.tasks.scheduling import OpsiScheduling
+from module.os_handler.action_point import ActionPointLimit
 
 
 class SmartSchedulingConfig:
@@ -31,6 +32,76 @@ class SmartSchedulingConfig:
     @staticmethod
     def task_stop():
         raise TaskEnd
+
+
+class MeowPreserveConfig:
+    """提供智能调度代跑短猫时的共享行动力保留状态。"""
+
+    def __init__(self):
+        self.OS_ACTION_POINT_PRESERVE = 180
+
+    @contextmanager
+    def temporary(self, **kwargs):
+        backup = {key: getattr(self, key) for key in kwargs}
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        try:
+            yield
+        finally:
+            for key, value in backup.items():
+                setattr(self, key, value)
+
+    @staticmethod
+    def task_stop():
+        raise AssertionError('达到短猫保留值不应停止智能调度')
+
+
+class SchedulingMeowHarness:
+    """复现短猫达到自身阈值后异常冒泡的最小调度环境。"""
+
+    TASK_NAME_MEOWFFICER_FARMING = OpsiScheduling.TASK_NAME_MEOWFFICER_FARMING
+
+    def __init__(self):
+        self.config = MeowPreserveConfig()
+        self.executed_task_name = None
+
+    def run_meowfficer_farming_once(self, ap_preserve):
+        self.config.OS_ACTION_POINT_PRESERVE = ap_preserve
+        raise ActionPointLimit(total=5985, preserve=ap_preserve)
+
+    def _run_with_opsi_task_context(self, task_name, func, **kwargs):
+        self.executed_task_name = task_name
+        return func(**kwargs)
+
+    def run_scheduled_meowfficer_farming(self, ap_preserve):
+        return OpsiScheduling._run_scheduled_meowfficer_farming(self, ap_preserve)
+
+
+class SchedulingMeowCostLimitHarness(SchedulingMeowHarness):
+    def run_meowfficer_farming_once(self, ap_preserve):
+        self.config.OS_ACTION_POINT_PRESERVE = ap_preserve
+        raise ActionPointLimit(current=15, total=15, cost=120)
+
+
+class TestSmartSchedulingMeowPreserve(unittest.TestCase):
+    def test_returns_to_scheduling_and_restores_global_preserve_at_meow_limit(self):
+        scheduling = SchedulingMeowHarness()
+
+        scheduling.run_scheduled_meowfficer_farming(ap_preserve=6000)
+
+        self.assertEqual(
+            scheduling.executed_task_name,
+            OpsiScheduling.TASK_NAME_MEOWFFICER_FARMING,
+        )
+        self.assertEqual(scheduling.config.OS_ACTION_POINT_PRESERVE, 180)
+
+    def test_propagates_real_ap_shortage_and_still_restores_global_preserve(self):
+        scheduling = SchedulingMeowCostLimitHarness()
+
+        with self.assertRaises(ActionPointLimit):
+            scheduling.run_scheduled_meowfficer_farming(ap_preserve=6000)
+
+        self.assertEqual(scheduling.config.OS_ACTION_POINT_PRESERVE, 180)
 
 
 class TestSmartSchedulingExploreDelay(unittest.TestCase):


### PR DESCRIPTION
## Summary by Sourcery

确保在进行 meowfficer 农场调度时，在处理基于预留值的限制时，既能保留和恢复全局行动点预留，又不会中止智能调度。

Bug 修复：
- 防止 meowfficer 农场将其行动点预留配置泄漏到后续的调度运行中。
- 将达到配置的 meowfficer 预留阈值视为受控地返回调度流程，而不是未处理的 ActionPointLimit 错误。

测试：
- 添加有针对性的测试框架和测试用例，以验证 meowfficer 农场在执行后会恢复全局行动点预留，并能正确区分预留限制和真正的行动点短缺。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure meowfficer farming scheduling preserves and restores global action point reserve while handling reserve-based limits without aborting smart scheduling.

Bug Fixes:
- Prevent meowfficer farming from leaking its action point preserve configuration into subsequent scheduling runs.
- Treat reaching the configured meowfficer reserve threshold as a controlled return to scheduling instead of an unhandled ActionPointLimit error.

Tests:
- Add targeted harnesses and tests to verify meowfficer farming restores global action point preserve after execution and correctly distinguishes between reserve limits and genuine action point shortages.

</details>