### PR TITLE
chore: 在 .gitignore 中添加 .claude 目录，避免技能文件上传远程

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ debug_ocr/
 PaddleOCR
 .trae
 docs/
+.claude
 # Created by .ignore support plugin (hsz.mobi)
 
 ### JetBrains template


### PR DESCRIPTION
本地 Claude Code 技能文件位于 .claude/skills/，仅供本地开发使用，
不应提交到远程仓库。

## Summary by Sourcery

Build:
- 将 `.claude` 目录添加到 `.gitignore`，以防止本地 Claude Code 技能文件被提交。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Add the .claude directory to .gitignore to prevent local Claude Code skill files from being committed.

</details>