### PR TITLE
feat(island): 未达标物品库存最少优先轮转补种，并修复岛屿购买/选角/速运问题

### DIFF
--- a/module/island/island.py
+++ b/module/island/island.py
@@ -890,10 +890,12 @@ class Island(SelectCharacter):
             shopping_shown = self.appear(ISLAND_SHOPPING_CHECK)
             if shop_visible and not shopping_shown:
                 break
-            if self.appear_then_click(ISLAND_SHOP_CONFIRM):
+            if self.appear_then_click(ISLAND_SHOP_CONFIRM, interval=1):
+                # 点击确认后立即复检：弹窗或确认按钮消失都视为购买完成，退出避免重复点击
                 self.device.sleep(0.5)
-                self.device.click(ISLAND_SHOP_CONFIRM)
-                self.device.sleep(0.5)
+                self.device.screenshot()
+                if not self.appear(ISLAND_SHOP_CONFIRM) or not self.appear(ISLAND_SHOPPING_CHECK):
+                    break
                 continue
             if self.appear(ISLAND_SHOP_GET):
                 self.device.click(ISLAND_SHOP_CONFIRM)

--- a/module/island/island_daily_interact.py
+++ b/module/island/island_daily_interact.py
@@ -551,7 +551,9 @@ class IslandDailyInteract(Island):
 
     def _click_optional_interact_or_complete(self, interact_button, complete_button, label, timeout=8):
         for _ in self.loop(timeout=timeout):
-            if self.appear_then_click(interact_button, interval=2):
+            # 交互按钮用模板匹配而非纯颜色检测：已完成状态下同一区域可能被
+            # “管理苗圃”等浅色选项行占据，颜色检测会误判为未完成并误点卡住。
+            if self.appear_then_click(interact_button, offset=(20, 20), interval=2):
                 logger.info(f'[岛屿-每日周任务] 点击{label}')
                 return 'clicked'
             if self.appear(complete_button, offset=(20, 20)):

--- a/module/island/island_farm.py
+++ b/module/island/island_farm.py
@@ -255,7 +255,7 @@ class IslandFarm(Island, WarehouseOCR, LoginHandler):
         }
 
     def check_inventory_and_prepare_lists(self):
-        """检查库存并准备需要补种的列表"""
+        """检查库存并准备需要补种的列表（按库存升序，最少的优先）"""
         for category in ['farm', 'orchard', 'nursery']:
             inventory = self.warehouse_inventory(category)
             config = self.INVENTORY_CONFIG[category]
@@ -278,6 +278,8 @@ class IslandFarm(Island, WarehouseOCR, LoginHandler):
                         continue
                 if count < threshold:
                     self.to_plant_lists[category].append(item_name)
