### PR TITLE
fix(ci-report): workflow_run 事件下按 head 分支反查 PR，修复 fork PR 无法发布检查报告评论

### DIFF
--- a/dev_tools/ci_pr_report.py
+++ b/dev_tools/ci_pr_report.py
@@ -67,9 +67,11 @@ def get_pr_number(event_path: str, token: str = "", repo: str = "", run_id: str 
 
     支持两类事件：
     - pull_request：直接读取 event.pull_request.number；
-    - workflow_run（由 CI 完成后触发）：通过 API 查询
-      GET /repos/{repo}/actions/runs/{run_id}/pull_requests 获取关联 PR，
-      事件负载中的 workflow_run.pull_requests 作为回退。
+    - workflow_run（由 CI 完成后触发），依次尝试：
+      1) GET /repos/{repo}/actions/runs/{run_id}/pull_requests；
+      2) 按 head 分支查询 GET /repos/{repo}/pulls?head={owner}:{branch}
+         （fork PR 的 run 拉取不到 pull_requests，但 head 分支查询有效）；
+      3) 事件负载中的 workflow_run.pull_requests 作为最后回退。
     """
     try:
         with open(event_path, encoding="utf-8") as fp:
@@ -77,8 +79,10 @@ def get_pr_number(event_path: str, token: str = "", repo: str = "", run_id: str 
     except (OSError, json.JSONDecodeError):
         return None
 
-    # workflow_run 事件：优先查 API（该字段在事件负载中可能为空）。
+    # workflow_run 事件。
     if "workflow_run" in event:
+        wfr = event.get("workflow_run", {})
+        # 1) run 关联的 PR（fork PR 时可能 404/为空）。
         if token and repo and run_id:
             try:
                 data = api(
@@ -90,7 +94,25 @@ def get_pr_number(event_path: str, token: str = "", repo: str = "", run_id: str 
                     return prs[0].get("number")
             except (urllib.error.URLError, urllib.error.HTTPError):
                 pass
-        wfr_prs = event.get("workflow_run", {}).get("pull_requests") or []
+
+        # 2) 按 head 分支查找开放 PR（对 fork PR 有效）。
+        head_branch = wfr.get("head_branch")
+        if head_branch and token and repo:
+            try:
+                head_repo = wfr.get("head_repository", {}).get("full_name") or repo
+                owner = head_repo.split("/", 1)[0]
+                data = api(
+                    f"https://api.github.com/repos/{repo}/pulls"
+                    f"?state=open&head={owner}:{head_branch}",
+                    token,
+                )
+                if isinstance(data, list) and data:
+                    return data[0].get("number")
+            except (urllib.error.URLError, urllib.error.HTTPError):
+                pass
+
+        # 3) 事件负载回退。
+        wfr_prs = wfr.get("pull_requests") or []
         if wfr_prs:
             return wfr_prs[0].get("number")
         return None


### PR DESCRIPTION
## 背景与问题

CI 报告评论功能（`.github/workflows/ci-report.yml`，由 `workflow_run` 在 CI 完成后触发）在 **fork PR** 场景下无法解析出 PR 号，导致评论不发布：

1. `GET /actions/runs/{run_id}/pull_requests` 对 fork PR 的 CI run 返回 **404**；
2. `workflow_run` 事件负载里的 `pull_requests` 字段为空；
3. `ci_pr_report.py::get_pr_number` 两个渠道都拿不到 PR 号 → 日志输出 `非 PR 事件，跳过`。

同仓库 PR（如 fork 内 self-PR）不受影响，但来自 fork 的 PR（本仓库主要贡献方式）无法获得报告。

## 修复方案

在 `dev_tools/ci_pr_report.py::get_pr_number` 中，为 `workflow_run` 事件**新增按 head 分支反查 PR** 的回退逻辑：

1. 先按原逻辑尝试 `GET /actions/runs/{run_id}/pull_requests`；
2. 失败（404/空）时，改用 `GET /repos/{repo}/pulls?state=open&head={owner}:{branch}`，其中
   - `owner` 取 `workflow_run.head_repository.full_name`（fork PR 时为 fork 所属者）；
   - `branch` 取 `workflow_run.head_branch`；
3. 最后回退到事件负载 `workflow_run.pull_requests`。

该查询已实测对 fork PR 有效（能正确返回 PR 号），且不改变同仓库 PR 的既有行为。

## 验证

- `ruff check` 通过；语法编译通过。
- `get_pr_number` 单测：workflow_run 事件（run pull_requests 返回 404 → 走 head 分支反查）正确解析出 PR 号；pull_request 事件与"非 PR 事件"行为不变。
- 说明：`workflow_run` 仅在 workflow 文件位于默认分支（master）时触发，因此本修复需合入 dev 后再合入 master，才对后续 fork PR 生效。

## Summary by Sourcery

改进针对 `workflow_run` 事件的 CI 报告 PR 编号解析，特别是用于来自 fork 的拉取请求。

Bug Fixes:
- 确保 CI 报告评论能够解析基于 fork 的 `workflow_run` 事件的 PR 编号，修复此前导致发布失败的问题。

Enhancements:
- 扩展 `workflow_run` 的 PR 解析逻辑，当无法通过运行记录直接关联到 PR 时，回退为按 head 分支查询打开的拉取请求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve CI report PR number resolution for workflow_run events, especially for forked pull requests.

Bug Fixes:
- Ensure CI report comments can resolve the PR number for fork-based workflow_run events that previously failed to publish.

Enhancements:
- Extend workflow_run PR resolution logic to fall back to querying open pull requests by head branch when direct run associations are unavailable.

</details>