### PR TITLE
ci(ci-report): 引入占位评论机制，修复误覆盖审查机器人评论并确保 CI 通过

### DIFF
--- a/.github/workflows/ci-report-placeholder.yml
+++ b/.github/workflows/ci-report-placeholder.yml
@@ -1,0 +1,48 @@
+name: CI Report Placeholder
+
+# 在 PR 提交时立即创建一条带唯一标记的占位评论，
+# 提示「CI 检查进行中，报告将在完成后更新」；
+# ci-report workflow（workflow_run）在 ci.yml 完成后找到该占位评论并更新为最终报告。
+#
+# 为什么用 pull_request_target：
+# - fork PR 的 pull_request 事件下 GITHUB_TOKEN 只读，无法在 base 仓库发评论；
+# - pull_request_target 在 base 仓库上下文运行，具备写权限，可对 fork PR 发评论。
+#
+# 安全：本工作流只通过 actions/github-script 调 API 发评论，不 checkout、不执行 PR 代码。
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: ci-report-placeholder-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  create-placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create / ensure placeholder comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const number = context.payload.pull_request.number;
+            const marker = '<!-- ci-report-placeholder -->';
+            const body = `${marker}\n\n⏳ CI 检查进行中，报告将在完成后更新。`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: number, per_page: 100,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              core.info(`占位评论已存在（id=${existing.id}），跳过创建`);
+              return;
+            }
+            const created = await github.rest.issues.createComment({
+              owner, repo, issue_number: number, body,
+            });
+            core.info(`已创建占位评论（id=${created.data.id}）`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,34 +98,8 @@ jobs:
           name: import-smoke-summary
           path: import-smoke-summary.json
 
-  # 在所有检查完成后（即使某些 job 失败）发布/更新 PR 检查报告评论。
-  # 参考 noneflow 的 resuable_comment_issue 模式：用固定标记定位已有评论并更新，
-  # 避免每次 push 都新增一条评论。
-  pr-report:
-    name: PR 检查报告
-    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-    needs: [ruff, button-config-check, import-smoke]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download import smoke summary
-        if: always()
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: import-smoke-summary
-          path: .ci-reports
-
-      - name: Post PR report
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_EVENT_PATH: ${{ github.event_path }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: python3 dev_tools/ci_pr_report.py --summary-file .ci-reports/import-smoke-summary.json
+  # 说明：PR 检查报告评论由两条 workflow 协作完成：
+  # 1. ci-report-placeholder.yml（pull_request_target）：PR 提交时立即创建占位评论；
+  # 2. ci-report.yml（workflow_run）：CI 完成后找到占位评论并更新为最终报告。
+  # 因此不再在 ci.yml 内直接发布评论（fork PR 下 GITHUB_TOKEN 只读无法发布，
+  # 且与占位机制重复）。

--- a/dev_tools/ci_pr_report.py
+++ b/dev_tools/ci_pr_report.py
@@ -37,7 +37,12 @@ import urllib.request
 from datetime import datetime, timezone
 
 # 用于定位/更新同一条评论的标记。
+# 占位评论与最终报告都携带 PLACEHOLDER_MARKER，便于在 re-run 时更新同一条。
+# REPORT_MARKER 兼容旧的报告评论。
+PLACEHOLDER_MARKER = "<!-- ci-report-placeholder -->"
 REPORT_MARKER = "<!-- ci-report -->"
+# 我们的评论统一由 GitHub Actions bot 发布（GITHUB_TOKEN）。
+SELF_BOT_LOGIN = "github-actions[bot]"
 
 _STATUS_ICON = {
     "success": "✅",
@@ -172,7 +177,7 @@ def build_report(repo: str, run_id: str, commit: str, jobs: list[dict],
     run_url = f"https://github.com/{repo}/actions/runs/{run_id}"
     lines = [
         "## CI 检查报告",
-        REPORT_MARKER,
+        PLACEHOLDER_MARKER,
         "",
         f"- 运行：[{run_id}]({run_url})",
         f"- 提交：`{commit[:12]}`" if commit else "",
@@ -211,10 +216,18 @@ def build_report(repo: str, run_id: str, commit: str, jobs: list[dict],
 
 
 def find_self_comment(comments: list[dict]) -> int | None:
-    """查找带标记的评论（通常是由本机器人发布的）。"""
+    """查找我们自己的评论（带标记 + 由 GitHub Actions bot 发布）。
+
+    只按标记文本识别会误伤其他 bot：例如审查机器人（sourcery-ai）的评论
+    可能引用 PR 描述中出现的 ``<!-- ci-report -->`` 字样。因此同时校验
+    评论作者必须是 github-actions[bot]，绝不更新其他 bot/用户的评论。
+    """
     for comment in comments:
         body = comment.get("body") or ""
-        if REPORT_MARKER in body:
+        login = (comment.get("user") or {}).get("login", "")
+        if login == SELF_BOT_LOGIN and (
+            PLACEHOLDER_MARKER in body or REPORT_MARKER in body
+        ):
             return comment.get("id")
     return None
 

--- a/dev_tools/import_smoke_test.py
+++ b/dev_tools/import_smoke_test.py
@@ -163,6 +163,11 @@ def main() -> int:
                         help="将扫描汇总写入 JSON 文件（供 CI 报告使用），即使失败也会写入")
     args = parser.parse_args()
 
+    # 模拟真实运行环境：应用启动时会创建 ./log/ 目录。
+    # 全新 checkout 无该目录时，部分模块（如 module.azur_stats.image.* 的
+    # 导入链）初始化日志文件会抛 FileNotFoundError，导致误报意外失败。
+    (REPO_ROOT / "log").mkdir(parents=True, exist_ok=True)
+
     start = time.time()
     print(f"[import-smoke] 扫描 module/ + deploy/" + (" + campaign/" if args.include_campaign else "")
           + f"，超时 {args.timeout}s，并行 {args.workers}")


### PR DESCRIPTION
## 背景与问题

CI 报告评论链路存在两个问题：

1. **误覆盖其他 bot 的评论**：`ci_pr_report.py::find_self_comment` 仅按标记文本
   `<!-- ci-report -->` 匹配评论。审查机器人（sourcery-ai）的评论若引用了
   PR 描述中出现的该标记，会被误判为"自己的评论"并**覆盖**（实测：PR #743 上
   sourcery-ai 的评论被更新成了我们的 CI 报告）。
2. **全新环境 CI 失败**：import-smoke 在全新 checkout（无 `./log/` 目录）下，
   部分模块（如 `module.azur_stats.image.*` 导入链）初始化日志文件时报
   `FileNotFoundError: .../log/-c.txt`，导致 Import Smoke Test 失败。

## 修复方案

1. **新增占位评论机制**（`.github/workflows/ci-report-placeholder.yml`）：
   - 用 `pull_request_target` 在 PR 打开/同步时**立即创建**一条带唯一标记
     `<!-- ci-report-placeholder -->` 的占位评论（"⏳ CI 检查进行中，报告将在完成后更新"）；
   - 只通过 `actions/github-script` 调 API，不 checkout、不执行 PR 代码（安全）。
2. **`ci_pr_report.py`**：
   - `find_self_comment` 增加**作者校验**：仅更新 `github-actions[bot]` 发布且
     携带我们标记的评论，**绝不覆盖其他 bot/用户**；
   - 报告体携带 `<!-- ci-report-placeholder -->` 标记，re-run 时更新同一条。
3. **`ci.yml`**：移除 `pr-report` job（fork PR 下 token 只读无法发布，且与占位机制
   重复；报告改由 占位 workflow + ci-report workflow_run 协作完成）。
4. **`import_smoke_test.py`**：扫描前确保 `./log/` 存在，模拟真实运行环境，修复 CI 失败。

## 验证

- `ruff` 通过；语法编译通过；三个 workflow YAML 结构校验通过。
- `find_self_comment` 单测：
  - sourcery-ai 评论（含 `<!-- ci-report -->` 字样）→ 不匹配，不会被覆盖；
  - 我们的占位/报告评论 → 正确匹配并更新；
  - 兼容旧报告标记。
- 说明：placeholder 机制在合并到 master 后对后续 PR 生效（`workflow_run`/
  `pull_request_target` 均在默认分支上下文运行）。

## Summary by Sourcery

引入 CI 报告占位评论工作流，更新 CI 报告生成逻辑以安全地仅针对 GitHub Actions 评论，并通过创建日志目录确保在干净检出环境中导入冒烟测试可以成功运行。

New Features:
- 添加 CI 报告占位工作流，在拉取请求上使用唯一标记发布初始状态评论。

Bug Fixes:
- 通过同时要求标记和 GitHub Actions 机器人为作者，防止 CI 报告更新覆盖其他机器人或用户的评论。
- 通过在进行模块导入扫描前创建 `./log` 目录，确保在全新检出环境中导入冒烟测试能够通过。

Enhancements:
- 更新 CI 报告内容以使用占位标记，从而在重新运行时始终一致地更新同一条评论。
- 从主 CI 工作流中移除工作流内的 PR 报告任务，改为使用占位评论加专用 CI 报告工作流。

CI:
- 添加基于 `pull_request_target` 的工作流，在 PR 上创建或确认存在 CI 报告占位评论。
- 记录说明现在 CI 报告评论由占位和 ci-report 工作流生成，而不是直接在 `ci.yml` 中生成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a CI report placeholder comment workflow, update CI report generation to safely target only GitHub Actions comments, and ensure import smoke tests succeed in clean checkouts by creating the log directory.

New Features:
- Add a CI report placeholder workflow that posts an initial status comment on pull requests using a unique marker.

Bug Fixes:
- Prevent CI report updates from overwriting other bots’ or users’ comments by requiring both a marker and the GitHub Actions bot as author.
- Ensure import smoke tests pass in fresh checkouts by creating the ./log directory before module import scanning.

Enhancements:
- Update CI report content to use the placeholder marker so re-runs consistently update the same comment.
- Remove the in-workflow PR report job from the main CI workflow in favor of the placeholder plus dedicated CI report workflows.

CI:
- Add a pull_request_target-based workflow that creates or ensures the CI report placeholder comment on PRs.
- Document that CI report comments are now produced by the placeholder and ci-report workflows rather than directly in ci.yml.

</details>