+            # 库存最少的作物排最前，轮转分配时优先补种
+            self.to_plant_lists[category].sort(key=lambda name: inventory.get(name, 0))
 
     def _is_orchard_crop_in_season(self, crop_name):
         """
@@ -616,18 +618,16 @@ class IslandFarm(Island, WarehouseOCR, LoginHandler):
 
             need_default = max(0, default_count - already_planted_default)
 
-            num_from_list = min(len(to_plant_list), idle_count)
-
-            for i in range(num_from_list):
-                crop_name = to_plant_list[i]
-                all_plants_to_plant[category].append(crop_name)
-
-            remaining_idle = idle_count - num_from_list
-
-            if remaining_idle > 0 and need_default > 0:
-                actual_default = min(remaining_idle, need_default)
-                for _ in range(actual_default):
-                    all_plants_to_plant[category].append(default_crop)
+            if to_plant_list:
+                # 未达标作物：按库存升序轮转分配所有空闲岗位（如 A B C A B ...）
+                for i in range(idle_count):
+                    all_plants_to_plant[category].append(to_plant_list[i % len(to_plant_list)])
+            else:
+                # 所有未达标作物都已安排后才种植默认作物
+                if idle_count > 0 and need_default > 0:
+                    actual_default = min(idle_count, need_default)
+                    for _ in range(actual_default):
+                        all_plants_to_plant[category].append(default_crop)
 
             if all_plants_to_plant[category]:
                 logger.info(f"[岛屿-农田] \n{category}需要种植的作物: {all_plants_to_plant[category]}")

--- a/module/island/island_fishery.py
+++ b/module/island/island_fishery.py
@@ -138,35 +138,40 @@ class IslandFishery(Island, WarehouseOCR, LoginHandler):
         return removed
 
     def _build_supply_plant_products(self, idle_count):
-        """按岗位容量把鱼苗需求压缩成待养殖产品列表。"""
-        products_to_plant = []
-        supply_post_counts = {}
-        remaining_idle = idle_count
-
+        """按库存升序轮转分配岗位，未达标物品优先补足（如 A B C A B ...）。"""
+        # 收集未达标产品及其所需岗位数，按当前库存升序排序（库存最少的最优先）
+        demand = []
         for item_config in self.FISHERY_ITEMS:
             product = item_config['name']
             fry_needed = self.to_plant_list.count(product)
             if fry_needed <= 0:
                 continue
-
             buy_max = item_config.get('buy_max', 4)
             post_capacity = buy_max + 1
             post_needed = (fry_needed + post_capacity - 1) // post_capacity
-            post_to_use = min(post_needed, remaining_idle)
-
-            if post_to_use <= 0:
-                break
-
-            products_to_plant.extend([product] * post_to_use)
-            supply_post_counts[product] = supply_post_counts.get(product, 0) + post_to_use
-            remaining_idle -= post_to_use
+            stock = self.inventory_counts.get(product, 0)
+            demand.append((product, post_needed, stock))
             logger.info(
                 f"{product}: 需养殖{fry_needed}个鱼苗，每岗容量{post_capacity}，"
-                f"本轮占用{post_to_use}个岗位"
+                f"库存{stock}，需要{post_needed}个岗位"
             )
 
-            if remaining_idle <= 0:
-                break
+        demand.sort(key=lambda x: x[2])
+        products_to_plant = []
+        supply_post_counts = {}
+        assigned = {product: 0 for product, _, _ in demand}
+        remaining_idle = idle_count
+        idx = 0
+
+        # 轮转分配：按库存升序循环，每个未达标产品至少一岗，岗位充足时继续补最少的
+        while remaining_idle > 0 and demand and any(assigned[p] < n for p, n, _ in demand):
+            product, post_needed, _ = demand[idx % len(demand)]
+            if assigned[product] < post_needed:
+                products_to_plant.append(product)
+                supply_post_counts[product] = supply_post_counts.get(product, 0) + 1
+                assigned[product] += 1
+                remaining_idle -= 1
+            idx += 1
 
         return products_to_plant, remaining_idle, supply_post_counts
 

--- a/module/island/island_manufacture.py
+++ b/module/island/island_manufacture.py
@@ -23,26 +23,18 @@ FIXED_SELECT_SHEPHERD_PURSE = Button(
 
 
 # 季节限定手工产品配置（按 SEASONAL_ITEMS['handmade'] 的键引用）
+# 注意：清单中的部分物品（如夏季茉莉精油、秋季花束）有意不在此配置内，
+# 即季节定义保留但工厂不实际制作。
 SEASONAL_HANDMADE_ITEMS = {
     'shepherd_purse': {
         'name': 'shepherd_purse', 'template': TEMPLATE_SHEPHERD_PURSE,
         'var_name': 'shepherd_purse', 'selection': FIXED_SELECT_SHEPHERD_PURSE,
         'selection_check': FIXED_SELECT_SHEPHERD_PURSE, 'post_action': POST_SHEPHERD_PURSE,
     },
-    'jasmine_oil': {
-        'name': 'jasmine_oil', 'template': TEMPLATE_JASMINE_OIL,
-        'var_name': 'jasmine_oil', 'selection': SELECT_JASMINE_OIL,
-        'selection_check': SELECT_JASMINE_OIL_CHECK, 'post_action': POST_JASMINE_OIL,
-    },
     'summer_bouquet': {
         'name': 'summer_bouquet', 'template': TEMPLATE_SUMMER_BOUQUET,
         'var_name': 'summer_bouquet', 'selection': SELECT_SUMMER_BOUQUET,
         'selection_check': SELECT_SUMMER_BOUQUET_CHECK, 'post_action': POST_SUMMER_BOUQUET,
-    },
-    'autumn_bouquet': {
-        'name': 'autumn_bouquet', 'template': TEMPLATE_AUTUMN_BOUQUET,
-        'var_name': 'autumn_bouquet', 'selection': SELECT_AUTUMN_BOUQUET,
-        'selection_check': SELECT_AUTUMN_BOUQUET_CHECK, 'post_action': POST_AUTUMN_BOUQUET,
     },
 }
 
@@ -380,7 +372,7 @@ class IslandManufacture(IslandShopBase):
         leather_stock = self.warehouse_counts.get('leather', 0)
         # 构建产品选择列表（按优先级）
         product_list = []
-        # 优先生产当前季节的限定手工品（荠菜干、秋季花束等）
+        # 优先生产当前季节的限定手工品（荠菜干、夏季花束等）
         seasonal_names = []
         if hasattr(self, 'season_config') and self.season_config.is_seasonal_enabled:
             seasonal_names = self.season_config.get_seasonal_items('handmade') or []

--- a/module/island/island_mine_forest.py
+++ b/module/island/island_mine_forest.py
@@ -203,6 +203,8 @@ class IslandMineForest(Island,LoginHandler):
                     logger.info(f"[岛屿-矿山林场]   {name}: 仓库{warehouse_count}+生产中{in_production}={effective_count} < {threshold} → 缺 {need_count}")
                 else:
                     logger.info(f"[岛屿-矿山林场]   {name}: 仓库{warehouse_count}+生产中{in_production}={effective_count} ≥ {threshold} → 不缺")
+            # 库存最少的产物排最前，轮转分配时优先补足
+            needs[category].sort(key=lambda name: inventory.get(name, 0))
 
         logger.info(f"[岛屿-矿山林场] 需要生产的产物: {needs}")
         return needs
@@ -475,33 +477,56 @@ class IslandMineForest(Island,LoginHandler):
 
         logger.info(f"[岛屿-矿山林场] 空闲岗位: 矿山 {len(idle_posts['mine'])} 个, 林场 {len(idle_posts['forest'])} 个")
 
-        # 产物有缺口的先分配，剩下的默认
+        # 产物有缺口的先分配（库存最少优先轮转），剩下的默认
         all_to_plant = {'mine': [], 'forest': []}
         for category in ['mine', 'forest']:
-            # needs 中属于该分类的产物
+            # needs 中属于该分类的产物（已按库存升序）
             cat_needs = needs.get(category, [])
             idle_count = len(idle_posts[category])
 
-            # 取 min(空闲数, 缺口数) 个配给缺口产物
-            num_from_needs = min(len(cat_needs), idle_count)
-            for i in range(num_from_needs):
-                all_to_plant[category].append(cat_needs[i])
+            # 计算每个缺口产物需要的岗位数（每岗最多 max_runs * UNITS_PER_RUN 单位）
+            remaining_need = {
+                name: self.needs_count.get((category, name), 0)
+                for name in cat_needs
+            }
+            posts_needed = {}
+            for name in cat_needs:
+                max_units_per_post = self.PRODUCT_MAX_RUNS.get(name, 5) * self.UNITS_PER_RUN
+                posts_needed[name] = max(1, -(-remaining_need[name] // max_units_per_post))
+            assigned = {name: 0 for name in cat_needs}
 
-            # 剩余空闲 → 按配置分配默认产物，其余空着不动
-            remaining = idle_count - num_from_needs
+            # 按库存升序轮转分配岗位（如 A B C A B ...），每个缺口产物至少一岗，
+            # 岗位充足时继续补最少的产物，直到岗位用完或所有缺口产物岗位需求满足
+            idx = 0
+            while len(all_to_plant[category]) < idle_count and \
+                    any(assigned[n] < posts_needed[n] for n in cat_needs):
+                name = cat_needs[idx % len(cat_needs)]
+                if assigned[name] < posts_needed[name]:
+                    max_units_per_post = self.PRODUCT_MAX_RUNS.get(name, 5) * self.UNITS_PER_RUN
+                    post_need = min(remaining_need[name], max_units_per_post)
+                    remaining_need[name] -= post_need
+                    assigned[name] += 1
+                    all_to_plant[category].append((name, post_need))
+                idx += 1
+
+            # 所有缺口产物岗位需求满足后，剩余空闲 → 按配置分配默认产物
+            remaining = idle_count - len(all_to_plant[category])
             if category == 'mine':
                 # MineSilver: 几个空闲岗位产银矿，其余空着
                 silver_count = min(self.config.IslandMine_MineSilver, remaining)
                 for _ in range(silver_count):
-                    all_to_plant['mine'].append('Silver')
+                    all_to_plant['mine'].append(('Silver', None))
             else:
                 # CutElegant: 几个空闲岗位产典雅之木，其余空着
                 elegant_count = min(self.config.IslandForest_CutElegant, remaining)
                 for _ in range(elegant_count):
-                    all_to_plant['forest'].append('Elegant')
+                    all_to_plant['forest'].append(('Elegant', None))
 
             if all_to_plant[category]:
-                logger.info(f"[岛屿-矿山林场] {category} 需要种植: {all_to_plant[category]}")
+                logger.info(
+                    f"[岛屿-矿山林场] {category} 需要种植: "
+                    f"{[(p, n) for p, n in all_to_plant[category]]}"
+                )
 
         # ===== 步骤4：执行种植（无需买种子） =====
         if any(all_to_plant.values()):
@@ -514,8 +539,7 @@ class IslandMineForest(Island,LoginHandler):
             for i, pid in enumerate(idle_posts['mine']):
                 if i >= len(all_to_plant['mine']):
                     break
-                product = all_to_plant['mine'][i]
-                need_count = self.needs_count.get(('mine', product), None)
+                product, need_count = all_to_plant['mine'][i]
                 time_var = f'time_{pid}'
                 logger.info(f"[岛屿-矿山林场] 种植矿山 {pid}: {product}")
                 self.post_plant(self.posts[pid]['button'], product, 'mine', time_var, need_count=need_count)
@@ -529,8 +553,7 @@ class IslandMineForest(Island,LoginHandler):
             for i, pid in enumerate(idle_posts['forest']):
                 if i >= len(all_to_plant['forest']):
                     break
-                product = all_to_plant['forest'][i]
-                need_count = self.needs_count.get(('forest', product), None)
+                product, need_count = all_to_plant['forest'][i]
                 time_var = f'time_{pid}'
                 logger.info(f"[岛屿-矿山林场] 种植林场 {pid}: {product}")
                 self.post_plant(self.posts[pid]['button'], product, 'forest', time_var, need_count=need_count)

--- a/module/island/island_select_character.py
+++ b/module/island/island_select_character.py
@@ -16,7 +16,10 @@ class SelectCharacter(UI):
     def __init__(self, *args, **kwargs):
         UI.__init__(self, *args, **kwargs)
         self.select_character_grid = ButtonGrid(
-            origin=(58, 141),
+            # 头像左上角位于单元格偏移 (33, 45) 处，
+            # 与 _cell_button_from_portrait() 的锚点偏移保持一致。
+            # 仅识别可靠可读的前两行，第三行不参与网格判定。
+            origin=(58, 112),
             delta=(140, 180),
             button_shape=(120, 160),
             grid_shape=(6, 2),
@@ -27,7 +30,7 @@ class SelectCharacter(UI):
         self.unavailable_characters = set()
 
         # 定义状态检测区域（相对于每个角色按钮）
-        self.character_area_relative = (25, 38, 125, 92)
+        self.character_area_relative = (25, 38, 125, 96)
         self.working_area_relative = (15, 92, 105, 121)
         self.stamina_area_relative = (18, 165, 58, 182)
         self.stamina_ocr_area_relative = (0, 165, 80, 184)
@@ -710,6 +713,8 @@ class SelectCharacter(UI):
                 )
                 # 点击目标直接用头像匹配框，避免固定网格在滚动偏移下点错位置
                 char_info["button"] = portrait_button
+                # 选中状态检测以重建单元格为基准（头像框与单元格偏移不同）
+                char_info["cell_button"] = cell_button
                 checked = self._check_character_strict(char_info, stamina_threshold)
                 if checked is None:
                     self.unavailable_characters.add(char_name)
@@ -742,11 +747,13 @@ class SelectCharacter(UI):
             return False
 
         row, col = char_info["grid_position"]
-        # 滚动回退路径携带头像匹配框作为点击目标，网格路径使用固定网格
+        # 滚动回退路径携带头像匹配框作为点击目标，网格路径使用固定网格；
+        # 选中状态检测以重建单元格为基准，避免头像框偏移导致确认失败
         button = char_info.get("button") or self.select_character_grid[row, col]
+        status_button = char_info.get("cell_button") or button
         for attempt in range(5):
             screenshot = self.device.screenshot()
-            if self._check_selected_status(screenshot, button):
+            if self._check_selected_status(screenshot, status_button):
                 return True
             self.device.click(button)
             self.device.sleep(0.3)


### PR DESCRIPTION
## 概述

本 PR 汇总了岛屿系统最近的 5 条改动：统一优化农田/渔场/矿林的补种与养殖优先级，
并修复购买确认、角色选择、JUU 速运状态识别等运行时问题。

## 改动内容

### 1. 未达标物品按库存最少优先轮转补种/养殖

- 农田/渔场/矿林统一按**库存升序**排列未达标物品，岗位按轮转顺序分配
  （如 A B C A B ...），库存最少的物品优先补足；
- 每个未达标物品至少占一个岗位；岗位充足时继续补充库存最少者，
  岗位不足时优先给库存最少的物品；
- 默认作物/默认产物（如土豆、银矿、典雅之木）仅在所有未达标物品
  分配完成后才种植；
- 矿林按缺口拆分每岗产量（每岗不超过 `max_runs × 4`），避免多岗超产。

### 2. 修复购买确认弹窗关闭后仍重复点击

- 购买确认成功后不再无条件补点一次，避免点击次数翻倍；
- 点击确认后立即复检，弹窗或确认按钮消失即退出循环；
- 确认按钮点击增加 1 秒间隔，防止连点触发 `GameTooManyClickError`。

### 3. 修正岛屿选角网格偏移与滚动回退选中确认

- 修正角色选择网格的偏移计算；
- 滚动回退后重新确认选中，避免选错角色。

### 4. 调整工厂季节限定手工品生产配置

- 夏季不再制作茉莉精油（仅制作夏季花束），秋季不再制作秋季花束；
- 季节限定物品清单与 i18n 帮助文本保持完整，仅从
  `SEASONAL_HANDMADE_ITEMS` 移除对应生产项。

### 5. 修复 JUU 速运已完成状态误识别

- 修复 JUU 速运配送中已完成状态被误判为未完成，导致误点苗圃管理的问题。

## 验证情况

- 三个补种/养殖模块通过 `compile()` 与 ruff（E9/F63/F7/F82）检查；
- 轮转分配逻辑经模拟数据验证：ABCAB 顺序、岗位不足时优先最少、
  矿林缺口拆分（如 100 → 48+48+4）均符合预期；
- 购买确认修复已同步到测试环境，弹窗关闭后不再重复点击；
- `config_updater` 重跑后无多余 diff，i18n 与生成产物一致。

## 涉及文件

- `module/island/island_farm.py`
- `module/island/island_fishery.py`
- `module/island/island_mine_forest.py`
- `module/island/island.py`
- `module/island/island_manufacture.py`
- `module/island/island_season.py`
- `module/config/i18n/*.json`（跟随第 4 条提交）

## Summary by Sourcery

根据库存最低优先补给岛屿资源，并优化岛屿系统中的多项运行时交互。

New Features:
- 统一农场、渔场以及矿场/林地的资源补给逻辑，使低于阈值的物品按从库存最低开始的轮询顺序分配到各个岗位。

Bug Fixes:
- 通过依据配置的最大运行次数限制每个岗位的产出，修复矿场/林地过度生产的问题。
- 修正角色选择网格在滚动时的锚点与选择确认逻辑，避免误选角色。
- 通过在确认对话框或按钮消失后立即停止点击，防止商店购买确认重复触发以及过度点击导致的错误。
- 避免已完成的 JUU 快递被错误识别为未完成，防止在苗圃管理中产生多余错误点击。

Enhancements:
- 调整季节性手工工厂配置，使夏季不再生产茉莉花油、秋季不再生产秋日花束，同时保持季节定义与国际化文本一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prioritize island resource replenishment based on lowest inventory and refine several runtime interactions in the island system.

New Features:
- Unify farm, fishery, and mine/forest replenishment so under-threshold items are allocated to posts in a round-robin order starting from the lowest stock.

Bug Fixes:
- Fix mine/forest overproduction by capping per-post output according to configured maximum runs.
- Correct character selection grid anchoring and selection confirmation when scrolling to avoid mis-clicked roles.
- Prevent duplicate shop purchase confirmations and excessive click errors by stopping once the confirmation dialog or button disappears.
- Avoid misidentifying completed JUU express deliveries as incomplete to prevent erroneous nursery management clicks.

Enhancements:
- Adjust seasonal handmade factory configuration so summer no longer produces jasmine oil and autumn no longer produces autumn bouquets, while keeping seasonal definitions and i18n texts aligned.

</details>