### PR TITLE
feat(os): 大世界购买行动力双模式及紧急调度增强

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -128,6 +128,7 @@
       "CommissionRecord": "do_not",
       "CombatRecord": "do_not",
       "OpsiRecord": "upload",
+      "OpsiShopRecord": "upload",
       "MeowfficerBuy": "do_not",
       "MeowfficerTalent": "do_not",
       "TelemetryReport": true,
@@ -1942,8 +1943,10 @@
       "CustomFilter": "DailyEvent > Gem-4 > Gem-2 > Gem-8 > ExtraCube-0:30\n> UrgentCube-1:30 > UrgentCube-1:45 > UrgentCube-3\n> ExtraDrill-5:20 > ExtraDrill-2 > ExtraDrill-3:20\n> UrgentCube-2:15 > UrgentCube-4\n> ExtraDrill-1 > UrgentCube-6 > ExtraCube-1:30\n> ExtraDrill-2:40 > ExtraDrill-0:20\n> Major > DailyChip > DailyResource\n> ExtraPart-0:30 > ExtraOil-1 > UrgentBox-6\n> ExtraCube-3 > ExtraPart-1 > UrgentBox-3\n> ExtraCube-4 > ExtraPart-1:30 > ExtraOil-4\n> UrgentBox-1 > ExtraCube-5 > UrgentBox-1\n> ExtraCube-8 > ExtraOil-8\n> UrgentDrill-4 > UrgentDrill-2:40 > UrgentDrill-2\n> UrgentDrill-1 > UrgentDrill-1:30 > UrgentDrill-1:10\n> Extra-0:20 > Extra-0:30 > Extra-1:00 > Extra-1:30 > Extra-2:00\n> shortest",
       "Blacklist": null,
       "DoMajorCommission": false,
+      "GemNotify": false,
       "CommissionNotifyReward": false,
-      "CommissionNotifyRewardStatistics": true
+      "CommissionNotifyRewardStatistics": true,
+      "CommissionNotifyRewardCube": false
     },
     "Storage": {
       "Storage": {}
@@ -2123,6 +2126,29 @@
     "Awaken": {
       "LevelCap": "level120",
       "Favourite": false
+    },
+    "Storage": {
+      "Storage": {}
+    }
+  },
+  "Secretary": {
+    "Scheduler": {
+      "Enable": false,
+      "PushNotification": false,
+      "NextRun": "2020-01-01 00:00:00",
+      "Command": "Secretary",
+      "SuccessInterval": 0,
+      "FailureInterval": 120,
+      "ServerUpdate": "00:00",
+      "Sensitive": false
+    },
+    "Secretary": {
+      "CustomFilter": "ultra > super_rare > elite > rare > common",
+      "LowFavorabilityPriority": false,
+      "BackupEnable": true,
+      "CheckInterval": 0,
+      "Notify": true,
+      "OnePushConfig": "provider: null"
     },
     "Storage": {
       "Storage": {}
@@ -2731,6 +2757,7 @@
     },
     "OpsiFleetAutoChange": {
       "Enable": false,
+      "AnyShipReached": false,
       "CooldownHours": 24,
       "LastRun": "2020-01-01 00:00:00"
     },
@@ -2762,7 +2789,10 @@
       "MonthEndActionPointCleanupEnable": false,
       "MonthEndActionPointCleanupDays": 0,
       "MonthEndActionPointPreserve": 0,
-      "MonthEndShopPurchase": true
+      "MonthEndShopPurchase": true,
+      "BuyActionPointMode": "off",
+      "BuyActionPointUpperThreshold": 200,
+      "BuyActionPointLowerThreshold": 100
     },
     "Storage": {
       "Storage": {}

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -306,7 +306,6 @@
           "en-3",
           "en-4",
           "en-5",
-          "en-6",
           "jp-0",
           "jp-1",
           "jp-2",
@@ -324,12 +323,7 @@
           "jp-14",
           "jp-15",
           "jp-16",
-          "jp-17",
-          "tw-0",
-          "tw-1",
-          "tw-2",
-          "tw-3",
-          "tw-4"
+          "jp-17"
         ]
       },
       "ScreenshotMethod": {
@@ -547,10 +541,13 @@
         "value": "auto",
         "option": [
           "auto",
-          "lite",
-          "standard",
-          "pro",
-          "alocr_en_v2_6"
+          "alocr_en_900k",
+          "azur_lane_v6_6",
+          "azur_lane_v6_5",
+          "ppocr_v6",
+          "alocr_en_v2_6",
+          "alocr_en_v2_0",
+          "alocr_en_v1_0"
         ]
       },
       "OcrModelVersionChinese": {
@@ -558,10 +555,11 @@
         "value": "auto",
         "option": [
           "auto",
-          "lite",
-          "standard",
-          "pro",
-          "alocr_cn_v3"
+          "cn_v6_1",
+          "cn_v6",
+          "ppocr_v6",
+          "alocr_cn_v3",
+          "alocr_cn_v2_5"
         ]
       },
       "OcrModelVersionJapanese": {
@@ -569,9 +567,8 @@
         "value": "auto",
         "option": [
           "auto",
-          "lite",
-          "standard",
-          "pro"
+          "azur_lane_jp_v6",
+          "ppocr_v6"
         ]
       },
       "OcrModelVersionTraditionalChinese": {
@@ -579,9 +576,7 @@
         "value": "auto",
         "option": [
           "auto",
-          "lite",
-          "standard",
-          "pro"
+          "ppocr_v6"
         ]
       },
       "ScreenshotInterval": {
@@ -660,6 +655,16 @@
         ]
       },
       "OpsiRecord": {
+        "type": "select",
+        "value": "upload",
+        "option": [
+          "do_not",
+          "save",
+          "upload",
+          "save_and_upload"
+        ]
+      },
+      "OpsiShopRecord": {
         "type": "select",
         "value": "upload",
         "option": [
@@ -2406,10 +2411,10 @@
           "event_20260813_cn"
         ],
         "option_en": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_jp": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_tw": [
           "event_20260625_cn"
@@ -2926,10 +2931,10 @@
           "event_20260813_cn"
         ],
         "option_en": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_jp": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_tw": [
           "event_20260625_cn"
@@ -3878,10 +3883,10 @@
           "event_20260813_cn"
         ],
         "option_en": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_jp": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_tw": [
           "event_20260625_cn"
@@ -4321,10 +4326,10 @@
           "event_20260813_cn"
         ],
         "option_en": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_jp": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_tw": [
           "event_20260625_cn"
@@ -4764,10 +4769,10 @@
           "event_20260813_cn"
         ],
         "option_en": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_jp": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_tw": [
           "event_20260625_cn"
@@ -6112,21 +6117,25 @@
         "type": "state",
         "value": "campaign_main",
         "option": [
+          "coalition_20230323",
+          "coalition_20260122",
           "coalition_20260723"
         ],
         "option_cn": [
           "coalition_20260723"
         ],
         "option_en": [
-          "coalition_20260723"
+          "coalition_20260122"
         ],
         "option_jp": [
-          "coalition_20260723"
+          "coalition_20260122"
         ],
         "option_tw": [
-          "coalition_20260723"
+          "coalition_20230323"
         ],
         "option_bold": [
+          "coalition_20230323",
+          "coalition_20260122",
           "coalition_20260723"
         ]
       },
@@ -6411,21 +6420,25 @@
         "type": "state",
         "value": "campaign_main",
         "option": [
+          "coalition_20230323",
+          "coalition_20260122",
           "coalition_20260723"
         ],
         "option_cn": [
           "coalition_20260723"
         ],
         "option_en": [
-          "coalition_20260723"
+          "coalition_20260122"
         ],
         "option_jp": [
-          "coalition_20260723"
+          "coalition_20260122"
         ],
         "option_tw": [
-          "coalition_20260723"
+          "coalition_20230323"
         ],
         "option_bold": [
+          "coalition_20230323",
+          "coalition_20260122",
           "coalition_20260723"
         ]
       },
@@ -7613,10 +7626,10 @@
           "event_20260813_cn"
         ],
         "option_en": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_jp": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_tw": [
           "event_20260625_cn"
@@ -8073,10 +8086,10 @@
           "event_20260813_cn"
         ],
         "option_en": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_jp": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_tw": [
           "event_20260625_cn"
@@ -8533,10 +8546,10 @@
           "event_20260813_cn"
         ],
         "option_en": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_jp": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_tw": [
           "event_20260625_cn"
@@ -8993,10 +9006,10 @@
           "event_20260813_cn"
         ],
         "option_en": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_jp": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_tw": [
           "event_20260625_cn"
@@ -9443,10 +9456,10 @@
           "event_20260813_cn"
         ],
         "option_en": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_jp": [
-          "event_20260813_cn"
+          "event_20260625_cn"
         ],
         "option_tw": [
           "event_20260625_cn"
@@ -10163,21 +10176,25 @@
         "type": "select",
         "value": "campaign_main",
         "option": [
+          "coalition_20230323",
+          "coalition_20260122",
           "coalition_20260723"
         ],
         "option_cn": [
           "coalition_20260723"
         ],
         "option_en": [
-          "coalition_20260723"
+          "coalition_20260122"
         ],
         "option_jp": [
-          "coalition_20260723"
+          "coalition_20260122"
         ],
         "option_tw": [
-          "coalition_20260723"
+          "coalition_20230323"
         ],
         "option_bold": [
+          "coalition_20230323",
+          "coalition_20260122",
           "coalition_20260723"
         ]
       },
@@ -10489,6 +10506,10 @@
         "value": ""
       },
       "DoMajorCommission": {
+        "type": "checkbox",
+        "value": false
+      },
+      "GemNotify": {
         "type": "checkbox",
         "value": false
       },
@@ -11221,6 +11242,94 @@
       "Favourite": {
         "type": "checkbox",
         "value": false
+      }
+    },
+    "Storage": {
+      "Storage": {
+        "type": "storage",
+        "value": {},
+        "valuetype": "ignore",
+        "display": "disabled"
+      }
+    }
+  },
+  "Secretary": {
+    "Scheduler": {
+      "Enable": {
+        "type": "checkbox",
+        "value": false,
+        "option": [
+          true,
+          false
+        ]
+      },
+      "PushNotification": {
+        "type": "checkbox",
+        "value": false,
+        "option": [
+          true,
+          false
+        ]
+      },
+      "NextRun": {
+        "type": "datetime",
+        "value": "2020-01-01 00:00:00",
+        "validate": "datetime"
+      },
+      "Command": {
+        "type": "input",
+        "value": "Secretary",
+        "display": "hide"
+      },
+      "SuccessInterval": {
+        "type": "input",
+        "value": 0,
+        "display": "hide"
+      },
+      "FailureInterval": {
+        "type": "input",
+        "value": 120,
+        "display": "hide"
+      },
+      "ServerUpdate": {
+        "type": "input",
+        "value": "00:00",
+        "display": "hide"
+      },
+      "Sensitive": {
+        "type": "checkbox",
+        "value": false,
+        "option": [
+          true,
+          false
+        ]
+      }
+    },
+    "Secretary": {
+      "CustomFilter": {
+        "type": "textarea",
+        "value": "ultra > super_rare > elite > rare > common"
+      },
+      "LowFavorabilityPriority": {
+        "type": "checkbox",
+        "value": false
+      },
+      "BackupEnable": {
+        "type": "checkbox",
+        "value": true
+      },
+      "CheckInterval": {
+        "type": "input",
+        "value": 0
+      },
+      "Notify": {
+        "type": "checkbox",
+        "value": true
+      },
+      "OnePushConfig": {
+        "type": "textarea",
+        "value": "provider: null",
+        "mode": "yaml"
       }
     },
     "Storage": {
@@ -13834,6 +13943,14 @@
           false
         ]
       },
+      "AnyShipReached": {
+        "type": "checkbox",
+        "value": false,
+        "option": [
+          true,
+          false
+        ]
+      },
       "CooldownHours": {
         "type": "select",
         "value": 24,
@@ -13991,6 +14108,23 @@
           true,
           false
         ]
+      },
+      "BuyActionPointMode": {
+        "type": "select",
+        "value": "off",
+        "option": [
+          "off",
+          "hazard1_leveling",
+          "meowfficer_farming"
+        ]
+      },
+      "BuyActionPointUpperThreshold": {
+        "type": "input",
+        "value": 200
+      },
+      "BuyActionPointLowerThreshold": {
+        "type": "input",
+        "value": 100
       }
     },
     "Storage": {
@@ -14399,8 +14533,7 @@
           "Belfast",
           "ChangFeng",
           "Mogador",
-          "RoyalFortune",
-          "DaVinci"
+          "RoyalFortune"
         ]
       },
       "Char2": {
@@ -14440,8 +14573,7 @@
           "Belfast",
           "ChangFeng",
           "Mogador",
-          "RoyalFortune",
-          "DaVinci"
+          "RoyalFortune"
         ]
       },
       "Product1": {
@@ -14577,8 +14709,7 @@
           "Belfast",
           "ChangFeng",
           "Mogador",
-          "RoyalFortune",
-          "DaVinci"
+          "RoyalFortune"
         ]
       },
       "Char2": {
@@ -14618,8 +14749,7 @@
           "Belfast",
           "ChangFeng",
           "Mogador",
-          "RoyalFortune",
-          "DaVinci"
+          "RoyalFortune"
         ]
       },
       "Product1": {
@@ -14767,8 +14897,7 @@
           "Belfast",
           "ChangFeng",
           "Mogador",
-          "RoyalFortune",
-          "DaVinci"
+          "RoyalFortune"
         ]
       },
       "Char2": {
@@ -14808,8 +14937,7 @@
           "Belfast",
           "ChangFeng",
           "Mogador",
-          "RoyalFortune",
-          "DaVinci"
+          "RoyalFortune"
         ]
       },
       "Product1": {
@@ -14915,8 +15043,7 @@
           "Belfast",
           "ChangFeng",
           "Mogador",
-          "RoyalFortune",
-          "DaVinci"
+          "RoyalFortune"
         ]
       },
       "Char2": {
@@ -14956,8 +15083,7 @@
           "Belfast",
           "ChangFeng",
           "Mogador",
-          "RoyalFortune",
-          "DaVinci"
+          "RoyalFortune"
         ]
       },
       "Product1": {
@@ -15068,8 +15194,7 @@
           "Belfast",
           "ChangFeng",
           "Mogador",
-          "RoyalFortune",
-          "DaVinci"
+          "RoyalFortune"
         ]
       },
       "Char2": {
@@ -15109,8 +15234,7 @@
           "Belfast",
           "ChangFeng",
           "Mogador",
-          "RoyalFortune",
-          "DaVinci"
+          "RoyalFortune"
         ]
       },
       "Product1": {

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -215,16 +215,34 @@ Optimization:
     option: [true, false]
   OcrModelVersionEnglish:
     value: auto
-    option: [auto, lite, standard, pro, alocr_en_v2_6]
+    option:
+      [
+        auto,
+        alocr_en_900k,
+        azur_lane_v6_6,
+        azur_lane_v6_5,
+        ppocr_v6,
+        alocr_en_v2_6,
+        alocr_en_v2_0,
+        alocr_en_v1_0,
+      ]
   OcrModelVersionChinese:
     value: auto
-    option: [auto, lite, standard, pro, alocr_cn_v3]
+    option:
+      [
+        auto,
+        cn_v6_1,
+        cn_v6,
+        ppocr_v6,
+        alocr_cn_v3,
+        alocr_cn_v2_5,
+      ]
   OcrModelVersionJapanese:
     value: auto
-    option: [auto, lite, standard, pro]
+    option: [auto, azur_lane_jp_v6, ppocr_v6]
   OcrModelVersionTraditionalChinese:
     value: auto
-    option: [auto, lite, standard, pro]
+    option: [auto, ppocr_v6]
   ScreenshotInterval: 0.3
   CombatScreenshotInterval: 1.0
   TaskHoardingDuration: 0
@@ -251,6 +269,9 @@ DropRecord:
     value: do_not
     option: [do_not, save]
   OpsiRecord:
+    value: upload
+    option: [do_not, save, upload, save_and_upload]
+  OpsiShopRecord:
     value: upload
     option: [do_not, save, upload, save_and_upload]
   MeowfficerBuy:
@@ -656,6 +677,9 @@ Commission:
     type: textarea
     value: ""
   DoMajorCommission: false
+  GemNotify:
+    type: checkbox
+    value: false
   CommissionNotifyReward:
     type: checkbox
     value: false
@@ -783,6 +807,17 @@ Reward:
   CollectExp: true
   CollectMission: true
   CollectWeeklyMission: false
+Secretary:
+  CustomFilter: |-
+    ultra > super_rare > elite > rare > common
+  LowFavorabilityPriority: false
+  BackupEnable: true
+  CheckInterval: 0
+  Notify: true
+  OnePushConfig:
+    type: textarea
+    mode: yaml
+    value: "provider: null"
 Awaken:
   LevelCap:
     value: level120
@@ -1152,6 +1187,10 @@ OpsiFleetAutoChange:
     type: checkbox
     value: false
     option: [true, false]
+  AnyShipReached:
+    type: checkbox
+    value: false
+    option: [true, false]
   CooldownHours:
     value: 24
     option: [12, 24, 48, 72]
@@ -1196,6 +1235,14 @@ OpsiScheduling:
   MonthEndShopPurchase:
     value: true
     option: [true, false]
+  # ===== 新增：买行动力双模式 =====
+  BuyActionPointMode:
+    value: "off"
+    option: ["off", hazard1_leveling, meowfficer_farming]
+  BuyActionPointUpperThreshold:
+    value: 200
+  BuyActionPointLowerThreshold:
+    value: 100
 OpsiPreventActionPointOverflow:
   Task:
     value: OpsiScheduling
@@ -1675,7 +1722,6 @@ _IslandBusinessChar: &IslandBusinessChar
     - ChangFeng
     - Mogador
     - RoyalFortune
-    - DaVinci
 
 _IslandBusinessProduct1: &IslandBusinessProduct1
   type: select

--- a/module/config/config_generated.py
+++ b/module/config/config_generated.py
@@ -92,7 +92,7 @@ class GeneratedConfig:
     # 配置组 `Emulator`
     Emulator_Serial = 'auto'
     Emulator_PackageName = 'auto'  # auto, com.bilibili.azurlane, com.YoStarEN.AzurLane, com.YoStarJP.AzurLane, com.hkmanjuu.azurlane.gp, com.bilibili.blhx.huawei, com.bilibili.blhx.honor, com.bilibili.blhx.mi, com.tencent.tmgp.bilibili.blhx, com.bilibili.blhx.baidu, com.bilibili.blhx.qihoo, com.bilibili.blhx.nearme.gamecenter, com.bilibili.blhx.vivo, com.bilibili.blhx.mz, com.bilibili.blhx.dl, com.bilibili.blhx.lenovo, com.bilibili.blhx.uc, com.bilibili.blhx.mzw, com.yiwu.blhx.yx15, com.bilibili.blhx.m4399, com.bilibili.blhx.bilibiliMove, com.hkmanjuu.azurlane.gp.mc
-    Emulator_ServerName = 'disabled'  # disabled, cn_android-0, cn_android-1, cn_android-2, cn_android-3, cn_android-4, cn_android-5, cn_android-6, cn_android-7, cn_android-8, cn_android-9, cn_android-10, cn_android-11, cn_android-12, cn_android-13, cn_android-14, cn_android-15, cn_android-16, cn_android-17, cn_android-18, cn_android-19, cn_android-20, cn_android-21, cn_android-22, cn_android-23, cn_android-24, cn_android-25, cn_android-26, cn_android-27, cn_android-28, cn_android-29, cn_ios-0, cn_ios-1, cn_ios-2, cn_ios-3, cn_ios-4, cn_ios-5, cn_ios-6, cn_ios-7, cn_ios-8, cn_ios-9, cn_ios-10, cn_channel-0, cn_channel-1, cn_channel-2, cn_channel-3, cn_channel-4, cn_channel-5, en-0, en-1, en-2, en-3, en-4, en-5, en-6, jp-0, jp-1, jp-2, jp-3, jp-4, jp-5, jp-6, jp-7, jp-8, jp-9, jp-10, jp-11, jp-12, jp-13, jp-14, jp-15, jp-16, jp-17, tw-0, tw-1, tw-2, tw-3, tw-4
+    Emulator_ServerName = 'disabled'  # disabled, cn_android-0, cn_android-1, cn_android-2, cn_android-3, cn_android-4, cn_android-5, cn_android-6, cn_android-7, cn_android-8, cn_android-9, cn_android-10, cn_android-11, cn_android-12, cn_android-13, cn_android-14, cn_android-15, cn_android-16, cn_android-17, cn_android-18, cn_android-19, cn_android-20, cn_android-21, cn_android-22, cn_android-23, cn_android-24, cn_android-25, cn_android-26, cn_android-27, cn_android-28, cn_android-29, cn_ios-0, cn_ios-1, cn_ios-2, cn_ios-3, cn_ios-4, cn_ios-5, cn_ios-6, cn_ios-7, cn_ios-8, cn_ios-9, cn_ios-10, cn_channel-0, cn_channel-1, cn_channel-2, cn_channel-3, cn_channel-4, cn_channel-5, en-0, en-1, en-2, en-3, en-4, en-5, jp-0, jp-1, jp-2, jp-3, jp-4, jp-5, jp-6, jp-7, jp-8, jp-9, jp-10, jp-11, jp-12, jp-13, jp-14, jp-15, jp-16, jp-17
     Emulator_ScreenshotMethod = 'auto'  # auto, ADB, ADB_nc, uiautomator2, aScreenCap, aScreenCap_nc, DroidCast, DroidCast_raw, nemu_ipc, ldopengl
     Emulator_ControlMethod = 'MaaTouch'  # ADB, uiautomator2, minitouch, Hermit, MaaTouch
     Emulator_GameSettings = False  # True, False
@@ -131,10 +131,10 @@ class GeneratedConfig:
     Optimization_OcrDevice = 'auto'  # auto, qnn_npu, openvino_npu, openvino_gpu, gpu, openvino_cpu, cpu, ane
     Optimization_OcrBackend = 'auto'  # auto, onnxruntime, ncnn
     Optimization_OcrWindowsMlVendorEp = True  # True, False
-    Optimization_OcrModelVersionEnglish = 'auto'  # auto, lite, standard, pro, alocr_en_v2_6
-    Optimization_OcrModelVersionChinese = 'auto'  # auto, lite, standard, pro, alocr_cn_v3
-    Optimization_OcrModelVersionJapanese = 'auto'  # auto, lite, standard, pro
-    Optimization_OcrModelVersionTraditionalChinese = 'auto'  # auto, lite, standard, pro
+    Optimization_OcrModelVersionEnglish = 'auto'  # auto, alocr_en_900k, azur_lane_v6_6, azur_lane_v6_5, ppocr_v6, alocr_en_v2_6, alocr_en_v2_0, alocr_en_v1_0
+    Optimization_OcrModelVersionChinese = 'auto'  # auto, cn_v6_1, cn_v6, ppocr_v6, alocr_cn_v3, alocr_cn_v2_5
+    Optimization_OcrModelVersionJapanese = 'auto'  # auto, azur_lane_jp_v6, ppocr_v6
+    Optimization_OcrModelVersionTraditionalChinese = 'auto'  # auto, ppocr_v6
     Optimization_ScreenshotInterval = 0.3
     Optimization_CombatScreenshotInterval = 1.0
     Optimization_TaskHoardingDuration = 0
@@ -149,6 +149,7 @@ class GeneratedConfig:
     DropRecord_CommissionRecord = 'do_not'  # do_not, save, upload, save_and_upload
     DropRecord_CombatRecord = 'do_not'  # do_not, save
     DropRecord_OpsiRecord = 'upload'  # do_not, save, upload, save_and_upload
+    DropRecord_OpsiShopRecord = 'upload'  # do_not, save, upload, save_and_upload
     DropRecord_MeowfficerBuy = 'do_not'  # do_not, save
     DropRecord_MeowfficerTalent = 'do_not'  # do_not, save, upload, save_and_upload
     DropRecord_TelemetryReport = True
@@ -353,6 +354,7 @@ class GeneratedConfig:
     Commission_CustomFilter = 'DailyEvent > Gem-4 > Gem-2 > Gem-8 > ExtraCube-0:30\n> UrgentCube-1:30 > UrgentCube-1:45 > UrgentCube-3\n> ExtraDrill-5:20 > ExtraDrill-2 > ExtraDrill-3:20\n> UrgentCube-2:15 > UrgentCube-4\n> ExtraDrill-1 > UrgentCube-6 > ExtraCube-1:30\n> ExtraDrill-2:40 > ExtraDrill-0:20\n> Major > DailyChip > DailyResource\n> ExtraPart-0:30 > ExtraOil-1 > UrgentBox-6\n> ExtraCube-3 > ExtraPart-1 > UrgentBox-3\n> ExtraCube-4 > ExtraPart-1:30 > ExtraOil-4\n> UrgentBox-1 > ExtraCube-5 > UrgentBox-1\n> ExtraCube-8 > ExtraOil-8\n> UrgentDrill-4 > UrgentDrill-2:40 > UrgentDrill-2\n> UrgentDrill-1 > UrgentDrill-1:30 > UrgentDrill-1:10\n> Extra-0:20 > Extra-0:30 > Extra-1:00 > Extra-1:30 > Extra-2:00\n> shortest'
     Commission_Blacklist = None
     Commission_DoMajorCommission = False
+    Commission_GemNotify = False
     Commission_CommissionNotifyReward = False
     Commission_CommissionNotifyRewardStatistics = True
 
@@ -425,6 +427,14 @@ class GeneratedConfig:
     Reward_CollectExp = True
     Reward_CollectMission = True
     Reward_CollectWeeklyMission = False
+
+    # 配置组 `Secretary`
+    Secretary_CustomFilter = 'ultra > super_rare > elite > rare > common'
+    Secretary_LowFavorabilityPriority = False
+    Secretary_BackupEnable = True
+    Secretary_CheckInterval = 0
+    Secretary_Notify = True
+    Secretary_OnePushConfig = 'provider: null'
 
     # 配置组 `Awaken`
     Awaken_LevelCap = 'level120'  # level120, level125
@@ -662,6 +672,7 @@ class GeneratedConfig:
 
     # 配置组 `OpsiFleetAutoChange`
     OpsiFleetAutoChange_Enable = False  # True, False
+    OpsiFleetAutoChange_AnyShipReached = False  # True, False
     OpsiFleetAutoChange_CooldownHours = 24  # 12, 24, 48, 72
     OpsiFleetAutoChange_LastRun = datetime.datetime(2020, 1, 1, 0, 0)
 
@@ -679,6 +690,9 @@ class GeneratedConfig:
     OpsiScheduling_MonthEndActionPointCleanupDays = 0
     OpsiScheduling_MonthEndActionPointPreserve = 0
     OpsiScheduling_MonthEndShopPurchase = True  # True, False
+    OpsiScheduling_BuyActionPointMode = 'off'  # off, hazard1_leveling, meowfficer_farming
+    OpsiScheduling_BuyActionPointUpperThreshold = 200
+    OpsiScheduling_BuyActionPointLowerThreshold = 100
 
     # 配置组 `OpsiPreventActionPointOverflow`
     OpsiPreventActionPointOverflow_Task = 'OpsiScheduling'  # OpsiScheduling, OpsiHazard1Leveling, OpsiMeowfficerFarming
@@ -913,8 +927,8 @@ class GeneratedConfig:
     IslandBusiness_SeasonalThreshold = 7
 
     # 配置组 `IslandBusinessShop1`
-    IslandBusinessShop1_Char1 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune, DaVinci
-    IslandBusinessShop1_Char2 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune, DaVinci
+    IslandBusinessShop1_Char1 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune
+    IslandBusinessShop1_Char2 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune
     IslandBusinessShop1_Product1 = 'None'  # None, double_bamboo_shoots, tofu_meat, tofu_combo, hearty_meal, fo_tiao, amaranth_rice_ball, matsutake_chicken_soup, persimmon_cake
     IslandBusinessShop1_Product2 = 'None'  # None, double_bamboo_shoots, tofu_meat, tofu_combo, hearty_meal, fo_tiao, amaranth_rice_ball, matsutake_chicken_soup, persimmon_cake
     IslandBusinessShop1_Product3 = 'None'  # None, double_bamboo_shoots, tofu_meat, tofu_combo, hearty_meal, fo_tiao, amaranth_rice_ball, matsutake_chicken_soup, persimmon_cake
@@ -924,8 +938,8 @@ class GeneratedConfig:
     IslandBusinessShop1_BoostReplaceFilter = '30 > 20 > 10'
 
     # 配置组 `IslandBusinessShop2`
-    IslandBusinessShop2_Char1 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune, DaVinci
-    IslandBusinessShop2_Char2 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune, DaVinci
+    IslandBusinessShop2_Char1 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune
+    IslandBusinessShop2_Char2 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune
     IslandBusinessShop2_Product1 = 'None'  # None, spring_flower_tea, strawberry_lemon, strawberry_honey, floral_fruity, fruit_paradise, lavender_tea, sunny_honey, watermelon_juice, chrysanthemum_tea, carrot_pear_juice
     IslandBusinessShop2_Product2 = 'None'  # None, spring_flower_tea, strawberry_lemon, strawberry_honey, floral_fruity, fruit_paradise, lavender_tea, sunny_honey, watermelon_juice, chrysanthemum_tea, carrot_pear_juice
     IslandBusinessShop2_Product3 = 'None'  # None, spring_flower_tea, strawberry_lemon, strawberry_honey, floral_fruity, fruit_paradise, lavender_tea, sunny_honey, watermelon_juice, chrysanthemum_tea, carrot_pear_juice
@@ -935,8 +949,8 @@ class GeneratedConfig:
     IslandBusinessShop2_BoostReplaceFilter = '30 > 20 > strawberry_honey > fruit_paradise > 10'
 
     # 配置组 `IslandBusinessShop3`
-    IslandBusinessShop3_Char1 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune, DaVinci
-    IslandBusinessShop3_Char2 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune, DaVinci
+    IslandBusinessShop3_Char1 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune
+    IslandBusinessShop3_Char2 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune
     IslandBusinessShop3_Product1 = 'None'  # None, orchard_duo, succulently_sweet, berry_orange, strawberry_charlotte, seafood_rice
     IslandBusinessShop3_Product2 = 'None'  # None, orchard_duo, succulently_sweet, berry_orange, strawberry_charlotte, seafood_rice
     IslandBusinessShop3_Product3 = 'None'  # None, orchard_duo, succulently_sweet, berry_orange, strawberry_charlotte, seafood_rice
@@ -945,8 +959,8 @@ class GeneratedConfig:
     IslandBusinessShop3_BoostReplaceFilter = '30 > 20 > succulently_sweet > 10'
 
     # 配置组 `IslandBusinessShop4`
-    IslandBusinessShop4_Char1 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune, DaVinci
-    IslandBusinessShop4_Char2 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune, DaVinci
+    IslandBusinessShop4_Char1 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune
+    IslandBusinessShop4_Char2 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune
     IslandBusinessShop4_Product1 = 'None'  # None, roasted_skewer, stir_fried_chicken, steak_bowl, crayfish_stir_fry, carnival, double_energy
     IslandBusinessShop4_Product2 = 'None'  # None, roasted_skewer, stir_fried_chicken, steak_bowl, crayfish_stir_fry, carnival, double_energy
     IslandBusinessShop4_Product3 = 'None'  # None, roasted_skewer, stir_fried_chicken, steak_bowl, crayfish_stir_fry, carnival, double_energy
@@ -955,8 +969,8 @@ class GeneratedConfig:
     IslandBusinessShop4_BoostReplaceFilter = '30 > 20 > 10'
 
     # 配置组 `IslandBusinessShop5`
-    IslandBusinessShop5_Char1 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune, DaVinci
-    IslandBusinessShop5_Char2 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune, DaVinci
+    IslandBusinessShop5_Char1 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune
+    IslandBusinessShop5_Char2 = 'None'  # None, WorkerJuu, Cheshire, YingSwei, Saratoga, Akashi, NewJersey, Tashkent, LeMalin, Shimakaze, Amagi_chan, Unicorn, ChaoHo, ChenHai, WilliamDPorter, Helena, Friedrich, Atago, Yixian, August, Eugen, Hood, Javelin, Laffey, Explorer, Navigator, OceanCrosser, FeiYun, Takao, Anchorage, Belfast, ChangFeng, Mogador, RoyalFortune
     IslandBusinessShop5_Product1 = 'None'  # None, cheese, citrus_coffee, strawberry_milkshake, morning_light, wake_up_call, fruity_fruitier
     IslandBusinessShop5_Product2 = 'None'  # None, cheese, citrus_coffee, strawberry_milkshake, morning_light, wake_up_call, fruity_fruitier
     IslandBusinessShop5_Product3 = 'None'  # None, cheese, citrus_coffee, strawberry_milkshake, morning_light, wake_up_call, fruity_fruitier

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -1,15 +1,15 @@
 {
   "Menu": {
     "Alas": {
-      "name": "Smart Port Plus",
+      "name": "Smart Port Area+",
       "help": ""
     },
     "Farm": {
-      "name": "Sortie Plus",
+      "name": "Sortie+",
       "help": ""
     },
     "Event": {
-      "name": "Event Plus",
+      "name": "Event+",
       "help": ""
     },
     "EventDaily": {
@@ -25,7 +25,7 @@
       "help": ""
     },
     "Opsi": {
-      "name": "Operation Siren Plus",
+      "name": "Operation Siren+",
       "help": ""
     },
     "Island": {
@@ -37,7 +37,7 @@
       "help": ""
     },
     "Tool": {
-      "name": "Tools Plus",
+      "name": "Tools+",
       "help": ""
     }
   },
@@ -55,23 +55,23 @@
       "help": ""
     },
     "Main": {
-      "name": "Main Campaign-1 Plus",
+      "name": "Main Campaign-1+",
       "help": ""
     },
     "Main2": {
-      "name": "Main Campaign-2 Plus",
+      "name": "Main Campaign-2+",
       "help": ""
     },
     "Main3": {
-      "name": "Main Campaign-3 Plus",
+      "name": "Main Campaign+",
       "help": ""
     },
     "GemsFarming": {
-      "name": "Urgent Commission Plus",
+      "name": "Urgent Commission+",
       "help": ""
     },
     "ThreeOilLowCost": {
-      "name": "3-Oil Low Cost Plus",
+      "name": "3-Oil Low Cost+",
       "help": "Use a 3-oil low-cost fleet to fight. Automatically replaces and retires the flagship when it reaches level 32."
     },
     "Ambush11": {
@@ -83,23 +83,23 @@
       "help": ""
     },
     "Event": {
-      "name": "Event Map-1 Plus",
+      "name": "Event Map-1+",
       "help": ""
     },
     "Event2": {
-      "name": "Event Map-2 Plus",
+      "name": "Event Map-2+",
       "help": ""
     },
     "Event3": {
-      "name": "Event Map-3 Plus",
+      "name": "Event Map-3+",
       "help": ""
     },
     "Raid": {
-      "name": "Raid Event Plus",
+      "name": "Raid Event+",
       "help": ""
     },
     "RaidScuttle": {
-      "name": "Raid Scuttle Plus",
+      "name": "Raid Scuttle+",
       "help": ""
     },
     "Hospital": {
@@ -111,8 +111,8 @@
       "help": ""
     },
     "CoalitionScuttle": {
-      "name": "Coalition Scuttle Plus",
-      "help": "Farm affinity by having ships sunk in Coalition events. Recommend sortie with multiple fleets; the first fleet sinks. Refer to tutorials for details."
+      "name": "Task.CoalitionScuttle.name",
+      "help": "Task.CoalitionScuttle.help"
     },
     "MaritimeEscort": {
       "name": "Trade Convoy Plus",
@@ -167,7 +167,7 @@
       "help": ""
     },
     "Dorm": {
-      "name": "Dorm Plus",
+      "name": "Backyard",
       "help": ""
     },
     "Meowfficer": {
@@ -186,6 +186,10 @@
       "name": "Cognitive Awakening",
       "help": ""
     },
+    "Secretary": {
+      "name": "Secretary",
+      "help": "Automatically monitor the secretary ship's affinity and replace it when it reaches 90 affinity"
+    },
     "Daily": {
       "name": "Daily Missions",
       "help": ""
@@ -199,7 +203,7 @@
       "help": ""
     },
     "ShopFrequent": {
-      "name": "Arms Dealer Plus",
+      "name": "Munitions Shop",
       "help": ""
     },
     "ShopOnce": {
@@ -211,7 +215,7 @@
       "help": ""
     },
     "Gacha": {
-      "name": "Daily Build Plus",
+      "name": "Daily Gacha",
       "help": ""
     },
     "Freebies": {
@@ -223,7 +227,7 @@
       "help": "Automatically collects game coins when they won't overflow. Automatically plays mini-games when there are game coins and rewards are not full."
     },
     "PrivateQuarters": {
-      "name": "Private Quarters Plus",
+      "name": "Dormitory Plan",
       "help": ""
     },
     "OpsiGeneral": {
@@ -239,11 +243,11 @@
       "help": ""
     },
     "OpsiExplore": {
-      "name": "Monthly Exploration Plus",
+      "name": "Monthly Exploration+",
       "help": ""
     },
     "OpsiShop": {
-      "name": "OpSi Shop Plus",
+      "name": "OpSi Shop+",
       "help": ""
     },
     "OpsiVoucher": {
@@ -251,7 +255,7 @@
       "help": ""
     },
     "OpsiDaily": {
-      "name": "OpSi Daily Plus",
+      "name": "OpSi - Daily+",
       "help": ""
     },
     "OpsiObscure": {
@@ -267,7 +271,7 @@
       "help": "Purchase archive coordinates from the Voucher Shop and run them. Archive zones do not consume action points.\nThe following conditions must be met before using this feature:\n- Clear the Operation Siren main story and complete Simulation + Siren Proving Grounds\n- Enable Operation Siren exploration missions or use Campaign Data Logger (5000 oil item)"
     },
     "OpsiStronghold": {
-      "name": "Siren Stronghold Plus",
+      "name": "Siren Fortress",
       "help": ""
     },
     "OpsiMonthBoss": {
@@ -275,15 +279,15 @@
       "help": ""
     },
     "OpsiMeowfficerFarming": {
-      "name": "Meowfficer Farming",
+      "name": "Meowfficer Farming+",
       "help": ""
     },
     "OpsiHazard1Leveling": {
-      "name": "Corrosion 1 Leveling",
+      "name": "Corrosion 1 Leveling+",
       "help": ""
     },
     "OpsiScheduling": {
-      "name": "Smart Scheduling Plus",
+      "name": "Smart Scheduling+",
       "help": "Operation Siren smart scheduling function, used to coordinate switching between Corrosion 1 leveling and gold coin replenishment tasks.\nOnce enabled, it will automatically switch between different tasks and send push notifications based on gold coins and action points."
     },
     "OpsiPreventActionPointOverflow": {
@@ -422,7 +426,7 @@
     },
     "Enable": {
       "name": "Enable this feature",
-      "help": "Add this task to the scheduler\nCommission, Research, and Reward tasks are always enabled",
+      "help": "Add this task to the scheduler\nCommissioning, scientific research, and harvest tasks are mandatory.",
       "True": "Enabled",
       "False": "Disabled"
     },
@@ -454,7 +458,7 @@
     },
     "Sensitive": {
       "name": "Sensitive task",
-      "help": "When an error occurs, prohibit restarting the game and stop AzurPilot immediately. Suitable for critical timing tasks like cross-month daily, Obscured Zones, Abyssal Zones, etc.",
+      "help": "When an error occurs, prohibit restarting the game and stop AzurPilot immediately. Suitable for critical tasks like cross-month daily, obscure sea areas, and abyssal sea areas.",
       "True": "Yes",
       "False": "No"
     }
@@ -489,7 +493,7 @@
       "help": "Common emulator Serial can be found in the list below\nFill in \"auto\" to automatically detect the emulator. \"auto\" cannot be used when multiple emulators are running or an emulator that does not support automatic detection is used and must be filled in manually.\n\nEmulator default Serial:\n- BlueStacks 127.0.0.1:5555\n- BlueStacks 4 Hyper-v version, fill in \"bluestacks4-hyperv\" to automatically connect, fill in \"bluestacks4-hyperv-2\" for more options, and so on.\n- BlueStacks 5 Hyper-v version, fill in \"bluestacks5-hyperv\" to automatically connect, fill in \"bluestacks5-hyperv-1\" for more options, and so on.\n- NoxPlayer 127.0.0.1:62001\n- NoxPlayer 64-bit 127.0.0.1:59865\n- MuMu Player/MuMu Player X 127.0.0.1:7555\n- MuMu Player 12 127.0.0.1:16384\n- MuMu Pro (macOS) 127.0.0.1:16384, the order of opening is 127.0.0.1:16416, 127.0.0.1:16448...\n- MEmu 127.0.0.1:21503\n- LDPlayer emulator-5554 or 127.0.0.1:5555\nIf you use the multi-instance function of the emulator, their Serial will not be the default. You can execute `adb devices` query in console.bat, or fill it in according to the official tutorial of the emulator."
     },
     "PackageName": {
-      "name": "Game Server",
+      "name": "game server",
       "help": "When multiple game clients are installed on the emulator, you need to manually select the server",
       "auto": "Automatic detection",
       "com.bilibili.azurlane": "National service",
@@ -571,7 +575,6 @@
       "en-3": "[EN] Washington",
       "en-4": "[EN] Amagi",
       "en-5": "[EN] Little Enterprise",
-      "en-6": "[EN] Belfast",
       "jp-0": "[JP] ブレスト",
       "jp-1": "[JP] 横須賀",
       "jp-2": "[JP] 佐世保",
@@ -589,15 +592,10 @@
       "jp-14": "[JP] キール",
       "jp-15": "[JP] 若松",
       "jp-16": "[JP] オデッサ",
-      "jp-17": "[JP] スイートバン",
-      "tw-0": "[TW] 珍珠港",
-      "tw-1": "[TW] 珊瑚海",
-      "tw-2": "[TW] 中途島",
-      "tw-3": "[TW] 瓜達康納爾",
-      "tw-4": "[TW] 雷伊泰灣"
+      "jp-17": "[JP] スイートバン"
     },
     "ScreenshotMethod": {
-      "name": "Select Screenshot Method",
+      "name": "Emulator Screenshot Method",
       "help": "When using auto-select, a performance test will be performed and automatically changed to the fastest screenshot method\nGeneral speed: DroidCast_raw >> aScreenCap_nc > ADB_nc >>> aScreenCap > uiautomator2 ~= ADB\nRun Tools - Performance Test to find the fastest method",
       "auto": "Auto-select fastest",
       "ADB": "ADB",
@@ -611,7 +609,7 @@
       "ldopengl": "ldopengl"
     },
     "ControlMethod": {
-      "name": "Select Control Method",
+      "name": "Emulator Control Method",
       "help": "Speed: minitouch > Hermit >>> uiautomator2 ~= ADB\nRecommended: minitouch. Not recommended: Hermit unless running under vmos.",
       "ADB": "ADB",
       "uiautomator2": "uiautomator2",
@@ -640,7 +638,7 @@
       "help": "The following values are automatically filled in based on Serial. If you do not understand, please do not modify it at will. Modifying the port will automatically start the corresponding instance."
     },
     "Emulator": {
-      "name": "Select Emulator Type",
+      "name": "Emulator type",
       "help": "",
       "auto": "Automatic detection",
       "NoxPlayer": "NoxPlayer",
@@ -715,15 +713,15 @@
     },
     "StrictRestart": {
       "name": "Prohibit restarting when errors occur in sensitive tasks",
-      "help": "When an error occurs, directly terminate AzurPilot without restarting the game. Use for debugging, commission tasks, research tasks, Obscured Zones, Abyssal Zones, and other critical timing tasks"
+      "help": "Stop AzurPilot when an error occurs while running sensitive tasks instead of restarting the game\nSensitive tasks include hidden sea areas, abyssal sea areas, and cross-month daily tasks."
     },
     "SaveErrorCount": {
-      "name": "Keep Up to X Error Logs",
+      "name": "Error Log storage upper limit",
       "help": "Error logs exceeding the upper limit will be deleted. If it is 0 or a negative value, there is no limit."
     },
     "OnePushConfig": {
-      "name": "Error Push Settings",
-      "help": "Notification will be sent via OnePush when an error occurs. Configure the OnePush provider for use, refer to https://github.com/y1ndan/onepush"
+      "name": "Wrong push settings",
+      "help": "After an unhandled exception occurs, use Onepush to push an error message. See the documentation for configuration methods: https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/Onepush-configuration-%5BCN%5D"
     },
     "ScreenshotLength": {
       "name": "On error, keep the last X screenshots",
@@ -734,7 +732,7 @@
       "help": "After the game freezes (triggers GameStuckError) for the specified number of times, try restarting the emulator. It may help solve problems such as emulator freeze or memory overflow."
     },
     "GameStuckThreshold": {
-      "name": "Restart When Game Stuck for X Seconds",
+      "name": "Game stuck restart threshold",
       "help": "How many consecutive times it is stuck before triggering a restart."
     },
     "AdbOfflineRestart": {
@@ -742,7 +740,7 @@
       "help": "After the device cannot be detected continuously (ADB is offline or the connection fails) for the specified number of times, try to restart the emulator."
     },
     "AdbOfflineThreshold": {
-      "name": "Restart When Device Unreachable for X Seconds",
+      "name": "Device restart threshold not detected",
       "help": "The number of times the device cannot be detected in a row triggers a restart."
     },
     "LlmAnalysis": {
@@ -794,37 +792,38 @@
     },
     "OcrModelVersionEnglish": {
       "name": "OCR English Model Version",
-      "help": "Choose the English OCR model tier. Lite is lightest and fastest, Standard is balanced, Pro is highest accuracy. Auto uses Standard. alocr_en_v2_6 is the legacy AlOCR English model (ONNX backend only). This affects the English Azur Lane model.",
+      "help": "Choose the English OCR model version. Auto uses the recommended English AlOCR v2.6 model. This affects the English Azur Lane model; ncnn ignores this setting.",
       "auto": "Auto Recommended",
-      "lite": "Lite",
-      "standard": "Standard",
-      "pro": "Pro",
-      "alocr_en_v2_6": "AlOCR v2.6 (Legacy)"
+      "alocr_en_900k": "alocr_en_900k",
+      "azur_lane_v6_6": "English v6.6 (Azur Lane)",
+      "azur_lane_v6_5": "English v6.5 (Azur Lane)",
+      "ppocr_v6": "Generic PP-OCRv6",
+      "alocr_en_v2_6": "English AlOCR v2.6",
+      "alocr_en_v2_0": "English AlOCR v2.0",
+      "alocr_en_v1_0": "English AlOCR v1.0"
     },
     "OcrModelVersionChinese": {
       "name": "OCR Chinese Model Version",
-      "help": "Choose the Simplified Chinese OCR model tier. Lite is lightest and fastest, Standard is balanced, Pro is highest accuracy. Auto uses Standard. alocr_cn_v3 is the legacy AlOCR Chinese model (ONNX backend only). This affects cnocr/Chinese models.",
+      "help": "Choose the Simplified Chinese OCR model version. Auto uses the recommended Chinese v6.1 model. This affects cnocr/Chinese models; ncnn ignores this setting.",
       "auto": "Auto Recommended",
-      "lite": "Lite",
-      "standard": "Standard",
-      "pro": "Pro",
-      "alocr_cn_v3": "AlOCR v3 (Legacy)"
+      "cn_v6_1": "Chinese v6.1",
+      "cn_v6": "Chinese v6",
+      "ppocr_v6": "Generic PP-OCRv6",
+      "alocr_cn_v3": "Chinese AlOCR v3",
+      "alocr_cn_v2_5": "Chinese AlOCR v2.5"
     },
     "OcrModelVersionJapanese": {
       "name": "OCR Japanese Model Version",
-      "help": "Choose the Japanese OCR model tier. Lite is lightest and fastest but does not support Japanese, Standard is balanced, Pro is highest accuracy. Auto uses Standard. This affects Japanese models.",
+      "help": "Choose the Japanese OCR model version. Auto uses the Japanese Azur Lane v6 model. This affects Japanese models; ncnn ignores this setting.",
       "auto": "Auto Recommended",
-      "lite": "Lite",
-      "standard": "Standard",
-      "pro": "Pro"
+      "azur_lane_jp_v6": "Japanese v6 (Azur Lane JP)",
+      "ppocr_v6": "Generic PP-OCRv6"
     },
     "OcrModelVersionTraditionalChinese": {
       "name": "OCR Traditional Chinese Model Version",
-      "help": "Choose the Traditional Chinese OCR model tier. Lite is lightest and fastest, Standard is balanced, Pro is highest accuracy. Auto uses Standard.",
+      "help": "Choose the Traditional Chinese OCR model version. Currently only the generic PP-OCRv6 model is available; this separate setting is kept for future models. ncnn ignores this setting.",
       "auto": "Auto Recommended",
-      "lite": "Lite",
-      "standard": "Standard",
-      "pro": "Pro"
+      "ppocr_v6": "Generic PP-OCRv6"
     },
     "ScreenshotInterval": {
       "name": "Slow Down Screenshot Speed to X Seconds per Frame",
@@ -901,6 +900,14 @@
       "upload": "Upload",
       "save_and_upload": "Save and Upload"
     },
+    "OpsiShopRecord": {
+      "name": "DropRecord.OpsiShopRecord.name",
+      "help": "DropRecord.OpsiShopRecord.help",
+      "do_not": "do_not",
+      "save": "save",
+      "upload": "upload",
+      "save_and_upload": "save_and_upload"
+    },
     "MeowfficerBuy": {
       "name": "Meowfficer Purchase Screenshot",
       "help": "",
@@ -916,11 +923,11 @@
       "save_and_upload": "Save and Upload"
     },
     "TelemetryReport": {
-      "name": "Telemetry Data Reporting",
+      "name": "Telemetry data reporting",
       "help": "After being enabled, CL1 statistics (anonymous data such as the number of battles and Akashi encounter probability) will be reported anonymously to the server on a regular basis. For details on ID generation, please see the source code. For statistical information https://alas.nanoda.work/"
     },
     "BugReport": {
-      "name": "Bug Log Reporting",
+      "name": "Bug log reporting",
       "help": "When enabled, bug logs will be anonymously reported to the server when an exception is encountered to help improve ID generation. See the source code for details."
     }
   },
@@ -930,7 +937,7 @@
       "help": "It will take effect after the scheduler is restarted."
     },
     "LogKeepCount": {
-      "name": "Log Retention Count",
+      "name": "Log retention quantity",
       "help": "Log expiration time (days)"
     },
     "LogBackUpMethod": {
@@ -955,7 +962,7 @@
       "help": ""
     },
     "RetireMode": {
-      "name": "Select Retirement Mode",
+      "name": "Retirement mode",
       "help": "If you choose to strengthen, you will fall back to one-click retirement when the strengthening materials are insufficient.",
       "one_click_retire": "Retire with one click",
       "enhance": "Enhance",
@@ -994,9 +1001,9 @@
     "FleetRecover": {
       "name": "Morale Recovery",
       "help": "",
-      "not_in_dormitory": "Not in Dorm (20/h)",
-      "dormitory_floor_1": "Dorm 1st Floor (40/h)",
-      "dormitory_floor_2": "Dorm 2nd Floor (50/h)"
+      "not_in_dormitory": "Not placed in the Backyard (20/h)",
+      "dormitory_floor_1": "Backyard First Floor (40/h)",
+      "dormitory_floor_2": "Backyard Second Floor (50/h)"
     },
     "FleetOath": {
       "name": "All members are married (+10/h)",
@@ -1031,28 +1038,28 @@
   },
   "Enhance": {
     "_info": {
-      "name": "Enhance Settings",
-      "help": "Only takes effect when \"Retirement Mode\" is set to \"Enhance\""
+      "name": "Harden settings",
+      "help": "Only takes effect when \"Retirement Mode\" is set to \"Hardened\""
     },
     "ShipToEnhance": {
-      "name": "Ships to Enhance",
+      "name": "Ships in need of reinforcement",
       "help": "",
-      "all": "Enhance All Ships",
-      "favourite": "Enhance Favorite Ships Only"
+      "all": "Strengthen all ships",
+      "favourite": "Only commonly used ships are strengthened"
     },
     "Filter": {
       "name": "Enhance filter string",
       "help": "Format: \"cv > bb > ...\",\nLeave blank to use the default enhancement method"
     },
     "CheckPerCategory": {
-      "name": "Check X Ships per Category",
-      "help": "Prioritizes checking whether enhancement materials are available"
+      "name": "Number of reinforcements per category",
+      "help": "How many ships can be enhanced at most for each ship category?\nShips in combat will be skipped and not counted,\nPrioritize whether there are strengthening materials"
     }
   },
   "OldRetire": {
     "_info": {
-      "name": "Traditional Retirement Settings",
-      "help": "Only takes effect when \"Retirement Mode\" is set to \"Traditional\"\nNote: Traditional retirement is based on rarity, and may retire Bulin"
+      "name": "Legacy Retirement Settings",
+      "help": "Only takes effect when \"Retirement Mode\" is set to \"Legacy Retirement\"\nNOTE: Traditional retirement based on character rarity, possible retirement of Bree"
     },
     "N": {
       "name": "Retire N (White)",
@@ -1071,7 +1078,7 @@
       "help": ""
     },
     "RetireAmount": {
-      "name": "Retire X Ships Each Time",
+      "name": "Retire Quantity",
       "help": "",
       "retire_all": "Retire All",
       "retire_10": "Retire 10"
@@ -1087,15 +1094,15 @@
       "help": "For example, 7-2, 12-4, D3, SP4, case-insensitive\nIf the level is missing, please wait for the update"
     },
     "Event": {
-      "name": "Event Name",
-      "help": "Automatically select the latest event",
-      "campaign_main": "Main Campaign",
+      "name": "Activity name",
+      "help": "Automatically select the latest activity",
+      "campaign_main": "main line diagram",
       "coalition_20230323": "Frostfall",
       "coalition_20240627": "Welcome to Little Academy",
       "coalition_20250626": "The Neon City Investigator",
       "coalition_20251120": "DATE A LANE",
       "coalition_20260122": "Light & Shadow Fashion Shoot!",
-      "coalition_20260723": "Authentic Horror Story",
+      "coalition_20260723": "怪谈纪实：逃离白夜山庄",
       "event_20200227_cn": "Northern Overture",
       "event_20200312_cn": "The Solomon Ranger Rerun",
       "event_20200326_cn": "Microlayer Medley",
@@ -1181,7 +1188,7 @@
       "event_20260417_cn": "Vacation Lane – Beachside Brilliance",
       "event_20260520_cn": "Alliance Before the Hagiobull",
       "event_20260625_cn": "Miracle by Midnight",
-      "event_20260813_cn": "Depths of the Astrarium",
+      "event_20260813_cn": "沉溺于星光之城",
       "raid_20200624": "Air Raid Drills with Essex Rerun",
       "raid_20210708": "Cross Wave rerun",
       "raid_20220127": "Mystery Investigation",
@@ -1243,7 +1250,7 @@
       "war_archives_20240725_cn": "archives Interlude of Illusions"
     },
     "Mode": {
-      "name": "Select Stage Mode",
+      "name": "Stage Mode",
       "help": "Only applies to main campaign",
       "normal": "Normal",
       "hard": "Hard"
@@ -1326,7 +1333,7 @@
       "help": ""
     },
     "DailyRunCount": {
-      "name": "Sortie X Times Daily",
+      "name": "Daily Sortie Count",
       "help": "Maximum War Archives runs per day.\n0 means no limit.\nAfter reaching the limit, the task is delayed until the next server reset instead of being disabled."
     },
     "DailyRunCountRemain": {
@@ -1348,7 +1355,7 @@
       "help": ""
     },
     "Fleet1": {
-      "name": "Fleet 1 Uses Fleet Number X",
+      "name": "Fleet 1 Number",
       "help": "",
       "1": "1 ",
       "2": "2 ",
@@ -1365,7 +1372,7 @@
       "diamond": "Diamond"
     },
     "Fleet1Mode": {
-      "name": "Fleet 1 Auto Battle Mode",
+      "name": "Fleet 1 Auto Mode",
       "help": "",
       "combat_auto": "Auto Battle",
       "combat_manual": "Manual",
@@ -1382,7 +1389,7 @@
       "5": "5 "
     },
     "Fleet2": {
-      "name": "Fleet 2 Uses Fleet Number X",
+      "name": "Fleet 2 Number",
       "help": "",
       "0": "Not used",
       "1": "1 ",
@@ -1400,7 +1407,7 @@
       "diamond": "Diamond"
     },
     "Fleet2Mode": {
-      "name": "Fleet 2 Auto Battle Mode",
+      "name": "Fleet 2 Auto Mode",
       "help": "",
       "combat_auto": "Auto Battle",
       "combat_manual": "Manual",
@@ -1426,7 +1433,7 @@
     },
     "SkipPreparation": {
       "name": "Skip Fleet Preparation",
-      "help": "When enabled, skips the fleet selection step in the preparation screen and directly uses the currently pre-selected fleet for sortie\nSuitable for accounts with unlocked fleet slots, to avoid dropdown detection getting stuck\nBefore enabling, make sure Fleet 1 and Fleet 2 are manually selected in-game"
+      "help": "Skip the fleet selection step in the fleet preparation screen and use the game's current pre-selected fleet.\nUseful for accounts that have not unlocked all fleet slots, avoiding dropdown menu detection freeze.\nMake sure you have manually selected Fleet 1 and Fleet 2 in-game before enabling."
     }
   },
   "Submarine": {
@@ -1435,14 +1442,14 @@
       "help": ""
     },
     "Fleet": {
-      "name": "Use Submarine Fleet X",
+      "name": "Submarine Fleet Number",
       "help": "",
       "0": "Not used",
       "1": "1 ",
       "2": "2 "
     },
     "Mode": {
-      "name": "Select Submarine Sortie Plan",
+      "name": "Submarine Attack Mode",
       "help": "Only takes effect when auto-search is off. Note: 'Hunt and Boss' combines 'Hunt Only' and 'Boss Only' - submarines will hunt during mob battles and be summoned during boss battles.",
       "do_not_use": "Not Used",
       "hunt_only": "Hunt Only",
@@ -1451,7 +1458,7 @@
       "every_combat": "Every Combat"
     },
     "AutoSearchMode": {
-      "name": "Select Submarine Auto Plan",
+      "name": "Submarine Auto-Search Mode",
       "help": "Only takes effect when using auto-search",
       "sub_standby": "Standby",
       "sub_auto_call": "Auto-Summon Submarine"
@@ -1496,9 +1503,9 @@
     "Fleet1Recover": {
       "name": "Fleet 1 Morale Recovery",
       "help": "",
-      "not_in_dormitory": "Not in Dorm (20/h)",
-      "dormitory_floor_1": "Dorm 1st Floor (40/h)",
-      "dormitory_floor_2": "Dorm 2nd Floor (50/h)"
+      "not_in_dormitory": "Not in Backyard (20/h)",
+      "dormitory_floor_1": "Backyard 1st Floor (40/h)",
+      "dormitory_floor_2": "Backyard 2nd Floor (50/h)"
     },
     "Fleet1Oath": {
       "name": "All Fleet 1 Members Oathed (+10/h)",
@@ -1527,9 +1534,9 @@
     "Fleet2Recover": {
       "name": "Fleet 2 Morale Recovery",
       "help": "",
-      "not_in_dormitory": "Not in Dorm (20/h)",
-      "dormitory_floor_1": "Dorm 1st Floor (40/h)",
-      "dormitory_floor_2": "Dorm 2nd Floor (50/h)"
+      "not_in_dormitory": "Not in Backyard (20/h)",
+      "dormitory_floor_1": "Backyard 1st Floor (40/h)",
+      "dormitory_floor_2": "Backyard 2nd Floor (50/h)"
     },
     "Fleet2Oath": {
       "name": "All Fleet 2 Members Oathed (+10/h)",
@@ -1656,11 +1663,11 @@
   "GemsFarming": {
     "_info": {
       "name": "Urgent Commission Farming",
-      "help": "Warning: This feature allows players to earn a small amount of Gems, but it is not an efficient way to farm Gems\nNew Azur Lane players often overvalue limit break avoidance and low oil cost, while neglecting ship development\nRunning this feature only makes you feel productive, while your account actually makes zero progress\nPlease press the return button"
+      "help": "Warning: This feature allows players to obtain a small amount of diamonds, but is not an efficient way to obtain diamonds.\nPlayers who have been playing Azur Lane for a short time can easily become superstitious about zero breakage and low consumption, while neglecting character development.\nRunning this function will only make you feel very fulfilled, but your account will actually have zero improvement.\nThe main purpose of this function is to allow players with a formed lineup to obtain additional Rubik's Cubes. Please treat diamonds rationally as a by-product.\n\nThis feature will replace the flagship after flagship level 32\nRegarding the emergency commission refresh mechanism, you can read https://bbs.nga.cn/read.php?tid=27134956\nCommissioned fuel consumption ratio: A3 > A1 > 2-4 > 2-1. It is recommended to choose the activity diagram when there is an activity diagram. 2-1 will pick the question mark to have more supplies.\nOne team will complete all battles. The front row should be level 100 zero-break destroyer with output equipment, and the back row should be level 33 and below white-skin zero-break aircraft carriers.\nThe second team should provide cross-team support (cross-team barrage, cross-team assistance)\n\nWhen the fleet function cannot be set, the mission should be stopped in the following ways to avoid cross-team attacks and a large amount of oil being consumed:\nIf error push is set, a task stop message will be pushed and the task will be stopped.\nIf error push is not set, AzurPilot will be stopped directly."
     },
     "ChangeFlagship": {
       "name": "Change Flagship",
-      "help": "White-rarity light carriers and white-rarity carriers will be treated as retirement targets\nOnly 0 limit break, no equipment, white-rarity light carriers will be used as replacement\nControls: When to replace the flagship",
+      "help": "Change flagship when flagship level >= 32 or red face\nLook for white-skinned aircraft carriers with levels between 1-31, and choose replacement flagships when they retire. All white-skinned aircraft carriers with levels greater than level 1 will be considered decommissioned targets. Please be sure to target ships that are not targets. Change flagship equipment when changing ships, this is done by recording the previous equipment.\n\nChanging equipment will only change the slot in the equipment, even white equipment will be changed. If a flagship is specified, all 5 equipment will be replaced. If a flagship is not specified, only the equipment will be replaced.",
       "ship": "Change ship",
       "ship_equip": "Change ships + equipment"
     },
@@ -1677,12 +1684,12 @@
     },
     "CommonCVFilter": {
       "name": "Custom Flagship Carrier Filter",
-      "help": "Filter usable light carriers, syntax same as common CV filter\nSeparated by spaces, case-insensitive\nExample: bogue: Bogue, ranger: Ranger, langley: Langley, hermes: Hermes"
+      "help": "To use a custom filter, you need to set \"Specify Flagship Carrier\" to \"Custom\", and the flagship carrier will be selected first for replacement according to the order of the filter.\nbogue: Borg ranger: raider langley: Langley hermes: athletic god"
     },
     "ChangeVanguard": {
       "name": "Change Vanguard",
-      "help": "Replace vanguard with low-oil-cost ships from Eagle Union or Iron Blood\nOnly 0 limit break, no equipment, white-rarity destroyers will be used as replacement\nControls: When to replace the vanguard",
-      "disabled": "Do Not Change",
+      "help": "Change the front row when the front row is red. If you choose not to change, the red face will be forced to attack.\nTo change the front row, you need to find a white eagle or iron-blooded white-skin ship with a mood of no less than 10 and a level of 100 to drive away, so try to ensure that there are enough to drive away. Outside the national server, it is the level 70 White Eagle White Ship Expulsion.",
+      "disabled": "Do not replace",
       "ship": "Change ship",
       "ship_equip": "Change ships + equipment"
     },
@@ -1699,30 +1706,30 @@
     },
     "CommonDDFilter": {
       "name": "Custom front row filter",
-      "help": "Filter usable low-oil-cost vanguard ships\nSeparate by spaces\nfoote: Foote, cassin: Cassin, downes: Downes"
+      "help": "To use a custom filter, you need to set \"Specify Front Row\" to \"Custom\", and the front row will be replaced first according to the filter order.\nz20：Z20 z21：Z21 aulick：Aulick foote：Foot cassin：Cassin downes：Downs"
     },
     "EquipmentCode": {
       "name": "Equipment code",
-      "help": "Default equipment code for light carriers\nSeparate by spaces\nbogue: Bogue, hermes: Hermes, langley: Langley, ranger: Ranger"
+      "help": "Only takes effect when \"Change Ship + Equipment\" is selected.\nWhen changing a ship, if the current ship equipment code in the settings is null, it will be exported; when changing a ship, if the current ship equipment code in the settings is null, the equipment code exported from the previous ship will be used, otherwise the equipment code in the settings will be used.\nBlueStacks emulator users need to enable the virtual keyboard first. For details, see https://support.bluestacks.com/hc/zh-tw/articles/360061968892-%E5%A6%82%E4%BD%95%E5%9C% A8-BlueStacks-5-%E4%B8%8A%E4%BD%BF%E7%94%A8%E5%B0%8F%E9%8D%B5%E7%9B%A4-%E8%99%9B%E6%93%AC%E9%8D%B5%E7%9B%A4\nDD: front row expulsion bogue: Borg hermes: athletic god langley: Langley ranger: raider"
     },
     "UseEmotionFirst": {
-      "name": "Prioritize Morale",
+      "name": "Prioritize Mood",
       "help": "When replacing ships, prioritize the highest mood ships."
     },
     "IgnoreEmotionWarning": {
-      "name": "Ignore Low Morale Warning",
+      "name": "Ignore Mood Warning Popup",
       "help": "Force through the mood warning popup when it appears."
     },
     "AllowHighFlagshipLevel": {
-      "name": "Only Replace Max-Level Back Row",
-      "help": "When the flagship has a replacement and its level is higher than the vanguard\nUse white-rarity light carriers in the back row to consume oil and earn experience\nIf the back row has other ships, this function will not be used\nPlease manually add ships that need leveling"
+      "name": "Only replace the full-level rear row",
+      "help": "After opening, only level 100 white-skin light aircraft will be selected when changing flagships.\nPlease make sure there are qualified ships in the dock when using it."
     },
     "AllowLowVanguardLevel": {
-      "name": "Allow Low-Level Vanguard Replacement",
+      "name": "Replaceable low-level front row",
       "help": "After opening, the front row level limit is changed to level 30 or above. If it is difficult mode (such as the CD picture), it will be changed to level 70."
     },
     "DelayTaskIFNoFlagship": {
-      "name": "Delay Task When No Replacement Flagship Available",
+      "name": "Postpone mission when there is no replacement flagship",
       "help": "When changing the flagship, if a white aircraft carrier that meets the conditions cannot be found, the mission will be postponed."
     },
     "CommissionLimit": {
@@ -1752,7 +1759,7 @@
       "help": ""
     },
     "PtLimit": {
-      "name": "Stop When Event PT Reaches X",
+      "name": "Event PT Limit",
       "help": "When accumulated PT reaches the given value, all event tasks are disabled. 0 means no limit. Cannot trigger immediately when using auto-search.\nAfter enabling, you only need to open all event tasks without counting total runs."
     },
     "TimeLimit": {
@@ -1790,7 +1797,7 @@
     },
     "StageFilter": {
       "name": "Event Daily Filter",
-      "help": "Sortie in filter order"
+      "help": "Sort by filter"
     },
     "LastStage": {
       "name": "Last Completed Stage",
@@ -1805,33 +1812,33 @@
     "Mode": {
       "name": "Difficulty",
       "help": "",
-      "easy": "Easy",
+      "easy": "Simple",
       "normal": "Normal",
       "hard": "Hard",
       "ex": "EX"
     },
     "UseTicket": {
-      "name": "Use Exercise Tickets",
+      "name": "Use practice tickets",
       "help": ""
     }
   },
   "RaidScuttle": {
     "_info": {
-      "name": "Raid Scuttle",
-      "help": "Raid event scuttle settings. Select the position of ships to be sunk."
+      "name": "Fight together and sink the ship",
+      "help": ""
     },
     "Sacrifice": {
       "name": "Sacrifice ship position",
       "help": "",
-      "vanguard": "Vanguard",
+      "vanguard": "front row",
       "flagship": "flagship",
-      "vanguard_flagship": "Vanguard + Flagship"
+      "vanguard_flagship": "Front row + flagship"
     }
   },
   "RaidDaily": {
     "_info": {
-      "name": "Raid Daily",
-      "help": "Complete daily Raid on Easy, Normal, and Hard difficulties"
+      "name": "Fighting together every day",
+      "help": "Complete daily battles on easy and normal difficulty"
     },
     "StageFilter": {
       "name": "Difficulty filter",
@@ -1840,7 +1847,7 @@
   },
   "Hospital": {
     "_info": {
-      "name": "Event Settings",
+      "name": "Activity settings",
       "help": ""
     },
     "UseRecommendFleet": {
@@ -1850,15 +1857,15 @@
   },
   "HospitalEvent": {
     "_info": {
-      "name": "Hospital Event Settings",
+      "name": "Co-fighting activity settings",
       "help": ""
     },
     "Mode": {
       "name": "Difficulty",
       "help": "",
-      "easy": "Noon",
-      "normal": "Dusk",
-      "hard": "Night"
+      "easy": "Easy",
+      "normal": "Normal",
+      "hard": "Hard"
     },
     "Stage": {
       "name": "Level name",
@@ -1882,7 +1889,7 @@
   },
   "Coalition": {
     "_info": {
-      "name": "Coalition Settings",
+      "name": "Activity settings",
       "help": "Teams must be manually allocated in the game before going out."
     },
     "Mode": {
@@ -1895,7 +1902,7 @@
       "ex": "EX"
     },
     "Fleet": {
-      "name": "Sortie Fleet",
+      "name": "attack team",
       "help": "",
       "single": "Single team battle",
       "multi": "Multiple teams attack"
@@ -1903,15 +1910,15 @@
   },
   "CoalitionScuttle": {
     "_info": {
-      "name": "Coalition Scuttle",
-      "help": "Coalition event scuttle settings. Select the position of ships to be sunk."
+      "name": "CoalitionScuttle._info.name",
+      "help": "CoalitionScuttle._info.help"
     },
     "Sacrifice": {
-      "name": "Sacrificial Ship Position",
-      "help": "Select the position of ships to be sunk: Vanguard, Flagship, or Vanguard + Flagship",
-      "vanguard": "Vanguard",
-      "flagship": "Flagship",
-      "vanguard_flagship": "Vanguard + Flagship"
+      "name": "CoalitionScuttle.Sacrifice.name",
+      "help": "CoalitionScuttle.Sacrifice.help",
+      "vanguard": "vanguard",
+      "flagship": "flagship",
+      "vanguard_flagship": "vanguard_flagship"
     }
   },
   "EventShop": {
@@ -1947,13 +1954,13 @@
       "help": ""
     },
     "PresetFilter": {
-      "name": "Commission Filter",
-      "help": "Select a preset commission filter or enter a custom filter",
+      "name": "delegate filter",
+      "help": "If you do not have enough understanding of the output and benefits of the commission, it is not recommended to write a custom filter. It is recommended to use a pre-optimized commission filter.\nIf you run the brush emergency commission function 24 hours a day, you should use the filter (7x24 brush commission).\nIt is not recommended to use the oil priority filter while running the emergency commission function.",
       "cube": "Diamond>Cubes>Oil",
-      "cube_24h": "Diamond > Cubes > Oil (7x24 Commission Farming)",
-      "chip": "Diamond > Cognitive Chips > Cubes",
-      "chip_24h": "Diamond > Cognitive Chips > Cubes (7x24 Commission Farming)",
-      "oil": "Diamond > Oil > Cubes",
+      "cube_24h": "Diamond > Cubes > Oil (7x24 brush commission)",
+      "chip": "Diamond>Mind>Cubes",
+      "chip_24h": "Diamond > Mind > Cubes (7x24 brush commission)",
+      "oil": "Diamond>Oil>Cubes",
       "custom": "Customize"
     },
     "DynamicProgramming": {
@@ -1989,16 +1996,20 @@
       "help": "Enter commission filter rules to ignore, separated by half-width commas (,), for example: ExtraBook, UrgentOil-8, Major. The blacklist applies to both the traditional greedy strategy and the planner."
     },
     "DoMajorCommission": {
-      "name": "Run Major Commissions (1200/1000 Oil)",
+      "name": "Make the main commission (1200 oil/1000 oil commission)",
       "help": "The 1200 oil commission is now obsolete and the yield is very low. It is recommended to close it."
     },
+    "GemNotify": {
+      "name": "Gem Commission Execution Notification",
+      "help": "Send the current running Gem Commission list after a new Gem Commission starts"
+    },
     "CommissionNotifyReward": {
-      "name": "Commission Reward Push Notification",
-      "help": "Push notification when receiving commission rewards (especially for gems)"
+      "name": "Successful Commission Gem Notification",
+      "help": "Note: Please enable and configure Error Notification Settings; otherwise, this feature will not take effect."
     },
     "CommissionNotifyRewardStatistics": {
-      "name": "Include Statistics in Push",
-      "help": "Display today/week/month cumulative gem count in notification"
+      "name": "Gem Notification Details",
+      "help": "After enabling, AzurPilot will notify the number of diamonds obtained from the current commission, as well as the total diamonds obtained for the day/week/month."
     }
   },
   "Tactical": {
@@ -2028,33 +2039,33 @@
   },
   "ControlExpOverflow": {
     "_info": {
-      "name": "Overflow EXP Control",
+      "name": "Overflow experience control",
       "help": "Prevent the use of advanced skill books from overflowing a large amount of experience when skills are almost at full level.\nFor example, if the T3 book overflows by 100 points and the T4 book overflows by 100 points, when there are 1100 experience points left, the T4 book will not be used and the T3 book will be used instead."
     },
     "Enable": {
-      "name": "Enable Overflow EXP Control",
+      "name": "Enable overflow experience control",
       "help": ""
     },
     "T4Allow": {
-      "name": "Allow T4 Skill Book to Overflow X EXP",
+      "name": "Allow T4 skill book to overflow X experience points",
       "help": ""
     },
     "T3Allow": {
-      "name": "Allow T3 Skill Book to Overflow X EXP",
+      "name": "Allow T3 skill book to overflow X experience points",
       "help": ""
     },
     "T2Allow": {
-      "name": "Allow T2 Skill Book to Overflow X EXP",
+      "name": "Allow T2 skill book to overflow X experience points",
       "help": ""
     },
     "T1Allow": {
-      "name": "Allow T1 Skill Book to Overflow X EXP",
+      "name": "Allow T1 skill book to overflow X experience points",
       "help": ""
     }
   },
   "AddNewStudent": {
     "_info": {
-      "name": "Learn New Skills",
+      "name": "learn new skills",
       "help": "When there is a vacant position in the Tactics Academy, a ship girl will be automatically assigned and will learn the first skill that is not yet full level."
     },
     "Enable": {
@@ -2066,7 +2077,7 @@
       "help": "During student selection apply the favorite filter\nThereby, giving priority to certain ship girls\nApply the favorite status to a ship girl in-game"
     },
     "MinLevel": {
-      "name": "Only Add Characters Level >= X",
+      "name": "Add Students with Level >= X Only",
       "help": ""
     }
   },
@@ -2148,7 +2159,7 @@
   },
   "Dorm": {
     "_info": {
-      "name": "Dorm",
+      "name": "Backyard",
       "help": ""
     },
     "Collect": {
@@ -2171,7 +2182,7 @@
   "BuyFurniture": {
     "_info": {
       "name": "Event furniture setup",
-      "help": "Purchase limited-time furniture from the Dorm furniture shop during events"
+      "help": "Purchase limited-time furniture from the Backyard Furniture Shop during events"
     },
     "Enable": {
       "name": "Buy event furniture",
@@ -2194,7 +2205,7 @@
       "help": ""
     },
     "BuyAmount": {
-      "name": "Buy X Meowfficer Boxes Daily",
+      "name": "Buy X cat boxes every day",
       "help": "The first cat box of the day is free"
     },
     "FortChoreMeowfficer": {
@@ -2212,7 +2223,7 @@
       "help": ""
     },
     "Mode": {
-      "name": "Select Training Mode",
+      "name": "Training mode",
       "help": "Seamless Meowfficer Training will collect Meowfficers every 2.5 ~ 3.5 hours.\nCollect one per day means collect one every day, collect all on Sunday, enhance and refill the queue to complete weekly missions",
       "seamlessly": "Seamless training",
       "once_a_day": "Collect one per day"
@@ -2308,6 +2319,36 @@
       "help": ""
     }
   },
+  "Secretary": {
+    "_info": {
+      "name": "Secretary Settings",
+      "help": "Configure automatic secretary replacement and notification settings"
+    },
+    "CustomFilter": {
+      "name": "Rarity Filter",
+      "help": "Rarities include ultra, super_rare, elite, rare, and common\nPlease enter the custom order below\nDefault priority: ultra > super_rare > elite > rare > common"
+    },
+    "LowFavorabilityPriority": {
+      "name": "Low Favorability Priority",
+      "help": "Ships will be selected in ascending order of favorability"
+    },
+    "BackupEnable": {
+      "name": "Backup Secretary",
+      "help": "Use ships in the secretary group as backup secretaries and prioritize switching to them"
+    },
+    "CheckInterval": {
+      "name": "Custom Check Interval (Hours)",
+      "help": "Check after the specified interval following a secretary switch. Set to 0 to calculate automatically based on affinity. If your secretary gains affinity through sorties, setting this value allows earlier replacement"
+    },
+    "Notify": {
+      "name": "Secretary Notifications",
+      "help": "Send secretary-related notifications via OnePush"
+    },
+    "OnePushConfig": {
+      "name": "OnePush Configuration",
+      "help": "Notification settings for secretary replacement. Leave empty to use the global configuration"
+    }
+  },
   "Awaken": {
     "_info": {
       "name": "Cognitive Awakening",
@@ -2326,7 +2367,7 @@
   },
   "GeneralShop": {
     "_info": {
-      "name": "Arms Dealer (General Shop)",
+      "name": "General Shop",
       "help": ""
     },
     "Enable": {
@@ -2339,15 +2380,15 @@
     },
     "Refresh": {
       "name": "Refresh store",
-      "help": "Refreshing costs 50 Gems"
+      "help": "Refreshing requires 50 diamonds"
     },
     "BuySkinBox": {
-      "name": "Buy Skins Equipment Box",
+      "name": "Buy appearance equipment box",
       "help": "To reduce maintenance costs, the appearance box selector in the filter will not be updated with the game, but AzurPilot will treat any unknown item with a quantity of 1 and consuming 7000 supplies as an appearance box and purchase it."
     },
     "ConsumeCoins": {
-      "name": "Spend Overflowing Coins",
-      "help": "When coins exceed the limit, auto-purchase items from the Arms Dealer. Stops when coins drop below the limit"
+      "name": "Consumption of overflow supplies",
+      "help": "When supplies exceed the threshold, purchase all items that consume supplies. 0 means disabled. Range: 1-600000"
     },
     "OverflowCoins": {
       "name": "Buy Meowfficer Boxes on Coin Overflow",
@@ -2551,7 +2592,7 @@
     },
     "Refresh": {
       "name": "Refresh Shop",
-      "help": "Refreshing costs 20 Gems"
+      "help": "Refreshing costs 20 gems"
     },
     "Filter": {
       "name": "Shop Filter",
@@ -2587,7 +2628,7 @@
       "6": "PR6"
     },
     "ShipIndex": {
-      "name": "Select Research Ship X",
+      "name": "Ship index",
       "help": "Counting from left to right, starting from 1",
       "0": "Don't buy",
       "1": "1",
@@ -2622,7 +2663,7 @@
       "6": "PR6"
     },
     "ShipIndex": {
-      "name": "Select Research Ship X",
+      "name": "Ship index",
       "help": "Counting from left to right, starting from 1",
       "0": "Don't buy",
       "1": "1",
@@ -2643,8 +2684,8 @@
   },
   "Gacha": {
     "_info": {
-      "name": "Daily Build",
-      "help": "Build ships to complete daily missions. Building once in the Light Build Pool daily saves 200 Coins."
+      "name": "Daily Construction",
+      "help": "Build ships to complete daily missions. Building once in the Light pool daily saves 200 Coins."
     },
     "Pool": {
       "name": "Build Pool",
@@ -2656,7 +2697,7 @@
       "wishing_well": "Wishing Well"
     },
     "Amount": {
-      "name": "Build X Times Daily",
+      "name": "Number of builds",
       "help": "",
       "1": "1",
       "2": "2",
@@ -2670,12 +2711,12 @@
       "10": "10"
     },
     "UseTicket": {
-      "name": "Use Single Build Permit",
+      "name": "Use single build permit",
       "help": "When enabled, pools that support build permits will use them first. When no permits are available or building in a standard pool, Cubes will be used instead."
     },
     "UseDrill": {
-      "name": "Use Quick Finisher to Complete Build",
-      "help": "If set to No, will wait until tomorrow to launch. Use this to save Quick Finishers"
+      "name": "Use Quick Finisher to complete construction",
+      "help": "If set to No, ships will be launched tomorrow instead, saving one Quick Finisher."
     }
   },
   "BattlePass": {
@@ -2757,7 +2798,7 @@
   },
   "PrivateQuarters": {
     "_info": {
-      "name": "Private Quarters Settings",
+      "name": "Dorm settings",
       "help": ""
     },
     "BuyRoses": {
@@ -2972,7 +3013,7 @@
       "help": "Recommended 1.0 ~ 3.0, because the character portrait may cover the HP bar, so a brief confirmation period is needed."
     },
     "OpponentRefreshValue": {
-      "name": "Opponents Refreshed X Times Today",
+      "name": "Exercise opponents refreshed X times today",
       "help": "Automatically updated value, resets at midnight.\nIf you manually refresh opponents, you should update this value."
     },
     "OpponentRefreshRecord": {
@@ -3004,7 +3045,7 @@
       "help": "Beacon assist three times a day"
     },
     "Tier": {
-      "name": "Find Beacons with Level Above X",
+      "name": "Find beacons with level greater than X",
       "help": "If you try several times and still can't find a beacon that meets the criteria, fight a random one."
     }
   },
@@ -3018,7 +3059,7 @@
       "help": "Every time you enter the storage, use all Coordinate Loggers"
     },
     "BuyActionPointLimit": {
-      "name": "Buy Action Points X Times",
+      "name": "Buy Action Points X times",
       "help": "Maximum number of times to buy Action Points",
       "0": "Don't buy",
       "1": "1 time (1000 Oil, 100 AP)",
@@ -3045,7 +3086,7 @@
     },
     "RepairPackThresholdHazard1": {
       "name": "Use Repair Toolkit when any ship HP is below X (Corrosion 1)",
-      "help": "Only takes effect when \"Use Repair Toolkit to repair ships\" is enabled.\nOnly attempts repair during Corrosion 1 Leveling Plus.\n0.0 ~ 1.0"
+      "help": "Only takes effect when \"Use Repair Toolkit to repair ships\" is enabled.\nOnly attempts repair during Corrosion 1 Leveling+.\n0.0 ~ 1.0"
     },
     "DoRandomMapEvent": {
       "name": "Complete random map events",
@@ -3064,12 +3105,12 @@
       "help": "Send Operation Siren notifications to the launcher and Windows notification channel. Disabling this only affects launcher notifications and does not affect OnePush."
     },
     "IndependentPush": {
-      "name": "Independent Operation Siren Push",
-      "help": "When enabled, Operation Siren notifications will be pushed via the Operation Siren push provider below\nWhen disabled, notifications will be pushed via the Error provider\nBefore enabling, please enable push notifications for individual events, such as: Corrosion 1, Meowfficer Farming, etc."
+      "name": "Independent push of Siren Operation information",
+      "help": "The \"Push Siren Operation Related Information\" function needs to be enabled simultaneously.\nTo disable it, navigate to Smart Port Settings > Debug Settings > Error Push Settings, and the \"Error Push\" function needs to be enabled simultaneously.\nTo enable it, use the Siren Action Push Settings. If you need to separate the pushed content, please enable this function"
     },
     "OpsiOnePushConfig": {
       "name": "Operation Siren notifications push settings",
-      "help": "Push settings for Operation Siren notifications\nWhen Operation Siren push is enabled, notifications will only be sent if this option is enabled\nOperation Siren push settings allow setting different OnePush providers from error notifications\nWhen the independent push is disabled, notifications will be pushed via the error notification provider"
+      "help": "The settings will take effect only when the \"Siren Operation Information Independent Push\" function is enabled. Use Onepush to push a message about Corrosion 1 and Short Cat. See the document for configuration method: https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/Onepush-configuration-%5BCN%5D"
     },
     "AutoSearchTimeLimit": {
       "name": "Auto Search Time Limit",
@@ -3139,7 +3180,7 @@
   },
   "OpsiExplore": {
     "_info": {
-      "name": "Monthly Exploration Plus",
+      "name": "Operation Siren Explore",
       "help": "Explore all sea zones in Operation Siren at the beginning of each month, without needing to buy a Campaign Information Recorder (5000 Oil item).\nThis function will clear a sea zone every 27 minutes to ensure airspace search cooldown.\nThe following conditions must be met before using this feature:\n- Complete Operation Siren main story and finish Simulation Battle + Siren Proving Ground"
     },
     "SpecialRadar": {
@@ -3165,7 +3206,7 @@
   },
   "OpsiShop": {
     "_info": {
-      "name": "Operation Siren Shop Plus",
+      "name": "Operation Siren Shop",
       "help": "The following conditions must be met before using this feature:\n- Complete Operation Siren main story and finish Simulation Battle + Siren Proving Ground\n- Enable Operation Siren exploration or use Campaign Information Recorder (5000 Oil item)\n- The month after completing Operation Siren main story, i.e. when the Port Shop becomes the new version."
     },
     "PresetFilter": {
@@ -3182,7 +3223,7 @@
       "help": "To use a custom filter, set \"Port Shop Filter\" to \"Custom\" and read https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/filter_string_cn"
     },
     "DisableBeforeDate": {
-      "name": "Do not purchase from OpSi Shop Plus before the Xth day of each month",
+      "name": "Do not purchase from Operation Siren Shop before the Xth day of each month",
       "help": "Starting from the day after the specified date, buy from Operation Siren Shop once a day.\n0 means no limit, buy every day."
     }
   },
@@ -3198,11 +3239,11 @@
   },
   "OpsiDaily": {
     "_info": {
-      "name": "Operation Siren Daily Plus",
+      "name": "Operation Siren Daily",
       "help": "The following conditions must be met before using this feature:\n- Clear the Operation Siren main storyline and complete Simulation Battle + Siren Proving Ground\n- Enable Operation Siren Exploration mission or use the Campaign Information Recorder (5000 Oil item)"
     },
     "DoMission": {
-      "name": "Do Operation Siren Daily Plus",
+      "name": "Do Operation Siren dailies",
       "help": "Pick up dailies at port and complete all dailies"
     },
     "UseTuningSample": {
@@ -3264,8 +3305,8 @@
       "help": "When enabled, it will consume additional Action Points. Generally not needed, just run it slowly."
     },
     "HasStronghold": {
-      "name": "Siren Stronghold Available",
-      "help": "Execute when a Siren Stronghold is detected on the map"
+      "name": "Has Stronghold",
+      "help": "Whether a Siren Fortress is available on the map."
     }
   },
   "OpsiMonthBoss": {
@@ -3447,6 +3488,12 @@
       "True": "Enabled",
       "False": "Disabled"
     },
+    "AnyShipReached": {
+      "name": "Change when any ship reaches target level",
+      "help": "When enabled, automatically changes fleet when any checked ship reaches the target level.\nWhen disabled, all checked ships must reach the target level before changing",
+      "True": "Enabled",
+      "False": "Disabled"
+    },
     "CooldownHours": {
       "name": "Cooldown Hours",
       "help": "Cooldown period in hours after an auto-compose before the next one.",
@@ -3462,7 +3509,7 @@
   },
   "OpsiScheduling": {
     "_info": {
-      "name": "Smart Scheduling Plus",
+      "name": "Smart Scheduling",
       "help": "Operation Siren smart scheduling function, used to coordinate switching between Corrosion 1 Leveling and yellow coin replenishment tasks.\nOnce enabled, it will automatically switch between different tasks and send push notifications based on coins and Action Points.\n\nSome safety restrictions of the original AzurPilot have been lifted, please set parameters carefully"
     },
     "UseSmartSchedulingOperationCoinsPreserve": {
@@ -3530,6 +3577,21 @@
       "help": "OpsiScheduling.MonthEndShopPurchase.help",
       "True": "True",
       "False": "False"
+    },
+    "BuyActionPointMode": {
+      "name": "Buy Action Point Mode",
+      "help": "Dedicated mode for buying action points, mutually exclusive with existing coin/AP scheduling. When enabled, will use oil to buy action points and execute corresponding tasks. Set weekly purchase limit in 'Opsi General -> Buy Action Point X times' first.",
+      "off": "Off",
+      "hazard1_leveling": "Hazard 1 Leveling",
+      "meowfficer_farming": "Meowfficer Farming"
+    },
+    "BuyActionPointUpperThreshold": {
+      "name": "Buy AP Upper Threshold",
+      "help": "Only for 'Meowfficer Farming' mode. When current AP exceeds this value, skip purchase and execute sea zone tasks directly. Default 200 (natural AP recovery cap)."
+    },
+    "BuyActionPointLowerThreshold": {
+      "name": "Buy AP Lower Threshold",
+      "help": "Only for 'Meowfficer Farming' mode. When current AP falls below this value, stop executing sea zone tasks and return to purchase step. Default 100."
     }
   },
   "OpsiPreventActionPointOverflow": {
@@ -3582,7 +3644,7 @@
     },
     "WorkerFilter": {
       "name": "Farm Worker Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "MinFarm": {
       "name": "Crop Stock Threshold",
@@ -3613,7 +3675,7 @@
     },
     "WorkerFilter": {
       "name": "Orchard Worker Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "MinOrchard": {
       "name": "Fruit Stock Threshold",
@@ -3650,7 +3712,7 @@
     },
     "WorkerFilter": {
       "name": "Nursery Worker Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "MinNursery": {
       "name": "Nursery Crop Stock Threshold",
@@ -3679,7 +3741,7 @@
     },
     "ChickenFilter": {
       "name": "Chicken Worker Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "MinPork": {
       "name": "Pork Stock Threshold",
@@ -3687,7 +3749,7 @@
     },
     "PigFilter": {
       "name": "Pig Worker Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "Milk": {
       "name": "Raise Cattle",
@@ -3695,7 +3757,7 @@
     },
     "RancherFilter": {
       "name": "Character Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "Wool": {
       "name": "Raise Sheep",
@@ -3703,7 +3765,7 @@
     },
     "WoolWorkerFilter": {
       "name": "Sheep Worker Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     }
   },
   "IslandFishery": {
@@ -3760,7 +3822,7 @@
     },
     "RancherFilter": {
       "name": "Character Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     }
   },
   "IslandMine": {
@@ -3769,7 +3831,7 @@
       "help": ""
     },
     "Positions": {
-      "name": "Assign X Miner Positions",
+      "name": "Position Count",
       "help": "",
       "1": "1",
       "2": "2",
@@ -3787,7 +3849,7 @@
     },
     "WorkerFilter": {
       "name": "Mine Worker Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "MinCopper": {
       "name": "Copper Ore Min Stock",
@@ -3816,7 +3878,7 @@
       "help": ""
     },
     "Positions": {
-      "name": "Assign X Lumberjack Positions",
+      "name": "Position Count",
       "help": "",
       "1": "1",
       "2": "2",
@@ -3834,7 +3896,7 @@
     },
     "WorkerFilter": {
       "name": "Forest Worker Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "MinElegant": {
       "name": "Elegant Wood Min Stock",
@@ -3856,7 +3918,7 @@
     },
     "WorkerFilter": {
       "name": "Gathering Worker Filter",
-      "help": "Connect with >. Up to 3 characters, mapped to gathering slots 1-3.\nConnect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nDaily gathering cannot use WorkerJuu; it will be ignored if entered.\nOnly recognizes the first two rows in default order. If the specified character is unavailable, that slot falls back to the existing gathering logic."
+      "help": "Connect with >. Up to 3 characters, mapped to gathering slots 1-3.\nConnect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nDaily gathering cannot use WorkerJuu; it will be ignored if entered.\nOnly recognizes the first two rows in default order. If the specified character is unavailable, that slot falls back to the existing gathering logic."
     }
   },
   "IslandRestaurant": {
@@ -3865,14 +3927,14 @@
       "help": "Meals are produced sequentially from 1 to 8. The production target is the Meal X quantity option. The next item is only executed after the previous one is fully satisfied. Later items will not affect the completion of earlier items during runtime.\nDouble Bamboo Shoots and Asparagus Shrimp in meals 1-8 will automatically switch to corresponding seasonal meals based on the current season."
     },
     "PostNumber": {
-      "name": "Assign X Chef Positions",
+      "name": "Position Count",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "Chef Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "DoubleBambooShoots": {
       "name": "Prioritize Seasonal Dish",
@@ -3898,7 +3960,7 @@
       "persimmon_cake": "Persimmon Cake"
     },
     "MealNumber1": {
-      "name": "Produce Meal 1 to X Servings",
+      "name": "Meal 1 Quantity",
       "help": ""
     },
     "Meal2": {
@@ -3921,7 +3983,7 @@
       "persimmon_cake": "Persimmon Cake"
     },
     "MealNumber2": {
-      "name": "Produce Meal 2 to X Servings",
+      "name": "Meal 2 Quantity",
       "help": ""
     },
     "Meal3": {
@@ -3944,7 +4006,7 @@
       "persimmon_cake": "Persimmon Cake"
     },
     "MealNumber3": {
-      "name": "Produce Meal 3 to X Servings",
+      "name": "Meal 3 Quantity",
       "help": ""
     },
     "Meal4": {
@@ -3967,7 +4029,7 @@
       "persimmon_cake": "Persimmon Cake"
     },
     "MealNumber4": {
-      "name": "Produce Meal 4 to X Servings",
+      "name": "Meal 4 Quantity",
       "help": ""
     },
     "Meal5": {
@@ -3990,7 +4052,7 @@
       "persimmon_cake": "Persimmon Cake"
     },
     "MealNumber5": {
-      "name": "Produce Meal 5 to X Servings",
+      "name": "Meal 5 Quantity",
       "help": ""
     },
     "Meal6": {
@@ -4013,7 +4075,7 @@
       "persimmon_cake": "Persimmon Cake"
     },
     "MealNumber6": {
-      "name": "Produce Meal 6 to X Servings",
+      "name": "Meal 6 Quantity",
       "help": ""
     },
     "Meal7": {
@@ -4036,7 +4098,7 @@
       "persimmon_cake": "Persimmon Cake"
     },
     "MealNumber7": {
-      "name": "Produce Meal 7 to X Servings",
+      "name": "Meal 7 Quantity",
       "help": ""
     },
     "Meal8": {
@@ -4059,7 +4121,7 @@
       "persimmon_cake": "Persimmon Cake"
     },
     "MealNumber8": {
-      "name": "Produce Meal 8 to X Servings",
+      "name": "Meal 8 Quantity",
       "help": ""
     }
   },
@@ -4091,17 +4153,17 @@
   "IslandTeahouse": {
     "_info": {
       "name": "Polar Bear Drinks",
-      "help": "Meals are produced sequentially from 1 to 8. The production target is the Meal X quantity option. The next item is only executed after the previous one is fully satisfied. Later items will not affect the completion of earlier items during runtime.\nHoney drinks support automatic production; make sure honey stock is sufficient.\nSpring Flower Tea and Fresh Pineapple Juice in meals will automatically switch to corresponding seasonal meals based on the current season."
+      "help": "Meals are produced sequentially from 1 to 8. The production target is the Meal X quantity option. The next item is only executed after the previous one is fully satisfied. Later items will not affect the completion of earlier items during runtime.\nPlease craft honey products manually.\nSpring Flower Tea and Fresh Pineapple Juice in meals will automatically switch to corresponding seasonal meals based on the current season."
     },
     "PostNumber": {
-      "name": "Assign X Bartender Positions",
+      "name": "Position Count",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "Chef Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "Seasonal": {
       "name": "Prioritize Seasonal Drink",
@@ -4125,7 +4187,7 @@
       "carrot_pear_juice": "Carrot Pear Juice"
     },
     "MealNumber1": {
-      "name": "Produce Meal 1 to X Servings",
+      "name": "Meal 1 Quantity",
       "help": ""
     },
     "Meal2": {
@@ -4146,7 +4208,7 @@
       "carrot_pear_juice": "Carrot Pear Juice"
     },
     "MealNumber2": {
-      "name": "Produce Meal 2 to X Servings",
+      "name": "Meal 2 Quantity",
       "help": ""
     },
     "Meal3": {
@@ -4167,7 +4229,7 @@
       "carrot_pear_juice": "Carrot Pear Juice"
     },
     "MealNumber3": {
-      "name": "Produce Meal 3 to X Servings",
+      "name": "Meal 3 Quantity",
       "help": ""
     },
     "Meal4": {
@@ -4188,7 +4250,7 @@
       "carrot_pear_juice": "Carrot Pear Juice"
     },
     "MealNumber4": {
-      "name": "Produce Meal 4 to X Servings",
+      "name": "Meal 4 Quantity",
       "help": ""
     },
     "Meal5": {
@@ -4209,7 +4271,7 @@
       "carrot_pear_juice": "Carrot Pear Juice"
     },
     "MealNumber5": {
-      "name": "Produce Meal 5 to X Servings",
+      "name": "Meal 5 Quantity",
       "help": ""
     },
     "Meal6": {
@@ -4230,7 +4292,7 @@
       "carrot_pear_juice": "Carrot Pear Juice"
     },
     "MealNumber6": {
-      "name": "Produce Meal 6 to X Servings",
+      "name": "Meal 6 Quantity",
       "help": ""
     },
     "Meal7": {
@@ -4251,7 +4313,7 @@
       "carrot_pear_juice": "Carrot Pear Juice"
     },
     "MealNumber7": {
-      "name": "Produce Meal 7 to X Servings",
+      "name": "Meal 7 Quantity",
       "help": ""
     },
     "Meal8": {
@@ -4272,7 +4334,7 @@
       "carrot_pear_juice": "Carrot Pear Juice"
     },
     "MealNumber8": {
-      "name": "Produce Meal 8 to X Servings",
+      "name": "Meal 8 Quantity",
       "help": ""
     }
   },
@@ -4305,14 +4367,14 @@
       "help": "Meals are produced sequentially from 1 to 8. The production target is the Meal X quantity option. The next item is only executed after the previous one is fully satisfied. Later items will not affect the completion of earlier items during runtime."
     },
     "PostNumber": {
-      "name": "Assign X Grill Chef Positions",
+      "name": "Position Count",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "Chef Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "Meal1": {
       "name": "Meal 1",
@@ -4328,7 +4390,7 @@
       "double_energy": "Double Energy Combo"
     },
     "MealNumber1": {
-      "name": "Produce Meal 1 to X Servings",
+      "name": "Meal 1 Quantity",
       "help": ""
     },
     "Meal2": {
@@ -4345,7 +4407,7 @@
       "double_energy": "Double Energy Combo"
     },
     "MealNumber2": {
-      "name": "Produce Meal 2 to X Servings",
+      "name": "Meal 2 Quantity",
       "help": ""
     },
     "Meal3": {
@@ -4362,7 +4424,7 @@
       "double_energy": "Double Energy Combo"
     },
     "MealNumber3": {
-      "name": "Produce Meal 3 to X Servings",
+      "name": "Meal 3 Quantity",
       "help": ""
     },
     "Meal4": {
@@ -4379,7 +4441,7 @@
       "double_energy": "Double Energy Combo"
     },
     "MealNumber4": {
-      "name": "Produce Meal 4 to X Servings",
+      "name": "Meal 4 Quantity",
       "help": ""
     },
     "Meal5": {
@@ -4396,7 +4458,7 @@
       "double_energy": "Double Energy Combo"
     },
     "MealNumber5": {
-      "name": "Produce Meal 5 to X Servings",
+      "name": "Meal 5 Quantity",
       "help": ""
     },
     "Meal6": {
@@ -4413,7 +4475,7 @@
       "double_energy": "Double Energy Combo"
     },
     "MealNumber6": {
-      "name": "Produce Meal 6 to X Servings",
+      "name": "Meal 6 Quantity",
       "help": ""
     },
     "Meal7": {
@@ -4430,7 +4492,7 @@
       "double_energy": "Double Energy Combo"
     },
     "MealNumber7": {
-      "name": "Produce Meal 7 to X Servings",
+      "name": "Meal 7 Quantity",
       "help": ""
     },
     "Meal8": {
@@ -4447,7 +4509,7 @@
       "double_energy": "Double Energy Combo"
     },
     "MealNumber8": {
-      "name": "Produce Meal 8 to X Servings",
+      "name": "Meal 8 Quantity",
       "help": ""
     }
   },
@@ -4476,14 +4538,14 @@
       "help": "Meals are produced sequentially from 1 to 8. The production target is the Meal X quantity option. The next item is only executed after the previous one is fully satisfied. Later items will not affect the completion of earlier items during runtime."
     },
     "PostNumber": {
-      "name": "Assign X Cook Positions",
+      "name": "Position Count",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "Chef Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "Meal1": {
       "name": "Meal 1",
@@ -4501,7 +4563,7 @@
       "seafood_rice": "Seafood Rice"
     },
     "MealNumber1": {
-      "name": "Produce Meal 1 to X Servings",
+      "name": "Meal 1 Quantity",
       "help": ""
     },
     "Meal2": {
@@ -4520,7 +4582,7 @@
       "seafood_rice": "Seafood Rice"
     },
     "MealNumber2": {
-      "name": "Produce Meal 2 to X Servings",
+      "name": "Meal 2 Quantity",
       "help": ""
     },
     "Meal3": {
@@ -4539,7 +4601,7 @@
       "seafood_rice": "Seafood Rice"
     },
     "MealNumber3": {
-      "name": "Produce Meal 3 to X Servings",
+      "name": "Meal 3 Quantity",
       "help": ""
     },
     "Meal4": {
@@ -4558,7 +4620,7 @@
       "seafood_rice": "Seafood Rice"
     },
     "MealNumber4": {
-      "name": "Produce Meal 4 to X Servings",
+      "name": "Meal 4 Quantity",
       "help": ""
     },
     "Meal5": {
@@ -4577,7 +4639,7 @@
       "seafood_rice": "Seafood Rice"
     },
     "MealNumber5": {
-      "name": "Produce Meal 5 to X Servings",
+      "name": "Meal 5 Quantity",
       "help": ""
     },
     "Meal6": {
@@ -4596,7 +4658,7 @@
       "seafood_rice": "Seafood Rice"
     },
     "MealNumber6": {
-      "name": "Produce Meal 6 to X Servings",
+      "name": "Meal 6 Quantity",
       "help": ""
     },
     "Meal7": {
@@ -4615,7 +4677,7 @@
       "seafood_rice": "Seafood Rice"
     },
     "MealNumber7": {
-      "name": "Produce Meal 7 to X Servings",
+      "name": "Meal 7 Quantity",
       "help": ""
     },
     "Meal8": {
@@ -4634,7 +4696,7 @@
       "seafood_rice": "Seafood Rice"
     },
     "MealNumber8": {
-      "name": "Produce Meal 8 to X Servings",
+      "name": "Meal 8 Quantity",
       "help": ""
     }
   },
@@ -4665,14 +4727,14 @@
       "help": "Meals are produced sequentially from 1 to 8. The production target is the Meal X quantity option. The next item is only executed after the previous one is fully satisfied. Later items will not affect the completion of earlier items during runtime."
     },
     "PostNumber": {
-      "name": "Assign X Barista Positions",
+      "name": "Position Count",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "Chef Filter",
-      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
+      "help": "Connect with >, e.g. ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nOnly recognizes the first two rows in default order. If the specified character is unavailable, falls back to WorkerJuu."
     },
     "Friedrich": {
       "name": "Friedrich",
@@ -4693,7 +4755,7 @@
       "fruity_fruitier": "Fruity Fruitier"
     },
     "MealNumber1": {
-      "name": "Produce Meal 1 to X Servings",
+      "name": "Meal 1 Quantity",
       "help": ""
     },
     "Meal2": {
@@ -4711,7 +4773,7 @@
       "fruity_fruitier": "Fruity Fruitier"
     },
     "MealNumber2": {
-      "name": "Produce Meal 2 to X Servings",
+      "name": "Meal 2 Quantity",
       "help": ""
     },
     "Meal3": {
@@ -4729,7 +4791,7 @@
       "fruity_fruitier": "Fruity Fruitier"
     },
     "MealNumber3": {
-      "name": "Produce Meal 3 to X Servings",
+      "name": "Meal 3 Quantity",
       "help": ""
     },
     "Meal4": {
@@ -4747,7 +4809,7 @@
       "fruity_fruitier": "Fruity Fruitier"
     },
     "MealNumber4": {
-      "name": "Produce Meal 4 to X Servings",
+      "name": "Meal 4 Quantity",
       "help": ""
     },
     "Meal5": {
@@ -4765,7 +4827,7 @@
       "fruity_fruitier": "Fruity Fruitier"
     },
     "MealNumber5": {
-      "name": "Produce Meal 5 to X Servings",
+      "name": "Meal 5 Quantity",
       "help": ""
     },
     "Meal6": {
@@ -4783,7 +4845,7 @@
       "fruity_fruitier": "Fruity Fruitier"
     },
     "MealNumber6": {
-      "name": "Produce Meal 6 to X Servings",
+      "name": "Meal 6 Quantity",
       "help": ""
     },
     "Meal7": {
@@ -4801,7 +4863,7 @@
       "fruity_fruitier": "Fruity Fruitier"
     },
     "MealNumber7": {
-      "name": "Produce Meal 7 to X Servings",
+      "name": "Meal 7 Quantity",
       "help": ""
     },
     "Meal8": {
@@ -4819,7 +4881,7 @@
       "fruity_fruitier": "Fruity Fruitier"
     },
     "MealNumber8": {
-      "name": "Produce Meal 8 to X Servings",
+      "name": "Meal 8 Quantity",
       "help": ""
     }
   },
@@ -5056,8 +5118,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "Chang Feng",
       "Mogador": "Mogador",
-      "RoyalFortune": "Royal Fortune",
-      "DaVinci": "Da Vinci"
+      "RoyalFortune": "Royal Fortune"
     },
     "Char2": {
       "name": "Character 2",
@@ -5095,8 +5156,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "Chang Feng",
       "Mogador": "Mogador",
-      "RoyalFortune": "Royal Fortune",
-      "DaVinci": "Da Vinci"
+      "RoyalFortune": "Royal Fortune"
     },
     "Product1": {
       "name": "Product 1",
@@ -5222,8 +5282,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "Chang Feng",
       "Mogador": "Mogador",
-      "RoyalFortune": "Royal Fortune",
-      "DaVinci": "Da Vinci"
+      "RoyalFortune": "Royal Fortune"
     },
     "Char2": {
       "name": "Character 2",
@@ -5261,8 +5320,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "Chang Feng",
       "Mogador": "Mogador",
-      "RoyalFortune": "Royal Fortune",
-      "DaVinci": "Da Vinci"
+      "RoyalFortune": "Royal Fortune"
     },
     "Product1": {
       "name": "Product 1",
@@ -5400,8 +5458,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "Chang Feng",
       "Mogador": "Mogador",
-      "RoyalFortune": "Royal Fortune",
-      "DaVinci": "Da Vinci"
+      "RoyalFortune": "Royal Fortune"
     },
     "Char2": {
       "name": "Character 2",
@@ -5439,8 +5496,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "Chang Feng",
       "Mogador": "Mogador",
-      "RoyalFortune": "Royal Fortune",
-      "DaVinci": "Da Vinci"
+      "RoyalFortune": "Royal Fortune"
     },
     "Product1": {
       "name": "Product 1",
@@ -5538,8 +5594,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "Chang Feng",
       "Mogador": "Mogador",
-      "RoyalFortune": "Royal Fortune",
-      "DaVinci": "Da Vinci"
+      "RoyalFortune": "Royal Fortune"
     },
     "Char2": {
       "name": "Character 2",
@@ -5577,8 +5632,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "Chang Feng",
       "Mogador": "Mogador",
-      "RoyalFortune": "Royal Fortune",
-      "DaVinci": "Da Vinci"
+      "RoyalFortune": "Royal Fortune"
     },
     "Product1": {
       "name": "Product 1",
@@ -5681,8 +5735,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "Chang Feng",
       "Mogador": "Mogador",
-      "RoyalFortune": "Royal Fortune",
-      "DaVinci": "Da Vinci"
+      "RoyalFortune": "Royal Fortune"
     },
     "Char2": {
       "name": "Character 2",
@@ -5720,8 +5773,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "Chang Feng",
       "Mogador": "Mogador",
-      "RoyalFortune": "Royal Fortune",
-      "DaVinci": "Da Vinci"
+      "RoyalFortune": "Royal Fortune"
     },
     "Product1": {
       "name": "Product 1",
@@ -5799,7 +5851,7 @@
   },
   "Daemon": {
     "_info": {
-      "name": "Semi-Automatic Click",
+      "name": "semi-automatic click",
       "help": "It is useful when attacking unadapted levels, which can reduce a lot of manual operations.\nAzurPilot will help you click to prepare for battle, click to settle the battle, skip the plot, automatically retire, and close various pop-up windows. You just need to select the enemy manually."
     },
     "EnterMap": {
@@ -5869,7 +5921,7 @@
       "help": "Current scaffold: dock, first ship, quick change, equipping filter, placeholder strategy, next ship."
     },
     "ShipLimit": {
-      "name": "Process First X Ships",
+      "name": "Ship limit",
       "help": "0 means continue until no next ship is detected. Use 1 or another small value while debugging."
     },
     "EnableSlot1": {
@@ -5909,7 +5961,7 @@
       "help": "Test which screenshot scheme and control scheme is faster, speed varies based on emulator and computer configuration\nAfter the test is completed, select the fastest screenshot and control scheme in \"AzurPilot\" - \"Emulator Settings\""
     },
     "DeviceType": {
-      "name": "Select Device Type",
+      "name": "Device type",
       "help": "",
       "emulator": "emulator",
       "plone_cloud_with_adb": "Cloud mobile phone has public network ADB",
@@ -5918,7 +5970,7 @@
       "android_phone_vmos": "Android real machine VMOS virtual machine"
     },
     "TestScene": {
-      "name": "Test Scene",
+      "name": "test scenario",
       "help": "",
       "screenshot_click": "Screenshot + click speed test",
       "screenshot": "Screenshot speed test",
@@ -6039,7 +6091,7 @@
     },
     "BuyAp": {
       "name": "Weekly AP Purchase",
-      "help": "Whether to purchase 1000 action points weekly. Stronghold will still be fought even without purchasing."
+      "help": "Whether to purchase 1000 action points weekly. Fortress will still be fought even without purchasing."
     },
     "Cl1Coin": {
       "name": "Corrosion 1 Coin Expectation",

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -1,15 +1,15 @@
 {
   "Menu": {
     "Alas": {
-      "name": "スマートポートPlus",
+      "name": "スマートポートエリア+",
       "help": ""
     },
     "Farm": {
-      "name": "出撃Plus",
+      "name": "出撃+",
       "help": ""
     },
     "Event": {
-      "name": "イベントPlus",
+      "name": "イベント+",
       "help": ""
     },
     "EventDaily": {
@@ -25,7 +25,7 @@
       "help": ""
     },
     "Opsi": {
-      "name": "セイレーン作戦Plus",
+      "name": "セイレーン作戦+",
       "help": ""
     },
     "Island": {
@@ -37,7 +37,7 @@
       "help": ""
     },
     "Tool": {
-      "name": "ツールPlus",
+      "name": "ツール+",
       "help": ""
     }
   },
@@ -55,23 +55,23 @@
       "help": ""
     },
     "Main": {
-      "name": "メインステージ-1Plus",
+      "name": "メインステージ-1+",
       "help": ""
     },
     "Main2": {
-      "name": "メインステージ-2Plus",
+      "name": "メインステージ-2+",
       "help": ""
     },
     "Main3": {
-      "name": "メインステージ-3Plus",
+      "name": "メインステージ+",
       "help": ""
     },
     "GemsFarming": {
-      "name": "緊急委託Plus",
+      "name": "緊急委託+",
       "help": ""
     },
     "ThreeOilLowCost": {
-      "name": "3燃料低コストPlus",
+      "name": "3燃料低コスト+",
       "help": "3燃料低コスト編成で戦闘し、旗艦がレベル32に達すると自動的に旗艦を交換して退役させます。"
     },
     "Ambush11": {
@@ -83,23 +83,23 @@
       "help": ""
     },
     "Event": {
-      "name": "イベントマップ-1Plus",
+      "name": "イベントマップ-1+",
       "help": ""
     },
     "Event2": {
-      "name": "イベントマップ-2Plus",
+      "name": "イベントマップ-2+",
       "help": ""
     },
     "Event3": {
-      "name": "イベントマップ-3Plus",
+      "name": "イベントマップ-3+",
       "help": ""
     },
     "Raid": {
-      "name": "レイドイベントPlus",
+      "name": "レイドイベント+",
       "help": ""
     },
     "RaidScuttle": {
-      "name": "レイド沈船Plus",
+      "name": "レイド沈船+",
       "help": ""
     },
     "Hospital": {
@@ -111,8 +111,8 @@
       "help": ""
     },
     "CoalitionScuttle": {
-      "name": "連合沈船Plus",
-      "help": "連合イベントで艦船が撃沈された後に好感度を周回します。複数艦隊での出撃を推奨。第1艦隊で沈めます。関連チュートリアルをご確認ください。"
+      "name": "Task.CoalitionScuttle.name",
+      "help": "Task.CoalitionScuttle.help"
     },
     "MaritimeEscort": {
       "name": "海上護衛Plus",
@@ -186,6 +186,10 @@
       "name": "認知覚醒",
       "help": ""
     },
+    "Secretary": {
+      "name": "秘書艦",
+      "help": "秘書艦の好感度を自動で監視し、好感度が 90 に達すると自動で変更します"
+    },
     "Daily": {
       "name": "デイリー任務",
       "help": ""
@@ -215,7 +219,7 @@
       "help": ""
     },
     "Freebies": {
-      "name": "無料特典Plus",
+      "name": "無料報酬",
       "help": ""
     },
     "Minigame": {
@@ -223,7 +227,7 @@
       "help": "ゲームコインがオーバーフローしない場合に自動的にゲームコインを受け取り、ゲームコインがあり報酬が満杯でない場合に自動的にミニゲームをプレイします。"
     },
     "PrivateQuarters": {
-      "name": "ドルミトリープランPlus",
+      "name": "寮計画",
       "help": ""
     },
     "OpsiGeneral": {
@@ -239,11 +243,11 @@
       "help": ""
     },
     "OpsiExplore": {
-      "name": "月間開拓Plus",
+      "name": "月間開拓+",
       "help": ""
     },
     "OpsiShop": {
-      "name": "セイレーン作戦ショップPlus",
+      "name": "セイレーン作戦ショップ+",
       "help": ""
     },
     "OpsiVoucher": {
@@ -251,7 +255,7 @@
       "help": ""
     },
     "OpsiDaily": {
-      "name": "セイレーン作戦デイリーPlus",
+      "name": "セイレーン作戦-デイリー+",
       "help": ""
     },
     "OpsiObscure": {
@@ -275,15 +279,15 @@
       "help": ""
     },
     "OpsiMeowfficerFarming": {
-      "name": "短猫相接",
+      "name": "指揮ニャファーム+",
       "help": ""
     },
     "OpsiHazard1Leveling": {
-      "name": "侵蝕1レベリング",
+      "name": "侵蝕1レベリング+",
       "help": ""
     },
     "OpsiScheduling": {
-      "name": "スマートスケジューリングPlus",
+      "name": "スマートスケジューリング+",
       "help": "セイレーン作戦スマートスケジューリング機能。侵蝕1レベリングとゴールドコイン補充タスク間の切り替えを調整します。\n有効にすると、ゴールドコインと行動力に基づいて異なるタスク間を自動的に切り替え、プッシュ通知を送信します。"
     },
     "OpsiPreventActionPointOverflow": {
@@ -571,7 +575,6 @@
       "en-3": "[EN] Washington",
       "en-4": "[EN] Amagi",
       "en-5": "[EN] Little Enterprise",
-      "en-6": "[EN] Belfast",
       "jp-0": "[JP] ブレスト",
       "jp-1": "[JP] 横須賀",
       "jp-2": "[JP] 佐世保",
@@ -589,15 +592,10 @@
       "jp-14": "[JP] キール",
       "jp-15": "[JP] 若松",
       "jp-16": "[JP] オデッサ",
-      "jp-17": "[JP] スイートバン",
-      "tw-0": "[TW] 珍珠港",
-      "tw-1": "[TW] 珊瑚海",
-      "tw-2": "[TW] 中途島",
-      "tw-3": "[TW] 瓜達康納爾",
-      "tw-4": "[TW] 雷伊泰灣"
+      "jp-17": "[JP] スイートバン"
     },
     "ScreenshotMethod": {
-      "name": "スクリーンショット方式を選択",
+      "name": "エミュレータスクリーンショット方式",
       "help": "自動選択を使用すると、パフォーマンステストを実行し、最速のスクリーンショット方式に自動変更します\n通常の速度: DroidCast_raw >> aScreenCap_nc > ADB_nc >>> aScreenCap > uiautomator2 ~= ADB\nツール - パフォーマンステストを実行して最速の方式を見つけてください",
       "auto": "最速を自動選択",
       "ADB": "ADB",
@@ -611,7 +609,7 @@
       "ldopengl": "ldopengl"
     },
     "ControlMethod": {
-      "name": "コントロール方式を選択",
+      "name": "エミュレータ制御方式",
       "help": "速度: minitouch > Hermit >>> uiautomator2 ~= ADB\nminitouchを推奨。vmos下を除き、Hermitは非推奨。",
       "ADB": "ADB",
       "uiautomator2": "uiautomator2",
@@ -640,7 +638,7 @@
       "help": "以下の値はSerialに基づいて自動入力されます。理解できない場合は変更しないでください。ポートを変更すると、対応するインスタンスが自動的に起動します。"
     },
     "Emulator": {
-      "name": "エミュレータタイプを選択",
+      "name": "エミュレータの種類",
       "help": "",
       "auto": "自動検出",
       "NoxPlayer": "NoxPlayer",
@@ -718,7 +716,7 @@
       "help": "機密タスク実行中にエラーが発生した場合、ゲームを再起動せずにAzurPilotを停止します\n機密タスクには隠秘海域、深淵海域、月跨ぎデイリーなどが含まれます"
     },
     "SaveErrorCount": {
-      "name": "エラーログは最大X件保存",
+      "name": "エラーログ保存上限",
       "help": "上限を超えたエラーログは削除されます。0または負の値の場合、制限はありません。"
     },
     "OnePushConfig": {
@@ -734,7 +732,7 @@
       "help": "ゲームフリーズ（GameStuckError発生）が指定回数に達した後、エミュレータの再起動を試みます。エミュレータのフリーズやメモリオーバーフローなどの問題の解決に役立つ場合があります。"
     },
     "GameStuckThreshold": {
-      "name": "ゲームフリーズからX秒後に再起動",
+      "name": "ゲームがスタックした再起動のしきい値",
       "help": "再起動をトリガーする前にスタックが連続して何回発生するか。"
     },
     "AdbOfflineRestart": {
@@ -742,7 +740,7 @@
       "help": "指定した回数連続してデバイスが検出できない（ADB がオフラインまたは接続に失敗する）場合は、エミュレータを再起動してみてください。"
     },
     "AdbOfflineThreshold": {
-      "name": "デバイス未検出からX秒後に再起動",
+      "name": "デバイスの再起動しきい値が検出されない",
       "help": "デバイスが連続して検出できなかった回数に応じて、再起動がトリガーされます。"
     },
     "LlmAnalysis": {
@@ -794,37 +792,38 @@
     },
     "OcrModelVersionEnglish": {
       "name": "OCR 英語モデルバージョン",
-      "help": "英語 OCR モデルの階層を選択します。lite は最軽量で最速、standard はバランス型、pro は最高精度です。auto は standard を使用します。alocr_en_v2_6 は旧版 AlOCR 英語モデル（ONNX バックエンドのみ）です。この項目は英語 Azur Lane モデルに適用されます。",
+      "help": "英語 OCR モデルのバージョンを選択します。auto は推奨の英語 AlOCR v2.6 モデルを使用します。この項目は英語 Azur Lane モデルに適用されます。ncnn バックエンドでは無視されます。",
       "auto": "自動推奨",
-      "lite": "Lite（軽量）",
-      "standard": "Standard（標準）",
-      "pro": "Pro（高精度）",
-      "alocr_en_v2_6": "AlOCR v2.6（旧版）"
+      "alocr_en_900k": "alocr_en_900k",
+      "azur_lane_v6_6": "英語 v6.6 (Azur Lane)",
+      "azur_lane_v6_5": "英語 v6.5 (Azur Lane)",
+      "ppocr_v6": "汎用 PP-OCRv6",
+      "alocr_en_v2_6": "英語 AlOCR v2.6",
+      "alocr_en_v2_0": "英語 AlOCR v2.0",
+      "alocr_en_v1_0": "英語 AlOCR v1.0"
     },
     "OcrModelVersionChinese": {
       "name": "OCR 中国語モデルバージョン",
-      "help": "簡体中国語 OCR モデルの階層を選択します。lite は最軽量で最速、standard はバランス型、pro は最高精度です。auto は standard を使用します。alocr_cn_v3 は旧版 AlOCR 中国語モデル（ONNX バックエンドのみ）です。この項目は cnocr/中国語モデルに適用されます。",
+      "help": "簡体中国語 OCR モデルのバージョンを選択します。auto は推奨の中国語 v6.1 モデルを使用します。この項目は cnocr/中国語モデルに適用されます。ncnn バックエンドでは無視されます。",
       "auto": "自動推奨",
-      "lite": "Lite（軽量）",
-      "standard": "Standard（標準）",
-      "pro": "Pro（高精度）",
-      "alocr_cn_v3": "AlOCR v3（旧版）"
+      "cn_v6_1": "中国語 v6.1",
+      "cn_v6": "中国語 v6",
+      "ppocr_v6": "汎用 PP-OCRv6",
+      "alocr_cn_v3": "中国語 AlOCR v3",
+      "alocr_cn_v2_5": "中国語 AlOCR v2.5"
     },
     "OcrModelVersionJapanese": {
       "name": "OCR 日本語モデルバージョン",
-      "help": "日本語 OCR モデルの階層を選択します。lite は最軽量で最速ですが日本語には対応していません。standard はバランス型、pro は最高精度です。auto は standard を使用します。この項目は日本語モデルに適用されます。",
+      "help": "日本語 OCR モデルのバージョンを選択します。auto は日本語 Azur Lane v6 モデルを使用します。この項目は日本語モデルに適用されます。ncnn バックエンドでは無視されます。",
       "auto": "自動推奨",
-      "lite": "Lite（軽量）",
-      "standard": "Standard（標準）",
-      "pro": "Pro（高精度）"
+      "azur_lane_jp_v6": "日本語 v6 (Azur Lane JP)",
+      "ppocr_v6": "汎用 PP-OCRv6"
     },
     "OcrModelVersionTraditionalChinese": {
       "name": "OCR 繁体中国語モデルバージョン",
-      "help": "繁体中国語 OCR モデルの階層を選択します。lite は最軽量で最速、standard はバランス型、pro は最高精度です。auto は standard を使用します。",
+      "help": "繁体中国語 OCR モデルのバージョンを選択します。現在は汎用 PP-OCRv6 のみ利用できます。今後のモデル追加のため、独立した設定として残しています。ncnn バックエンドでは無視されます。",
       "auto": "自動推奨",
-      "lite": "Lite（軽量）",
-      "standard": "Standard（標準）",
-      "pro": "Pro（高精度）"
+      "ppocr_v6": "汎用 PP-OCRv6"
     },
     "ScreenshotInterval": {
       "name": "スクリーンショット速度をX秒に1枚に減速",
@@ -901,6 +900,14 @@
       "upload": "アップロード",
       "save_and_upload": "保存してアップロードする"
     },
+    "OpsiShopRecord": {
+      "name": "DropRecord.OpsiShopRecord.name",
+      "help": "DropRecord.OpsiShopRecord.help",
+      "do_not": "do_not",
+      "save": "save",
+      "upload": "upload",
+      "save_and_upload": "save_and_upload"
+    },
     "MeowfficerBuy": {
       "name": "オフニャ購入スクリーンショット",
       "help": "",
@@ -955,7 +962,7 @@
       "help": ""
     },
     "RetireMode": {
-      "name": "退役モードを選択",
+      "name": "退役モード",
       "help": "強化を選択した場合、強化素材が不足するとワンクリック退役に戻ります。",
       "one_click_retire": "ワンクリック退役",
       "enhance": "強化",
@@ -964,7 +971,7 @@
   },
   "PublicEmotion": {
     "_info": {
-      "name": "コンディション共用",
+      "name": "コンディション共有",
       "help": "同じ艦隊を使用して複数のタスクを完了できます\nこの機能を使用する場合は、対応するタスクの艦隊設定がすべての単独チームであり、その艦隊が共有艦隊であることを確認してください。"
     },
     "Enable": {
@@ -1045,7 +1052,7 @@
       "help": "形式: \"cv > bb > ...\"\nデフォルトの強化方法を使用する場合は空白のままにしてください"
     },
     "CheckPerCategory": {
-      "name": "カテゴリごとにX隻確認",
+      "name": "艦種ごとの強化チェック数",
       "help": "各艦種ごとに最大何隻まで強化チェックしますか？\n戦闘中の艦船はスキップされ、カウントされません。\n強化素材がある艦船を優先します"
     }
   },
@@ -1071,7 +1078,7 @@
       "help": ""
     },
     "RetireAmount": {
-      "name": "毎回X隻退役",
+      "name": "退役数量",
       "help": "",
       "retire_all": "全員退役",
       "retire_10": "10隻退役"
@@ -1095,7 +1102,7 @@
       "coalition_20250626": "ネオンシティの探索者",
       "coalition_20251120": "DATE A LANE",
       "coalition_20260122": "特集写真-撮影進行中",
-      "coalition_20260723": "怪談実録",
+      "coalition_20260723": "怪谈纪实：逃离白夜山庄",
       "event_20200227_cn": "凍絶の北海",
       "event_20200312_cn": "南洋に靡く硝煙（復刻）",
       "event_20200326_cn": "闇靄払う銀翼",
@@ -1181,7 +1188,7 @@
       "event_20260417_cn": "バケーションレーン・きらめく砂浜",
       "event_20260520_cn": "聖印前の同盟",
       "event_20260625_cn": "幻夢のカヴァルカード",
-      "event_20260813_cn": "星の導く街",
+      "event_20260813_cn": "沉溺于星光之城",
       "raid_20200624": "特別演習超空強襲波（復刻）",
       "raid_20210708": "交錯する新たな波 (復刻)",
       "raid_20220127": "秘密事件調査",
@@ -1243,7 +1250,7 @@
       "war_archives_20240725_cn": "檔案 夢幻の間奏曲"
     },
     "Mode": {
-      "name": "ステージモードを選択",
+      "name": "ステージモード",
       "help": "メインステージのみに適用されます",
       "normal": "普通",
       "hard": "ハード"
@@ -1326,7 +1333,7 @@
       "help": ""
     },
     "DailyRunCount": {
-      "name": "毎日X回出撃",
+      "name": "デイリー出撃回数",
       "help": "作戦アーカイブを1日に実行する最大回数です。\n0は無制限です。\n上限に達すると、タスクを無効化せず次回サーバー更新まで延期します。"
     },
     "DailyRunCountRemain": {
@@ -1348,7 +1355,7 @@
       "help": ""
     },
     "Fleet1": {
-      "name": "第一艦隊は第X艦隊を使用",
+      "name": "第一艦隊番号",
       "help": "",
       "1": "1 ",
       "2": "2 ",
@@ -1365,7 +1372,7 @@
       "diamond": "輪形陣"
     },
     "Fleet1Mode": {
-      "name": "第一艦隊自律戦闘モード",
+      "name": "第一艦隊自律モード",
       "help": "",
       "combat_auto": "自動戦闘",
       "combat_manual": "手動操作",
@@ -1382,7 +1389,7 @@
       "5": "5 "
     },
     "Fleet2": {
-      "name": "第二艦隊は第X艦隊を使用",
+      "name": "第二艦隊番号",
       "help": "",
       "0": "未使用",
       "1": "1 ",
@@ -1400,7 +1407,7 @@
       "diamond": "輪形陣"
     },
     "Fleet2Mode": {
-      "name": "第二艦隊自律戦闘モード",
+      "name": "第二艦隊自律モード",
       "help": "",
       "combat_auto": "自動戦闘",
       "combat_manual": "手動操作",
@@ -1425,8 +1432,8 @@
       "fleet1_standby_fleet2_all": "第一艦隊待機 第二艦隊全滅"
     },
     "SkipPreparation": {
-      "name": "編成チェックをスキップ",
-      "help": "有効にすると、編成画面の艦隊選択ステップをスキップし、現在のプリセット艦隊で直接出撃します。艦隊スロットが未解放のアカウントに適しています。"
+      "name": "Fleet.SkipPreparation.name",
+      "help": "Fleet.SkipPreparation.help"
     }
   },
   "Submarine": {
@@ -1435,14 +1442,14 @@
       "help": ""
     },
     "Fleet": {
-      "name": "第X潜水艦隊を使用",
+      "name": "潜水艦艦隊数",
       "help": "",
       "0": "未使用",
       "1": "1 ",
       "2": "2 "
     },
     "Mode": {
-      "name": "潜水艦出撃プランを選択",
+      "name": "潜水艦出撃方案",
       "help": "自律索敵がオフの場合にのみ有効です。注意：「狩猟及びBOSS戦」は「狩猟のみ」と「BOSS戦のみ」の組み合わせです。道中で狩猟攻撃を実行し、BOSS戦で潜水艦を召喚しようとします。",
       "do_not_use": "未使用",
       "hunt_only": "狩猟のみ",
@@ -1451,7 +1458,7 @@
       "every_combat": "毎戦出撃"
     },
     "AutoSearchMode": {
-      "name": "潜水艦自律プランを選択",
+      "name": "潜水艦自律方案",
       "help": "自律索敵の場合にのみ有効",
       "sub_standby": "待機",
       "sub_auto_call": "潜水艦を自動的に召喚する"
@@ -1752,7 +1759,7 @@
       "help": ""
     },
     "PtLimit": {
-      "name": "イベントPTがXに達したら停止",
+      "name": "イベントPT制限",
       "help": "累積PTが指定値に達すると、すべてのイベントタスクが無効になります。0は制限なしを意味します。自律索敵使用時は即時発動できません。\n有効にすると、すべてのイベントタスクを開くだけで、合計何回出撃するかを計算する必要がありません。"
     },
     "TimeLimit": {
@@ -1770,7 +1777,7 @@
       "help": "有効にすると、出撃ごとに資金量がチェックされます。"
     },
     "CoinLimit": {
-      "name": "資金をX以上に維持",
+      "name": "資金をXより多く保つ",
       "help": ""
     },
     "TaskCall": {
@@ -1890,7 +1897,7 @@
       "help": "SPステージはイベントデイリーSPで実行する必要があります",
       "easy": "簡単",
       "normal": "普通",
-      "hard": "ハード",
+      "hard": "困難",
       "sp": "SP",
       "ex": "EX"
     },
@@ -1903,15 +1910,15 @@
   },
   "CoalitionScuttle": {
     "_info": {
-      "name": "連合沈船",
-      "help": "連合イベント沈船設定。撃沈される艦船の位置を選択します。"
+      "name": "CoalitionScuttle._info.name",
+      "help": "CoalitionScuttle._info.help"
     },
     "Sacrifice": {
-      "name": "犠牲艦の位置",
-      "help": "撃沈される艦船の位置を選択します：前衛/旗艦/前衛+旗艦",
-      "vanguard": "前衛",
-      "flagship": "旗艦",
-      "vanguard_flagship": "前衛+旗艦"
+      "name": "CoalitionScuttle.Sacrifice.name",
+      "help": "CoalitionScuttle.Sacrifice.help",
+      "vanguard": "vanguard",
+      "flagship": "flagship",
+      "vanguard_flagship": "vanguard_flagship"
     }
   },
   "EventShop": {
@@ -1992,13 +1999,21 @@
       "name": "主要委託を実行する（1200燃料/1000燃料委託）",
       "help": "1200燃料委託は現在では廃止されており、収益が非常に低いです。オフにすることをお勧めします。"
     },
+    "GemNotify": {
+      "name": "ダイヤ委託実行通知",
+      "help": "新しいダイヤ委託を開始した後、現在実行中のダイヤ委託一覧を通知します"
+    },
     "CommissionNotifyReward": {
-      "name": "委託報酬プッシュ通知",
-      "help": "委託報酬獲得時に通知を送信（特にダイヤ報酬）"
+      "name": "委託成功でダイヤモンド取得通知",
+      "help": "注意：「プッシュ通知設定」を有効にして設定してください。設定されていない場合、この機能は動作しません。"
     },
     "CommissionNotifyRewardStatistics": {
-      "name": "通知に統計情報を含める",
-      "help": "通知に今日/週間/月間の累積ダイヤ数を表示"
+      "name": "ダイヤモンド通知の詳細",
+      "help": "オンにすると、AzurPilotは今回の委託で取得したダイヤモンドの数量と同時に、当日／今週／今月のダイヤモンド取得数量も通知します"
+    },
+    "CommissionNotifyRewardCube": {
+      "name": "Commission.CommissionNotifyRewardCube.name",
+      "help": "Commission.CommissionNotifyRewardCube.help"
     }
   },
   "Tactical": {
@@ -2036,19 +2051,19 @@
       "help": ""
     },
     "T4Allow": {
-      "name": "T4スキルブックの経験値オーバーフローをX許可",
+      "name": "T4スキルブックのX経験値溢出を許可する",
       "help": ""
     },
     "T3Allow": {
-      "name": "T3スキルブックの経験値オーバーフローをX許可",
+      "name": "T3スキルブックのX経験値溢出を許可する",
       "help": ""
     },
     "T2Allow": {
-      "name": "T2スキルブックの経験値オーバーフローをX許可",
+      "name": "T2スキルブックのX経験値溢出を許可する",
       "help": ""
     },
     "T1Allow": {
-      "name": "T1スキルブックの経験値オーバーフローをX許可",
+      "name": "T1スキルブックのX経験値溢出を許可する",
       "help": ""
     }
   },
@@ -2066,7 +2081,7 @@
       "help": ""
     },
     "MinLevel": {
-      "name": "レベルX以上のキャラクターのみ追加",
+      "name": "レベルがX以上のキャラクターのみを追加してください。",
       "help": ""
     }
   },
@@ -2104,12 +2119,12 @@
       "help": "資源が不足している場合、AzurPilotは条件が満たされるか科研キューが空になりそうになるまで科研を遅延させますが、科研が停止することはありません。\n長期間資源が不足している場合やAzurPilotの実行時間が十分でない場合は、このオプションをオフにして科研キューを常に満杯に保つことができます。"
     },
     "AllowGenreT": {
-      "name": "T型科研を許可する",
-      "help": "T型科研"
+      "name": "T型研究を許可",
+      "help": "T型研究は研究キューの停止や効率低下を招く可能性があります。必要な場合のみ有効にしてください。"
     },
     "RemainingCommissions": {
-      "name": "T型科研の残り委託回数",
-      "help": "T型科研"
+      "name": "T型研究の残り委託回数",
+      "help": "保留中のT型研究に必要な残り委託回数です。-1は保留中のT型研究がないことを示します。"
     },
     "PresetFilter": {
       "name": "科研フィルター",
@@ -2308,6 +2323,36 @@
       "help": ""
     }
   },
+  "Secretary": {
+    "_info": {
+      "name": "秘書艦設定",
+      "help": "秘書艦の自動変更および通知設定を行います"
+    },
+    "CustomFilter": {
+      "name": "レアリティフィルター",
+      "help": "レアリティはUR(ultra)、SSR(super_rare)、SR(elite)、R(rare)、N(common)を含みます\n下記にカスタム順序を入力してください\nデフォルト優先度：ultra > super_rare > elite > rare > common"
+    },
+    "LowFavorabilityPriority": {
+      "name": "低好感度優先",
+      "help": "好感度が低い順に秘書艦を選択します"
+    },
+    "BackupEnable": {
+      "name": "予備秘書艦",
+      "help": "秘書艦グループの艦船を予備秘書艦として使用し、優先的に交代します。"
+    },
+    "CheckInterval": {
+      "name": "カスタム確認間隔（時間）",
+      "help": "秘書艦を交代した後、設定した時間ごとに確認します。0 に設定すると好感度に応じて自動計算されます。秘書艦を出撃させて好感度を上げる場合、この項目を設定することでより早く交代できます。"
+    },
+    "Notify": {
+      "name": "秘書艦通知",
+      "help": "OnePush を使用して秘書艦に関する通知を送信します。"
+    },
+    "OnePushConfig": {
+      "name": "OnePush 設定",
+      "help": "秘書艦変更通知用の設定です。空欄の場合はグローバル設定を使用します"
+    }
+  },
   "Awaken": {
     "_info": {
       "name": "認知覚醒",
@@ -2326,7 +2371,7 @@
   },
   "GeneralShop": {
     "_info": {
-      "name": "軍火商（一般ショップ）",
+      "name": "武器商人（雑貨店）",
       "help": ""
     },
     "Enable": {
@@ -2360,7 +2405,7 @@
   },
   "GuildShop": {
     "_info": {
-      "name": "艦隊ショップ",
+      "name": "フリートストア",
       "help": ""
     },
     "Enable": {
@@ -2449,7 +2494,7 @@
       "plane": "艦載機"
     },
     "PR1": {
-      "name": "一期科研設計図選択",
+      "name": "一期研究設計図選択",
       "help": "",
       "neptune": "ネプチューン",
       "monarch": "君主",
@@ -2459,7 +2504,7 @@
       "saintlouis": "サン・ルイ"
     },
     "PR2": {
-      "name": "二期科研設計図選択",
+      "name": "二期研究設計図選択",
       "help": "",
       "seattle": "シアトル",
       "georgia": "ジョージア",
@@ -2467,7 +2512,7 @@
       "gascogne": "ガスコーニュ"
     },
     "PR3": {
-      "name": "三期科研設計図選択",
+      "name": "三期研究設計図選択",
       "help": "",
       "cheshire": "チェシャー",
       "mainz": "マインツ",
@@ -2578,16 +2623,16 @@
       "help": "色彩科研設計図を毎日購入します。色彩科研と金科研の設計図は割引カウントが独立しており、毎日それぞれ2枚無料で入手できます。"
     },
     "ResearchSeries": {
-      "name": "科研期数",
+      "name": "科学研究期間",
       "help": "",
-      "2": "フェーズ II 科研",
-      "3": "第Ⅲ期科研",
-      "4": "第4期科研",
-      "5": "第5期科研",
-      "6": "第6期科研"
+      "2": "フェーズ II 科学研究",
+      "3": "第Ⅲ相科学研究",
+      "4": "科学研究の第 4 段階",
+      "5": "科学研究の第 5 段階",
+      "6": "第6期科学研究"
     },
     "ShipIndex": {
-      "name": "科研船X番を選択",
+      "name": "出荷シリアル番号",
       "help": "左から右に1から数えます",
       "0": "購入しない",
       "1": "1",
@@ -2608,21 +2653,21 @@
   },
   "Shipyard": {
     "_info": {
-      "name": "金科研設計図購入設定",
+      "name": "ゴールド科学研究図面購入設定",
       "help": ""
     },
     "ResearchSeries": {
-      "name": "科研期数",
+      "name": "科学研究期間",
       "help": "",
-      "1": "第1期科研",
-      "2": "フェーズ II 科研",
-      "3": "第Ⅲ期科研",
-      "4": "第4期科研",
-      "5": "第5期科研",
-      "6": "第6期科研"
+      "1": "科学研究の第一段階",
+      "2": "フェーズ II 科学研究",
+      "3": "第Ⅲ相科学研究",
+      "4": "科学研究の第 4 段階",
+      "5": "科学研究の第 5 段階",
+      "6": "第6期科学研究"
     },
     "ShipIndex": {
-      "name": "科研船X番を選択",
+      "name": "出荷シリアル番号",
       "help": "左から右に1から数えます",
       "0": "購入しない",
       "1": "1",
@@ -2643,20 +2688,20 @@
   },
   "Gacha": {
     "_info": {
-      "name": "デイリー建造",
-      "help": "建造でデイリー任務を完了します。毎日軽型プールを1回引くことで資金200を節約できます。"
+      "name": "毎日のカード抽選",
+      "help": "カードを引いて毎日のタスクを完了します。毎日ライトプールを引いて、200 個の物資を入手します。"
     },
     "Pool": {
       "name": "カードプール",
       "help": "",
-      "light": "軽型プール",
-      "heavy": "重装型プール",
-      "special": "特装型プール",
-      "event": "期間限定プール",
-      "wishing_well": "祈願プール"
+      "light": "ライトプール",
+      "heavy": "ヘビープール",
+      "special": "特別なプール",
+      "event": "イベントプール",
+      "wishing_well": "願いのプール"
     },
     "Amount": {
-      "name": "毎日X回建造",
+      "name": "引いたカードの枚数",
       "help": "",
       "1": "1",
       "2": "2",
@@ -2670,17 +2715,17 @@
       "10": "10"
     },
     "UseTicket": {
-      "name": "単回建造券を使用する",
+      "name": "単一の建設チケットを使用する",
       "help": "オープン後、建設クーポンをサポートするプールは、最初に建設クーポンを使用して建設されます。建設クーポンがなく、通常のプールが建設された場合でも、ルービック キューブが使用されます。"
     },
     "UseDrill": {
-      "name": "建造ドリルを使用して建造を完了する",
-      "help": "いいえにすると翌日まで進水を待つことで、ドリルを1つ節約できます。"
+      "name": "ドリルを使用して構築を完了します",
+      "help": "水に入るのを明日まで待ちますか？ドリルビットを欲しがることができますか？"
     }
   },
   "BattlePass": {
     "_info": {
-      "name": "シーズンパス",
+      "name": "マンスリーパス",
       "help": ""
     },
     "Collect": {
@@ -2726,11 +2771,11 @@
   },
   "SupplyPack": {
     "_info": {
-      "name": "お得なパッケージ",
+      "name": "割引ギフトパッケージ",
       "help": ""
     },
     "Collect": {
-      "name": "毎週無料パッケージを購入する",
+      "name": "無料の週刊誌を購入する",
       "help": ""
     },
     "DayOfWeek": {
@@ -2757,7 +2802,7 @@
   },
   "PrivateQuarters": {
     "_info": {
-      "name": "ドルミトリープラン設定",
+      "name": "寮プランの設定",
       "help": ""
     },
     "BuyRoses": {
@@ -2769,8 +2814,8 @@
       "help": "ケーキギフトボックスの購入数は毎週月曜日にリセットされます\n実行するたびに、すべて一度に購入しようとします。ダイヤが不足している場合（ダイヤが210個未満）、購入はキャンセルされ、翌日に延期されます。"
     },
     "TargetInteract": {
-      "name": "毎日のコンディションを消費",
-      "help": "選択した艩娘と対話して今日のコンディションを消費します"
+      "name": "日々のエネルギーをクリアに",
+      "help": "選択した艦娘と対話して今日のエネルギーをクリアしよう"
     },
     "TargetShip": {
       "name": "毎日対話する艦娘を選択してください",
@@ -2972,7 +3017,7 @@
       "help": "キャラクターの立ち絵がHPバーを覆うため、HPが本当に閾値を下回っているか確認するのに時間がかかります。1.0～3.0を推奨します。"
     },
     "OpponentRefreshValue": {
-      "name": "本日対戦相手をX回リフレッシュ済み",
+      "name": "本日の演習対戦相手はX回リフレッシュされました",
       "help": "値は自動的に更新され、0時以降にリセットされます\n対戦相手を手動で更新する場合は、この値を変更する必要があります"
     },
     "OpponentRefreshRecord": {
@@ -2982,11 +3027,11 @@
   },
   "Sos": {
     "_info": {
-      "name": "SOS/海底",
+      "name": "海底地図",
       "help": ""
     },
     "Chapter": {
-      "name": "潜水艦出撃チャプター",
+      "name": "潜水艦攻撃の章",
       "help": "",
       "3": "3",
       "4": "4",
@@ -3004,7 +3049,7 @@
       "help": "1 日 3 回のビーコンサポート"
     },
     "Tier": {
-      "name": "レベルX以上のビーコンを検索",
+      "name": "X より大きいレベルのビーコンを検索する",
       "help": "何度か試しても条件を満たすビーコンが見つからない場合は、ランダムに試してください。"
     }
   },
@@ -3018,8 +3063,8 @@
       "help": "倉庫に入るたびにすべての座標レコーダーを使用する"
     },
     "BuyActionPointLimit": {
-      "name": "行動力をX回購入",
-      "help": "行動力を購入する回数。1回目の購入で燃料1000、行動力100を消費します",
+      "name": "作戦記録をX回購入",
+      "help": "作戦記録の購入最大回数",
       "0": "購入しない",
       "1": "1回（燃料1000、行動力100）",
       "2": "2回（燃料2000、行動力200）",
@@ -3028,7 +3073,7 @@
       "5": "5回（燃料10000、行動力1000）"
     },
     "OilLimit": {
-      "name": "行動力購入時に燃料Xを保留",
+      "name": "作戦記録購入時、燃料Xを保留",
       "help": ""
     },
     "RepairThreshold": {
@@ -3045,7 +3090,7 @@
     },
     "RepairPackThresholdHazard1": {
       "name": "いずれかの船のHPがX以下になったら、修理ボックスを使用して船を修理してください（侵蝕1）。",
-      "help": "「修理ボックスを使用して船を修理する」がオンの場合のみ有効です\n「侵蝕1レベリングPlus」中のみ修理を試みます。\n0.0～1.0"
+      "help": "「修理ボックスを使用して船を修理する」がオンの場合のみ有効です\n「侵蝕1レベリング+」中のみ修理を試みます。\n0.0～1.0"
     },
     "DoRandomMapEvent": {
       "name": "マップ上のランダムイベントを完了する",
@@ -3057,7 +3102,7 @@
     },
     "NotifyOpsiMail": {
       "name": "セイレーン作戦関連情報をプッシュ",
-      "help": "侵蝕1と短猫相接の記録機能を使用する場合には、このオプションを有効にしてください"
+      "help": "侵食1とショートキャットの情報を OnePush で通知します。ランチャー通知は「ランチャー通知」で個別に制御します。情報量が多いため騒がしい場合があります。"
     },
     "LauncherPush": {
       "name": "ランチャー通知",
@@ -3069,7 +3114,7 @@
     },
     "OpsiOnePushConfig": {
       "name": "セイレーン作戦プッシュ通知設定",
-      "help": "セイレーン作戦のプッシュ通知設定。セイレーン作戦プッシュが有効な場合、このオプションが有効なときにのみ通知が送信されます"
+      "help": "「塞壬行動信息獨立推送」功能開啟時設置才生效。Onepushを使用して、侵食1と短毛猫に関する情報を1つプッシュします。設定方法はドキュメントを参照してください：https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/Onepush-configuration-%5BCN%5D"
     },
     "AutoSearchTimeLimit": {
       "name": "自動探索時間制限",
@@ -3102,7 +3147,7 @@
     },
     "EnsureFullyCollected": {
       "name": "毎日200ビーコンデータの収集を保証",
-      "help": "短猫相接の侵蝕等級が低い海域を削除し、資金を節約します"
+      "help": "収集が満了するまで、行動力保留設定を一時的に無視します。同時に「ショートカット接続」をオンにする必要があります。"
     },
     "AutoCollectShip": {
       "name": "新META艦船を自動取得",
@@ -3139,7 +3184,7 @@
   },
   "OpsiExplore": {
     "_info": {
-      "name": "セイレーン作戦開拓Plus",
+      "name": "セイレーン作戦開拓",
       "help": "毎月初めにセイレーン作戦の全海域を開拓します。作戦情報記録装置（燃料5000の道具）の購入は不要です。\nこの機能は空域探索のクールダウンを確保するため、27分ごとに海域をクリアします。\nこの機能を使用する前に以下の条件を満たす必要があります：\n- セイレーン作戦のメインストーリーをクリアし、模擬戦闘＋セイレーン試験場を完了"
     },
     "SpecialRadar": {
@@ -3165,7 +3210,7 @@
   },
   "OpsiShop": {
     "_info": {
-      "name": "セイレーン作戦ショップPlus",
+      "name": "セイレーン作戦ショップ",
       "help": "この機能を使用する前に以下の条件を満たす必要があります：\n- セイレーン作戦のメインストーリーをクリアし、模擬戦＋セイレーン試験場を完了\n- セイレーン作戦開拓ミッションを有効にするか、作戦情報記録装置（燃料5000の道具）を使用します\n- セイレーン作戦メインストーリークリア翌月、港ショップが新バージョンになってから利用可能"
     },
     "PresetFilter": {
@@ -3182,13 +3227,13 @@
       "help": "カスタムフィルターを使用するには「港ショップフィルター」を「カスタム」に設定し、https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/filter_string_cn を参照してください。"
     },
     "DisableBeforeDate": {
-      "name": "毎月X日以前にセイレーン作戦ショップPlusで購入しない",
+      "name": "毎月X日以前にセイレーン作戦ショップで購入しない",
       "help": "指定日の翌日から1日1回セイレーン作戦ショップで購入する\n0は制限なし、毎日購入することを意味します"
     }
   },
   "OpsiVoucher": {
     "_info": {
-      "name": "特別交換ショップ（毎月ホワイトチケットショップ）",
+      "name": "特別引換店舗（月額ホワイトチケットストア）",
       "help": "月額ホワイトチケットストアを購入する\nこの機能を使用する前に、次の条件を満たす必要があります。\n- セイレーン作戦のメインストーリーをクリアし、模擬戦闘 + セイレーン試験場を完了"
     },
     "Filter": {
@@ -3198,11 +3243,11 @@
   },
   "OpsiDaily": {
     "_info": {
-      "name": "セイレーン作戦デイリーPlus",
+      "name": "セイレーン作戦デイリー",
       "help": "この機能を使用する前に、次の条件を満たす必要があります。\n- 大きな世界のメインストーリーをクリアし、模擬戦＋セイレーン試験場を完了\n- セイレーン作戦開拓ミッションを有効にするか、作戦情報記録装置（燃料5000の道具）を使用します"
     },
     "DoMission": {
-      "name": "セイレーン作戦デイリーPlusを実行",
+      "name": "セイレーン作戦デイリーを実行",
       "help": "毎日港で受け取り、毎日すべて完了します"
     },
     "UseTuningSample": {
@@ -3210,7 +3255,7 @@
       "help": "6 つのパフォーマンス サンプルすべてと強力なパフォーマンス サンプルを使用する"
     },
     "SkipSirenResearchMission": {
-      "name": "セイレーン研究任務をスキップ",
+      "name": "セイレーンの研究クエストをやっていない",
       "help": "有効にすると、「Siren Research・I」と「Siren Research・II」の 2 つのミッションがスキップされます。\nセイレーン調査ミッションで黄色のコインを使用して紫色のコインと交換します"
     },
     "KeepMissionZone": {
@@ -3348,7 +3393,7 @@
     },
     "OperationCoinsPreserve": {
       "name": "戦闘補給品引換券を X 個保持する",
-      "help": "短猫相接の侵蝕等級が低い海域を削除し、資金を節約します"
+      "help": "戦闘供給バウチャーが X より低い場合は、短い cat 接続を実行します。変更することはお勧めできません。"
     },
     "MinimumActionPointReserve": {
       "name": "X ポイントのアクションを保持する",
@@ -3406,7 +3451,7 @@
   },
   "OpsiCheckLeveling": {
     "_info": {
-      "name": "セイレーン作戦艦隊経験値チェック",
+      "name": "大世界艦隊体験テスト",
       "help": "出撃艦隊の全艦が経験値を積んでいるか確認し、積んでいればプッシュメッセージを送信する\nまず最初に設定で「エラープッシュ設定」を構成する必要があります"
     },
     "TargetLevel": {
@@ -3414,7 +3459,7 @@
       "help": "すべての船が満たされたレベルに上昇するのに十分な経験を蓄積すると、メッセージ プッシュがトリガーされます。"
     },
     "LastRun": {
-      "name": "前回経験値チェック時間（自動記録）",
+      "name": "エクスペリエンスが最後にチェックされた時間 (自動的に記録されます)",
       "help": "タスクが繰り返し実行されるのを防ぐために、最後のチェック時刻が記録されます。チェック間隔は 1 日です。この値は自動的に記録されるため、通常は手動で変更する必要はありません。"
     },
     "CheckInterval": {
@@ -3447,6 +3492,12 @@
       "True": "有効",
       "False": "無効"
     },
+    "AnyShipReached": {
+      "name": "任意の艦船が目標レベル到達時に変更",
+      "help": "有効にすると、確認対象の任意の艦船が目標レベルに到達した時に自動編成を実行します。\n無効の場合、確認対象のすべての艦船が目標レベルに到達する必要があります",
+      "True": "有効",
+      "False": "無効"
+    },
     "CooldownHours": {
       "name": "クールダウン時間（時間）",
       "help": "自動編成後のクールダウン時間。頻繁なトリガーを回避します。",
@@ -3462,7 +3513,7 @@
   },
   "OpsiScheduling": {
     "_info": {
-      "name": "スマートスケジューリングPlus",
+      "name": "インテリジェントスケジューリング",
       "help": "セイレーン作戦のインテリジェントスケジューリング機能は、侵蝕1レベリングとイエローコイン補充タスク間の切り替えを調整します。\n有効にすると、さまざまなタスクが自動的に切り替わり、ゴールド コインとモビリティに基づいてプッシュ通知が送信されます。\n\n悲しいかな、オリジナルのいくつかの絶対確実な制限が解除されました。パラメータを慎重に設定してください。"
     },
     "UseSmartSchedulingOperationCoinsPreserve": {
@@ -3476,7 +3527,7 @@
       "help": "戦闘補給バウチャーが X より低い場合は、黄色のコイン補充タスクを実行します。これを変更することはお勧めできません。"
     },
     "ActionPointPreserve": {
-      "name": "短猫相接 行動力をXポイント保留",
+      "name": "ショートキャットは X ポイントの可動性を接続して保持します",
       "help": "モビリティがX以下になると停止し、モビリティボックスが自動的に開きます。"
     },
     "OperationCoinsReturnThreshold": {
@@ -3484,25 +3535,25 @@
       "help": "黄色のコイン獲得ミッション中に、戦闘補給券を合計 X 枚獲得 (増加) し、レベルを上げるために侵蝕 1 に戻ります。"
     },
     "EnableMeowfficerFarming": {
-      "name": "短猫相接を有効にする",
+      "name": "ショートキャット接続を有効にする",
       "help": "インテリジェント スケジューリングでショート キャット接続タスクが黄色のコインを補充できるようにするかどうか",
       "True": "有効",
       "False": "無効"
     },
     "EnableObscure": {
-      "name": "隠秘海域を有効にする",
+      "name": "未知の海を可能にする",
       "help": "黄色のコインを補充するためにインテリジェントなスケジューリングでHidden Seaミッションを有効にするかどうか",
       "True": "有効",
       "False": "無効"
     },
     "EnableAbyssal": {
-      "name": "深淵座標を有効にする",
+      "name": "深海を有効にする",
       "help": "イエローコインを補充するためのインテリジェントなスケジューリングで深海ミッションを有効にするかどうか",
       "True": "有効",
       "False": "無効"
     },
     "EnableStronghold": {
-      "name": "セイレーン要塞を有効にする",
+      "name": "セイレン要塞を有効にする",
       "help": "黄色のコインを補充するためにインテリジェント スケジューリングで Siren Fortress タスクを有効にするかどうか",
       "True": "有効",
       "False": "無効"
@@ -3530,6 +3581,21 @@
       "help": "OpsiScheduling.MonthEndShopPurchase.help",
       "True": "True",
       "False": "False"
+    },
+    "BuyActionPointMode": {
+      "name": "行動力購入モード",
+      "help": "行動力購入専用モード。既存のコイン/行動力スケジューリングと排他。有効化すると石油で行動力を購入し対応任務を実行。事前に「大世界一般設定 → 行動力X回購入」で週間購入上限を設定してください。",
+      "off": "オフ",
+      "hazard1_leveling": "危険1練級",
+      "meowfficer_farming": "指揮猫牧場"
+    },
+    "BuyActionPointUpperThreshold": {
+      "name": "行動力購入上限閾値",
+      "help": "「指揮猫牧場」モードのみ使用。現在行動力がこの値を超えると購入をスキップし海域任務を直接実行。デフォルト200（大世界行動力自然回復上限）。"
+    },
+    "BuyActionPointLowerThreshold": {
+      "name": "行動力購入下限閾値",
+      "help": "「指揮猫牧場」モードのみ使用。現在行動力がこの値を下回ると海域任務の実行を停止し購入ステップに戻る。デフォルト100。"
     }
   },
   "OpsiPreventActionPointOverflow": {
@@ -3542,7 +3608,7 @@
       "help": "専用処理があるスマートスケジューリングを推奨します",
       "OpsiScheduling": "スマートスケジューリング（推奨）",
       "OpsiHazard1Leveling": "侵蝕1レベリング",
-      "OpsiMeowfficerFarming": "短猫相接"
+      "OpsiMeowfficerFarming": "指揮ニャ周回"
     },
     "ActionPointUpperbound": {
       "name": "現在行動力上限",
@@ -3582,7 +3648,7 @@
     },
     "WorkerFilter": {
       "name": "農場作業員フィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "MinFarm": {
       "name": "作物在庫閾値",
@@ -3613,7 +3679,7 @@
     },
     "WorkerFilter": {
       "name": "果樹園作業員フィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "MinOrchard": {
       "name": "果物在庫閾値",
@@ -3650,7 +3716,7 @@
     },
     "WorkerFilter": {
       "name": "苗床作業員フィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "MinNursery": {
       "name": "苗床作物在庫閾値",
@@ -3679,7 +3745,7 @@
     },
     "ChickenFilter": {
       "name": "鶏作業員フィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "MinPork": {
       "name": "豚肉在庫閾値",
@@ -3687,7 +3753,7 @@
     },
     "PigFilter": {
       "name": "豚作業員フィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "Milk": {
       "name": "牛を飼育",
@@ -3695,7 +3761,7 @@
     },
     "RancherFilter": {
       "name": "キャラクターフィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "Wool": {
       "name": "羊を飼育",
@@ -3703,7 +3769,7 @@
     },
     "WoolWorkerFilter": {
       "name": "羊作業員フィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     }
   },
   "IslandFishery": {
@@ -3760,7 +3826,7 @@
     },
     "RancherFilter": {
       "name": "キャラクターフィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     }
   },
   "IslandMine": {
@@ -3769,7 +3835,7 @@
       "help": ""
     },
     "Positions": {
-      "name": "鉱夫をX人配置",
+      "name": "ポジション数",
       "help": "",
       "1": "1",
       "2": "2",
@@ -3787,7 +3853,7 @@
     },
     "WorkerFilter": {
       "name": "鉱山作業員フィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "MinCopper": {
       "name": "銅鉱石最低在庫",
@@ -3816,7 +3882,7 @@
       "help": ""
     },
     "Positions": {
-      "name": "木こりをX人配置",
+      "name": "ポジション数",
       "help": "",
       "1": "1",
       "2": "2",
@@ -3834,7 +3900,7 @@
     },
     "WorkerFilter": {
       "name": "林場作業員フィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "MinElegant": {
       "name": "エレガント木材最低在庫",
@@ -3856,7 +3922,7 @@
     },
     "WorkerFilter": {
       "name": "採集キャラクターフィルター",
-      "help": ">で接続。最大3人まで指定でき、採集スロット1～3に対応します。\n>で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデイリー採集では WorkerJuu を選択できません。入力されている場合は自動で無視します。\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合、そのスロットは既存の採集ロジックにフォールバックします。"
+      "help": ">で接続。最大3人まで指定でき、採集スロット1～3に対応します。\n>で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデイリー採集では WorkerJuu を選択できません。入力されている場合は自動で無視します。\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合、そのスロットは既存の採集ロジックにフォールバックします。"
     }
   },
   "IslandRestaurant": {
@@ -3865,14 +3931,14 @@
       "help": "メニューは1～8の順に生産されます。生産目標はメニューX数量オプションで、前の項目が完全に満たされてから次の項目が実行されます。後続の項目は実行時にそれ以前の項目の達成に影響しません。\nメニュー1-8の涼拌双筍と筍と海老の炒め物は現在の季節に応じて対応する季節メニューに自動切替されます。"
     },
     "PostNumber": {
-      "name": "シェフをX人配置",
+      "name": "ポジション数",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "シェフフィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "DoubleBambooShoots": {
       "name": "季節料理を優先生産",
@@ -3898,7 +3964,7 @@
       "persimmon_cake": "柿のケーキ"
     },
     "MealNumber1": {
-      "name": "メニュー1をX人前生産",
+      "name": "メニュー1数量",
       "help": ""
     },
     "Meal2": {
@@ -3921,7 +3987,7 @@
       "persimmon_cake": "柿のケーキ"
     },
     "MealNumber2": {
-      "name": "メニュー2をX人前生産",
+      "name": "メニュー2数量",
       "help": ""
     },
     "Meal3": {
@@ -3944,7 +4010,7 @@
       "persimmon_cake": "柿のケーキ"
     },
     "MealNumber3": {
-      "name": "メニュー3をX人前生産",
+      "name": "メニュー3数量",
       "help": ""
     },
     "Meal4": {
@@ -3967,7 +4033,7 @@
       "persimmon_cake": "柿のケーキ"
     },
     "MealNumber4": {
-      "name": "メニュー4をX人前生産",
+      "name": "メニュー4数量",
       "help": ""
     },
     "Meal5": {
@@ -3990,7 +4056,7 @@
       "persimmon_cake": "柿のケーキ"
     },
     "MealNumber5": {
-      "name": "メニュー5をX人前生産",
+      "name": "メニュー5数量",
       "help": ""
     },
     "Meal6": {
@@ -4013,7 +4079,7 @@
       "persimmon_cake": "柿のケーキ"
     },
     "MealNumber6": {
-      "name": "メニュー6をX人前生産",
+      "name": "メニュー6数量",
       "help": ""
     },
     "Meal7": {
@@ -4036,7 +4102,7 @@
       "persimmon_cake": "柿のケーキ"
     },
     "MealNumber7": {
-      "name": "メニュー7をX人前生産",
+      "name": "メニュー7数量",
       "help": ""
     },
     "Meal8": {
@@ -4059,7 +4125,7 @@
       "persimmon_cake": "柿のケーキ"
     },
     "MealNumber8": {
-      "name": "メニュー8をX人前生産",
+      "name": "メニュー8数量",
       "help": ""
     }
   },
@@ -4091,17 +4157,17 @@
   "IslandTeahouse": {
     "_info": {
       "name": "白熊ドリンク",
-      "help": "メニューは1～8の順に生産されます。生産目標はメニューX数量オプションで、前の項目が完全に満たされてから次の項目が実行されます。後続の項目は実行時にそれ以前の項目の達成に影響しません。\nハニー製品は自動生産に対応しています。蜂蜜の在庫が十分であることを確認してください。\nメニューの春花茶とフレッシュパイナップルジュースは現在の季節に応じて対応する季節メニューに自動切替されます。"
+      "help": "メニューは1～8の順に生産されます。生産目標はメニューX数量オプションで、前の項目が完全に満たされてから次の項目が実行されます。後続の項目は実行時にそれ以前の項目の達成に影響しません。\nハニー製品は手動で作成してください。\nメニューの春花茶とフレッシュパイナップルジュースは現在の季節に応じて対応する季節メニューに自動切替されます。"
     },
     "PostNumber": {
-      "name": "バーテンダーをX人配置",
+      "name": "ポジション数",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "シェフフィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "Seasonal": {
       "name": "季節ドリンクを優先生産",
@@ -4125,7 +4191,7 @@
       "carrot_pear_juice": "ニンジン秋梨ジュース"
     },
     "MealNumber1": {
-      "name": "メニュー1をX人前生産",
+      "name": "メニュー1数量",
       "help": ""
     },
     "Meal2": {
@@ -4146,7 +4212,7 @@
       "carrot_pear_juice": "ニンジン秋梨ジュース"
     },
     "MealNumber2": {
-      "name": "メニュー2をX人前生産",
+      "name": "メニュー2数量",
       "help": ""
     },
     "Meal3": {
@@ -4167,7 +4233,7 @@
       "carrot_pear_juice": "ニンジン秋梨ジュース"
     },
     "MealNumber3": {
-      "name": "メニュー3をX人前生産",
+      "name": "メニュー3数量",
       "help": ""
     },
     "Meal4": {
@@ -4188,7 +4254,7 @@
       "carrot_pear_juice": "ニンジン秋梨ジュース"
     },
     "MealNumber4": {
-      "name": "メニュー4をX人前生産",
+      "name": "メニュー4数量",
       "help": ""
     },
     "Meal5": {
@@ -4209,7 +4275,7 @@
       "carrot_pear_juice": "ニンジン秋梨ジュース"
     },
     "MealNumber5": {
-      "name": "メニュー5をX人前生産",
+      "name": "メニュー5数量",
       "help": ""
     },
     "Meal6": {
@@ -4230,7 +4296,7 @@
       "carrot_pear_juice": "ニンジン秋梨ジュース"
     },
     "MealNumber6": {
-      "name": "メニュー6をX人前生産",
+      "name": "メニュー6数量",
       "help": ""
     },
     "Meal7": {
@@ -4251,7 +4317,7 @@
       "carrot_pear_juice": "ニンジン秋梨ジュース"
     },
     "MealNumber7": {
-      "name": "メニュー7をX人前生産",
+      "name": "メニュー7数量",
       "help": ""
     },
     "Meal8": {
@@ -4272,7 +4338,7 @@
       "carrot_pear_juice": "ニンジン秋梨ジュース"
     },
     "MealNumber8": {
-      "name": "メニュー8をX人前生産",
+      "name": "メニュー8数量",
       "help": ""
     }
   },
@@ -4305,14 +4371,14 @@
       "help": "メニューは1～8の順に生産されます。生産目標はメニューX数量オプションで、前の項目が完全に満たされてから次の項目が実行されます。後続の項目は実行時にそれ以前の項目の達成に影響しません。"
     },
     "PostNumber": {
-      "name": "グリルシェフをX人配置",
+      "name": "ポジション数",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "シェフフィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "Meal1": {
       "name": "メニュー1",
@@ -4328,7 +4394,7 @@
       "double_energy": "エネルギーダブルセット"
     },
     "MealNumber1": {
-      "name": "メニュー1をX人前生産",
+      "name": "メニュー1数量",
       "help": ""
     },
     "Meal2": {
@@ -4345,7 +4411,7 @@
       "double_energy": "エネルギーダブルセット"
     },
     "MealNumber2": {
-      "name": "メニュー2をX人前生産",
+      "name": "メニュー2数量",
       "help": ""
     },
     "Meal3": {
@@ -4362,7 +4428,7 @@
       "double_energy": "エネルギーダブルセット"
     },
     "MealNumber3": {
-      "name": "メニュー3をX人前生産",
+      "name": "メニュー3数量",
       "help": ""
     },
     "Meal4": {
@@ -4379,7 +4445,7 @@
       "double_energy": "エネルギーダブルセット"
     },
     "MealNumber4": {
-      "name": "メニュー4をX人前生産",
+      "name": "メニュー4数量",
       "help": ""
     },
     "Meal5": {
@@ -4396,7 +4462,7 @@
       "double_energy": "エネルギーダブルセット"
     },
     "MealNumber5": {
-      "name": "メニュー5をX人前生産",
+      "name": "メニュー5数量",
       "help": ""
     },
     "Meal6": {
@@ -4413,7 +4479,7 @@
       "double_energy": "エネルギーダブルセット"
     },
     "MealNumber6": {
-      "name": "メニュー6をX人前生産",
+      "name": "メニュー6数量",
       "help": ""
     },
     "Meal7": {
@@ -4430,7 +4496,7 @@
       "double_energy": "エネルギーダブルセット"
     },
     "MealNumber7": {
-      "name": "メニュー7をX人前生産",
+      "name": "メニュー7数量",
       "help": ""
     },
     "Meal8": {
@@ -4447,7 +4513,7 @@
       "double_energy": "エネルギーダブルセット"
     },
     "MealNumber8": {
-      "name": "メニュー8をX人前生産",
+      "name": "メニュー8数量",
       "help": ""
     }
   },
@@ -4476,14 +4542,14 @@
       "help": "メニューは1～8の順に生産されます。生産目標はメニューX数量オプションで、前の項目が完全に満たされてから次の項目が実行されます。後続の項目は実行時にそれ以前の項目の達成に影響しません。"
     },
     "PostNumber": {
-      "name": "クックをX人配置",
+      "name": "ポジション数",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "シェフフィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "Meal1": {
       "name": "メニュー1",
@@ -4501,7 +4567,7 @@
       "seafood_rice": "シーフードライス"
     },
     "MealNumber1": {
-      "name": "メニュー1をX人前生産",
+      "name": "メニュー1数量",
       "help": ""
     },
     "Meal2": {
@@ -4520,7 +4586,7 @@
       "seafood_rice": "シーフードライス"
     },
     "MealNumber2": {
-      "name": "メニュー2をX人前生産",
+      "name": "メニュー2数量",
       "help": ""
     },
     "Meal3": {
@@ -4539,7 +4605,7 @@
       "seafood_rice": "シーフードライス"
     },
     "MealNumber3": {
-      "name": "メニュー3をX人前生産",
+      "name": "メニュー3数量",
       "help": ""
     },
     "Meal4": {
@@ -4558,7 +4624,7 @@
       "seafood_rice": "シーフードライス"
     },
     "MealNumber4": {
-      "name": "メニュー4をX人前生産",
+      "name": "メニュー4数量",
       "help": ""
     },
     "Meal5": {
@@ -4577,7 +4643,7 @@
       "seafood_rice": "シーフードライス"
     },
     "MealNumber5": {
-      "name": "メニュー5をX人前生産",
+      "name": "メニュー5数量",
       "help": ""
     },
     "Meal6": {
@@ -4596,7 +4662,7 @@
       "seafood_rice": "シーフードライス"
     },
     "MealNumber6": {
-      "name": "メニュー6をX人前生産",
+      "name": "メニュー6数量",
       "help": ""
     },
     "Meal7": {
@@ -4615,7 +4681,7 @@
       "seafood_rice": "シーフードライス"
     },
     "MealNumber7": {
-      "name": "メニュー7をX人前生産",
+      "name": "メニュー7数量",
       "help": ""
     },
     "Meal8": {
@@ -4634,7 +4700,7 @@
       "seafood_rice": "シーフードライス"
     },
     "MealNumber8": {
-      "name": "メニュー8をX人前生産",
+      "name": "メニュー8数量",
       "help": ""
     }
   },
@@ -4665,14 +4731,14 @@
       "help": "メニューは1～8の順に生産されます。生産目標はメニューX数量オプションで、前の項目が完全に満たされてから次の項目が実行されます。後続の項目は実行時にそれ以前の項目の達成に影響しません。"
     },
     "PostNumber": {
-      "name": "バリスタをX人配置",
+      "name": "ポジション数",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "シェフフィルター",
-      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune > DaVinci\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
+      "help": ">で接続。例：ChaoHo > NewJersey > Amagi_chan\nSaratoga > Akashi > Tashkent > YingSwei\nLeMalin > Unicorn > Shimakaze > Cheshire\nChenHai > WilliamDPorter\nHelena > Friedrich > Atago\nYixian > August > Eugen > Hood > Javelin > Laffey > Explorer > Navigator > OceanCrosser > FeiYun > Takao > Anchorage > Belfast > ChangFeng > Mogador > RoyalFortune\nデフォルト順の先頭2行のみ認識します。指定キャラクターが使用できない場合は WorkerJuu にフォールバックします。"
     },
     "Friedrich": {
       "name": "フリードリヒ",
@@ -4693,7 +4759,7 @@
       "fruity_fruitier": "フルーティーフルーティエ"
     },
     "MealNumber1": {
-      "name": "メニュー1をX人前生産",
+      "name": "メニュー1数量",
       "help": ""
     },
     "Meal2": {
@@ -4711,7 +4777,7 @@
       "fruity_fruitier": "フルーティーフルーティエ"
     },
     "MealNumber2": {
-      "name": "メニュー2をX人前生産",
+      "name": "メニュー2数量",
       "help": ""
     },
     "Meal3": {
@@ -4729,7 +4795,7 @@
       "fruity_fruitier": "フルーティーフルーティエ"
     },
     "MealNumber3": {
-      "name": "メニュー3をX人前生産",
+      "name": "メニュー3数量",
       "help": ""
     },
     "Meal4": {
@@ -4747,7 +4813,7 @@
       "fruity_fruitier": "フルーティーフルーティエ"
     },
     "MealNumber4": {
-      "name": "メニュー4をX人前生産",
+      "name": "メニュー4数量",
       "help": ""
     },
     "Meal5": {
@@ -4765,7 +4831,7 @@
       "fruity_fruitier": "フルーティーフルーティエ"
     },
     "MealNumber5": {
-      "name": "メニュー5をX人前生産",
+      "name": "メニュー5数量",
       "help": ""
     },
     "Meal6": {
@@ -4783,7 +4849,7 @@
       "fruity_fruitier": "フルーティーフルーティエ"
     },
     "MealNumber6": {
-      "name": "メニュー6をX人前生産",
+      "name": "メニュー6数量",
       "help": ""
     },
     "Meal7": {
@@ -4801,7 +4867,7 @@
       "fruity_fruitier": "フルーティーフルーティエ"
     },
     "MealNumber7": {
-      "name": "メニュー7をX人前生産",
+      "name": "メニュー7数量",
       "help": ""
     },
     "Meal8": {
@@ -4819,7 +4885,7 @@
       "fruity_fruitier": "フルーティーフルーティエ"
     },
     "MealNumber8": {
-      "name": "メニュー8をX人前生産",
+      "name": "メニュー8数量",
       "help": ""
     }
   },
@@ -5011,7 +5077,7 @@
       "False": "無効"
     },
     "SeasonalThreshold": {
-      "name": "季節限定アイテムがX以下で置換",
+      "name": "季節置き換え閾値",
       "help": "在庫がこの数値を下回ると置き換えを実行"
     }
   },
@@ -5056,8 +5122,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "ChangFeng",
       "Mogador": "Mogador",
-      "RoyalFortune": "RoyalFortune",
-      "DaVinci": "DaVinci"
+      "RoyalFortune": "RoyalFortune"
     },
     "Char2": {
       "name": "キャラクター2",
@@ -5095,8 +5160,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "ChangFeng",
       "Mogador": "Mogador",
-      "RoyalFortune": "RoyalFortune",
-      "DaVinci": "DaVinci"
+      "RoyalFortune": "RoyalFortune"
     },
     "Product1": {
       "name": "メニュー1",
@@ -5222,8 +5286,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "ChangFeng",
       "Mogador": "Mogador",
-      "RoyalFortune": "RoyalFortune",
-      "DaVinci": "DaVinci"
+      "RoyalFortune": "RoyalFortune"
     },
     "Char2": {
       "name": "キャラクター2",
@@ -5261,8 +5324,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "ChangFeng",
       "Mogador": "Mogador",
-      "RoyalFortune": "RoyalFortune",
-      "DaVinci": "DaVinci"
+      "RoyalFortune": "RoyalFortune"
     },
     "Product1": {
       "name": "メニュー1",
@@ -5400,8 +5462,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "ChangFeng",
       "Mogador": "Mogador",
-      "RoyalFortune": "RoyalFortune",
-      "DaVinci": "DaVinci"
+      "RoyalFortune": "RoyalFortune"
     },
     "Char2": {
       "name": "キャラクター2",
@@ -5439,8 +5500,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "ChangFeng",
       "Mogador": "Mogador",
-      "RoyalFortune": "RoyalFortune",
-      "DaVinci": "DaVinci"
+      "RoyalFortune": "RoyalFortune"
     },
     "Product1": {
       "name": "メニュー1",
@@ -5538,8 +5598,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "ChangFeng",
       "Mogador": "Mogador",
-      "RoyalFortune": "RoyalFortune",
-      "DaVinci": "DaVinci"
+      "RoyalFortune": "RoyalFortune"
     },
     "Char2": {
       "name": "キャラクター2",
@@ -5577,8 +5636,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "ChangFeng",
       "Mogador": "Mogador",
-      "RoyalFortune": "RoyalFortune",
-      "DaVinci": "DaVinci"
+      "RoyalFortune": "RoyalFortune"
     },
     "Product1": {
       "name": "商品1",
@@ -5681,8 +5739,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "ChangFeng",
       "Mogador": "Mogador",
-      "RoyalFortune": "RoyalFortune",
-      "DaVinci": "DaVinci"
+      "RoyalFortune": "RoyalFortune"
     },
     "Char2": {
       "name": "キャラクター2",
@@ -5720,8 +5777,7 @@
       "Belfast": "Belfast",
       "ChangFeng": "ChangFeng",
       "Mogador": "Mogador",
-      "RoyalFortune": "RoyalFortune",
-      "DaVinci": "DaVinci"
+      "RoyalFortune": "RoyalFortune"
     },
     "Product1": {
       "name": "商品1",
@@ -5869,7 +5925,7 @@
       "help": "現在の骨組み: ドック、先頭艦、クイック変更、装備中フィルター、仮の装備ロジック、次の艦。"
     },
     "ShipLimit": {
-      "name": "最初のX隻を処理",
+      "name": "処理する艦船数の上限",
       "help": "0 は次の艦船が見つからなくなるまで処理します。デバッグ時は 1 など小さい値を指定してください。"
     },
     "EnableSlot1": {
@@ -5909,7 +5965,7 @@
       "help": "どちらのスクリーンショット スキームと制御スキームが速いかをテストします。速度はエミュレータとコンピュータの構成によって異なります。\nテストが完了したら、「AzurPilot」-「シミュレーター設定」で最速のスクリーンショットと制御スキームを選択します。"
     },
     "DeviceType": {
-      "name": "デバイスタイプを選択",
+      "name": "デバイスの種類",
       "help": "",
       "emulator": "エミュレータ",
       "plone_cloud_with_adb": "クラウド携帯電話は公衆網ADBを搭載",

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -1,15 +1,15 @@
 {
   "Menu": {
     "Alas": {
-      "name": "智慧港区Plus",
+      "name": "智慧港区+",
       "help": ""
     },
     "Farm": {
-      "name": "出击Plus",
+      "name": "出击+",
       "help": ""
     },
     "Event": {
-      "name": "活动Plus",
+      "name": "活动+",
       "help": ""
     },
     "EventDaily": {
@@ -25,7 +25,7 @@
       "help": ""
     },
     "Opsi": {
-      "name": "大世界Plus",
+      "name": "大世界+",
       "help": ""
     },
     "Island": {
@@ -37,7 +37,7 @@
       "help": ""
     },
     "Tool": {
-      "name": "工具Plus",
+      "name": "工具+",
       "help": ""
     }
   },
@@ -55,23 +55,23 @@
       "help": ""
     },
     "Main": {
-      "name": "主线图-1Plus",
+      "name": "主线图-1+",
       "help": ""
     },
     "Main2": {
-      "name": "主线图-2Plus",
+      "name": "主线图-2+",
       "help": ""
     },
     "Main3": {
-      "name": "主线图-3Plus",
+      "name": "主线图-3+",
       "help": ""
     },
     "GemsFarming": {
-      "name": "紧急委托Plus",
+      "name": "紧急委托+",
       "help": ""
     },
     "ThreeOilLowCost": {
-      "name": "三油低耗Plus",
+      "name": "三油低耗+",
       "help": "使用三油低耗阵容进行战斗，在旗舰达到32级时自动更换旗舰并退役。"
     },
     "Ambush11": {
@@ -83,23 +83,23 @@
       "help": ""
     },
     "Event": {
-      "name": "活动图-1Plus",
+      "name": "活动图-1+",
       "help": ""
     },
     "Event2": {
-      "name": "活动图-2Plus",
+      "name": "活动图-2+",
       "help": ""
     },
     "Event3": {
-      "name": "活动图-3Plus",
+      "name": "活动图-3+",
       "help": ""
     },
     "Raid": {
-      "name": "共斗活动Plus",
+      "name": "共斗活动+",
       "help": ""
     },
     "RaidScuttle": {
-      "name": "共斗沉船Plus",
+      "name": "共斗沉船+",
       "help": ""
     },
     "Hospital": {
@@ -186,6 +186,10 @@
       "name": "认知觉醒",
       "help": ""
     },
+    "Secretary": {
+      "name": "秘书舰",
+      "help": "自动检测秘书舰好感度，达到设定值后自动更换秘书舰"
+    },
     "Daily": {
       "name": "每日任务",
       "help": ""
@@ -239,11 +243,11 @@
       "help": ""
     },
     "OpsiExplore": {
-      "name": "每月开荒Plus",
+      "name": "每月开荒+",
       "help": ""
     },
     "OpsiShop": {
-      "name": "大世界商店Plus",
+      "name": "大世界商店+",
       "help": ""
     },
     "OpsiVoucher": {
@@ -251,7 +255,7 @@
       "help": ""
     },
     "OpsiDaily": {
-      "name": "大世界每日Plus",
+      "name": "大世界每日+",
       "help": ""
     },
     "OpsiObscure": {
@@ -264,7 +268,7 @@
     },
     "OpsiArchive": {
       "name": "档案坐标",
-      "help": "从白票商店购买档案坐标并运行，档案海域不消耗行动力\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒Plus任务或使用战役信息记录仪（5000油道具）"
+      "help": "从白票商店购买档案坐标并运行，档案海域不消耗行动力\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒+任务或使用战役信息记录仪（5000油道具）"
     },
     "OpsiStronghold": {
       "name": "塞壬要塞",
@@ -283,8 +287,8 @@
       "help": "此功能开放了大量配置，默认配置已经可以满足大部分需求，配置前请确保你已了解侵蚀1的基础原理，后果自负"
     },
     "OpsiScheduling": {
-      "name": "智能调度Plus",
-      "help": "大世界智能调度Plus功能，开启后无需重复开启侵蚀1等任务，智能调度Plus将全部接管"
+      "name": "智能调度+",
+      "help": "大世界智能调度+功能，开启后无需重复开启侵蚀1等任务，智能调度+将全部接管"
     },
     "OpsiPreventActionPointOverflow": {
       "name": "防止行动力溢出",
@@ -292,11 +296,11 @@
     },
     "OpsiCrossMonth": {
       "name": "跨月每日",
-      "help": "    AzurPilot将在大世界跨月重置之前10分钟进入大世界，等待大世界重置但不退出大世界，然后完成新一天的大世界每日Plus、隐秘海域、深渊坐标和耄耋相接，以获得额外的金菜。运行大世界每日Plus时，按\"大世界每日Plus\"任务设置运行，其余同理。\n    重要：AzurPilot等待跨月期间，请不要操作游戏。"
+      "help": "    AzurPilot将在大世界跨月重置之前10分钟进入大世界，等待大世界重置但不退出大世界，然后完成新一天的大世界每日+、隐秘海域、深渊坐标和耄耋相接，以获得额外的金菜。运行大世界每日+时，按\"大世界每日+\"任务设置运行，其余同理。\n    重要：AzurPilot等待跨月期间，请不要操作游戏。"
     },
     "OpsiSimulator": {
       "name": "大世界模拟器 Alpha",
-      "help": "使用蒙特卡洛算法估算在当前状态下持续进行侵蚀循环一段时间后的结果，该功能不会影响AzurPilot正常运行\n模型所用参数均取自AzurPilot配置和统计，请确保正确配置了智能调度Plus等大世界设置\n目前为测试版本，结果不具备太多参考价值\n关于奸商售卖行动力的模型无足够充分的证据支撑。具体来讲，这里认为奸商卖6种行动力箱子满足超几何分布X~H(6,6,24)\n关于坠机：这里坠机是指整个模拟流程中行动力低于智能调度Plus中设置的行动力保留阈值至少一次。若低于该阈值，模拟器将停止侵蚀循环等待行动力自然回复"
+      "help": "使用蒙特卡洛算法估算在当前状态下持续进行侵蚀循环一段时间后的结果，该功能不会影响AzurPilot正常运行\n模型所用参数均取自AzurPilot配置和统计，请确保正确配置了智能调度+等大世界设置\n目前为测试版本，结果不具备太多参考价值\n关于奸商售卖行动力的模型无足够充分的证据支撑。具体来讲，这里认为奸商卖6种行动力箱子满足超几何分布X~H(6,6,24)\n关于坠机：这里坠机是指整个模拟流程中行动力低于智能调度+中设置的行动力保留阈值至少一次。若低于该阈值，模拟器将停止侵蚀循环等待行动力自然回复"
     },
     "IslandPlan": {
       "name": "全局配置",
@@ -571,7 +575,6 @@
       "en-3": "[EN] Washington",
       "en-4": "[EN] Amagi",
       "en-5": "[EN] Little Enterprise",
-      "en-6": "[EN] Belfast",
       "jp-0": "[JP] ブレスト",
       "jp-1": "[JP] 横須賀",
       "jp-2": "[JP] 佐世保",
@@ -589,15 +592,10 @@
       "jp-14": "[JP] キール",
       "jp-15": "[JP] 若松",
       "jp-16": "[JP] オデッサ",
-      "jp-17": "[JP] スイートバン",
-      "tw-0": "[TW] 珍珠港",
-      "tw-1": "[TW] 珊瑚海",
-      "tw-2": "[TW] 中途島",
-      "tw-3": "[TW] 瓜達康納爾",
-      "tw-4": "[TW] 雷伊泰灣"
+      "jp-17": "[JP] スイートバン"
     },
     "ScreenshotMethod": {
-      "name": "选择截图方案",
+      "name": "模拟器截图方案",
       "help": "使用自动选择时，将执行一次性能测试并自动更改为最快的截图方案\n一般情况下的速度: DroidCast_raw >> aScreenCap_nc > ADB_nc >>> aScreenCap > uiautomator2 ~= ADB\n运行 工具 - 性能测试 以寻找最快的方案",
       "auto": "自动选择最快的",
       "ADB": "ADB",
@@ -611,7 +609,7 @@
       "ldopengl": "ldopengl"
     },
     "ControlMethod": {
-      "name": "选择控制方案",
+      "name": "模拟器控制方案",
       "help": "速度: minitouch > Hermit >>> uiautomator2 ~= ADB\n建议选minitouch，不建议选Hermit除非在vmos下",
       "ADB": "ADB",
       "uiautomator2": "uiautomator2",
@@ -640,7 +638,7 @@
       "help": "下列数值是根据Serial自动填充的，如果不懂请不要随意修改，修改端口即可自动启动对应实例"
     },
     "Emulator": {
-      "name": "选择模拟器类型",
+      "name": "模拟器类型",
       "help": "",
       "auto": "自动检测",
       "NoxPlayer": "夜神模拟器",
@@ -718,7 +716,7 @@
       "help": "运行敏感任务出错时停止AzurPilot，而不是重启游戏\n敏感任务包含隐秘海域、深渊坐标、跨月每日"
     },
     "SaveErrorCount": {
-      "name": "最多保存 X 个错误日志",
+      "name": "Error Log 保存上限",
       "help": "超出上限的错误日志将被删除，若为0或负值则没有限制"
     },
     "OnePushConfig": {
@@ -734,7 +732,7 @@
       "help": "在游戏连续卡死（触发GameStuckError）达到指定次数后，尝试重启模拟器。可能有助于解决模拟器假死或显存溢出等问题。"
     },
     "GameStuckThreshold": {
-      "name": "游戏卡死超过 X 秒后重启",
+      "name": "游戏卡死重启阈值",
       "help": "连续卡死多少次后触发重启。"
     },
     "AdbOfflineRestart": {
@@ -742,7 +740,7 @@
       "help": "在连续检测不到设备（ADB离线或连接失败）达到指定次数后，尝试重启模拟器。"
     },
     "AdbOfflineThreshold": {
-      "name": "检测不到设备超过 X 秒后重启",
+      "name": "检测不到设备重启阈值",
       "help": "连续检测不到设备多少次后触发重启。"
     },
     "LlmAnalysis": {
@@ -794,37 +792,38 @@
     },
     "OcrModelVersionEnglish": {
       "name": "OCR英文模型版本",
-      "help": "选择英文 OCR 模型档位。lite 轻量最快，standard 均衡，pro 精度最高。auto 使用 standard。alocr_en_v2_6 为旧版 AlOCR 专用英文模型，仅 ONNX 后端可用。该项影响英文 Azur Lane 模型。",
+      "help": "选择英文 OCR 模型版本。auto 使用英文推荐模型 AlOCR v2.6。该项影响英文 Azur Lane 模型；ncnn 后端会忽略此选择。",
       "auto": "自动推荐",
-      "lite": "Lite 轻量",
-      "standard": "Standard 标准",
-      "pro": "Pro 高精度",
-      "alocr_en_v2_6": "AlOCR v2.6（旧版）"
+      "alocr_en_900k": "alocr_en_900k",
+      "azur_lane_v6_6": "英文 v6.6 (Azur Lane)",
+      "azur_lane_v6_5": "英文 v6.5 (Azur Lane)",
+      "ppocr_v6": "通用 PP-OCRv6",
+      "alocr_en_v2_6": "英文 AlOCR v2.6",
+      "alocr_en_v2_0": "英文 AlOCR v2.0",
+      "alocr_en_v1_0": "英文 AlOCR v1.0"
     },
     "OcrModelVersionChinese": {
       "name": "OCR中文模型版本",
-      "help": "选择简体中文 OCR 模型档位。lite 轻量最快，standard 均衡，pro 精度最高。auto 使用 standard。alocr_cn_v3 为旧版 AlOCR 专用中文模型，仅 ONNX 后端可用。该项影响 cnocr/中文模型。",
+      "help": "选择简体中文 OCR 模型版本。auto 使用中文推荐模型 v6.1。该项影响 cnocr/中文模型；ncnn 后端会忽略此选择。",
       "auto": "自动推荐",
-      "lite": "Lite 轻量",
-      "standard": "Standard 标准",
-      "pro": "Pro 高精度",
-      "alocr_cn_v3": "AlOCR v3（旧版）"
+      "cn_v6_1": "中文 v6.1",
+      "cn_v6": "中文 v6",
+      "ppocr_v6": "通用 PP-OCRv6",
+      "alocr_cn_v3": "中文 AlOCR v3",
+      "alocr_cn_v2_5": "中文 AlOCR v2.5"
     },
     "OcrModelVersionJapanese": {
       "name": "OCR日文模型版本",
-      "help": "选择日文 OCR 模型档位。lite 轻量最快但不支持日语，standard 均衡，pro 精度最高。auto 使用 standard。该项影响日文模型。",
+      "help": "选择日文 OCR 模型版本。auto 使用日文 Azur Lane v6。该项影响日文模型；ncnn 后端会忽略此选择。",
       "auto": "自动推荐",
-      "lite": "Lite 轻量",
-      "standard": "Standard 标准",
-      "pro": "Pro 高精度"
+      "azur_lane_jp_v6": "日文 v6 (Azur Lane JP)",
+      "ppocr_v6": "通用 PP-OCRv6"
     },
     "OcrModelVersionTraditionalChinese": {
       "name": "OCR繁中模型版本",
-      "help": "选择繁体中文 OCR 模型档位。lite 轻量最快，standard 均衡，pro 精度最高。auto 使用 standard。",
+      "help": "选择繁体中文 OCR 模型版本。当前仅提供通用 PP-OCRv6，保留独立选项以便后续扩展。ncnn 后端会忽略此选择。",
       "auto": "自动推荐",
-      "lite": "Lite 轻量",
-      "standard": "Standard 标准",
-      "pro": "Pro 高精度"
+      "ppocr_v6": "通用 PP-OCRv6"
     },
     "ScreenshotInterval": {
       "name": "放慢截图速度至 X 秒一张",
@@ -901,6 +900,14 @@
       "upload": "上传",
       "save_and_upload": "保存并上传"
     },
+    "OpsiShopRecord": {
+      "name": "行动力箱子掉落截图",
+      "help": "",
+      "do_not": "无操作",
+      "save": "保存",
+      "upload": "上传",
+      "save_and_upload": "保存并上传"
+    },
     "MeowfficerBuy": {
       "name": "指挥喵购买截图",
       "help": "",
@@ -955,7 +962,7 @@
       "help": ""
     },
     "RetireMode": {
-      "name": "选择退役模式",
+      "name": "退役模式",
       "help": "若选择强化，强化材料不足时回退到一键退役",
       "one_click_retire": "一键退役",
       "enhance": "强化",
@@ -1045,7 +1052,7 @@
       "help": "格式: \"cv > bb > ...\"，\n留空则使用默认强化方式"
     },
     "CheckPerCategory": {
-      "name": "每个分类检查 X 艘",
+      "name": "每分类强化数量",
       "help": "每个舰船分类最多强化多少舰船，\n在战斗中的舰船会被跳过且不计入，\n优先判断是否有强化材料"
     }
   },
@@ -1071,7 +1078,7 @@
       "help": ""
     },
     "RetireAmount": {
-      "name": "每次退役 X 艘",
+      "name": "退役数量",
       "help": "",
       "retire_all": "退役全部",
       "retire_10": "退役10个"
@@ -1095,7 +1102,7 @@
       "coalition_20250626": "迷彩都市的寻踪者",
       "coalition_20251120": "DATE A LANE",
       "coalition_20260122": "光影风尚-拍摄进行时",
-      "coalition_20260723": "怪谈纪实",
+      "coalition_20260723": "怪谈纪实：逃离白夜山庄",
       "event_20200227_cn": "北境序曲",
       "event_20200312_cn": "复刻斯图尔特的硝烟",
       "event_20200326_cn": "微层混合",
@@ -1243,7 +1250,7 @@
       "war_archives_20240725_cn": "档案 幻梦间奏曲"
     },
     "Mode": {
-      "name": "选择关卡模式",
+      "name": "关卡模式",
       "help": "仅适用于主线图",
       "normal": "普通",
       "hard": "困难"
@@ -1326,7 +1333,7 @@
       "help": ""
     },
     "DailyRunCount": {
-      "name": "每日出击 X 次",
+      "name": "每日出击次数",
       "help": "每天最多运行作战档案多少次。\n0 表示不限制。\n达到次数后会延迟到下一次服务器刷新，不会关闭任务。"
     },
     "DailyRunCountRemain": {
@@ -1348,7 +1355,7 @@
       "help": ""
     },
     "Fleet1": {
-      "name": "一队使用第 X 支舰队",
+      "name": "一队编号",
       "help": "",
       "1": "1 ",
       "2": "2 ",
@@ -1365,7 +1372,7 @@
       "diamond": "轮形阵"
     },
     "Fleet1Mode": {
-      "name": "一队自律战斗模式",
+      "name": "一队自律模式",
       "help": "",
       "combat_auto": "自律战斗",
       "combat_manual": "手操",
@@ -1382,7 +1389,7 @@
       "5": "5 "
     },
     "Fleet2": {
-      "name": "二队使用第 X 支舰队",
+      "name": "二队编号",
       "help": "",
       "0": "不使用",
       "1": "1 ",
@@ -1400,7 +1407,7 @@
       "diamond": "轮形阵"
     },
     "Fleet2Mode": {
-      "name": "二队自律战斗模式",
+      "name": "二队自律模式",
       "help": "",
       "combat_auto": "自律战斗",
       "combat_manual": "手操",
@@ -1435,14 +1442,14 @@
       "help": ""
     },
     "Fleet": {
-      "name": "使用第 X 潜艇编队",
+      "name": "潜艇舰队编号",
       "help": "",
       "0": "不使用",
       "1": "1 ",
       "2": "2 "
     },
     "Mode": {
-      "name": "选择潜艇出击方案",
+      "name": "潜艇出击方案",
       "help": "仅在自律寻敌关闭的情况下生效，提醒: '狩猎及BOSS战'为'仅狩猎'与'仅BOSS战'的混合，它会在道中进行狩猎打击，并在BOSS战尝试召唤潜艇。",
       "do_not_use": "不使用",
       "hunt_only": "仅狩猎",
@@ -1451,7 +1458,7 @@
       "every_combat": "每战出击"
     },
     "AutoSearchMode": {
-      "name": "选择潜艇自律方案",
+      "name": "潜艇自律方案",
       "help": "仅在自律寻敌下生效",
       "sub_standby": "待机",
       "sub_auto_call": "自动召唤潜艇"
@@ -1752,7 +1759,7 @@
       "help": ""
     },
     "PtLimit": {
-      "name": "活动PT达到 X 后停止",
+      "name": "活动 PT 限制",
       "help": "当累计 PT 达到给定数值时，禁用所有活动任务，0 表示不限制，使用自律寻敌时不能即时触发\n开启后，你只需要打开所有活动任务，而不需要计算一共打多少次"
     },
     "TimeLimit": {
@@ -1770,7 +1777,7 @@
       "help": "启用后，将于每次出击后检查物资量"
     },
     "CoinLimit": {
-      "name": "保持物资大于 X",
+      "name": "保持物资大于X",
       "help": ""
     },
     "TaskCall": {
@@ -1992,13 +1999,17 @@
       "name": "做主要委托（1200油/1000油委托）",
       "help": "1200油委托现在已经过时，收益很低，建议关闭"
     },
+    "GemNotify": {
+      "name": "钻石委托执行通知",
+      "help": "开始新的钻石委托后，推送当前执行中的钻石委托列表"
+    },
     "CommissionNotifyReward": {
-      "name": "委托奖励推送通知",
-      "help": "获得委托奖励时推送通知（特别关注钻石奖励）"
+      "name": "委托成功获取钻石推送",
+      "help": "注意，请开启错误推送设置并配置，否则此功能不生效"
     },
     "CommissionNotifyRewardStatistics": {
-      "name": "推送包含统计信息",
-      "help": "在通知中显示今日/本周/本月累计钻石数量"
+      "name": "钻石推送详情",
+      "help": "开启后，AzurPilot在推送本次委托获取钻石数量的同时推送当日/本周/本月的钻石获取数量"
     }
   },
   "Tactical": {
@@ -2036,19 +2047,19 @@
       "help": ""
     },
     "T4Allow": {
-      "name": "允许T4技能书溢出 X 点经验",
+      "name": "允许 T4 技能书溢出 X 点经验",
       "help": ""
     },
     "T3Allow": {
-      "name": "允许T3技能书溢出 X 点经验",
+      "name": "允许 T3 技能书溢出 X 点经验",
       "help": ""
     },
     "T2Allow": {
-      "name": "允许T2技能书溢出 X 点经验",
+      "name": "允许 T2 技能书溢出 X 点经验",
       "help": ""
     },
     "T1Allow": {
-      "name": "允许T1技能书溢出 X 点经验",
+      "name": "允许 T1 技能书溢出 X 点经验",
       "help": ""
     }
   },
@@ -2212,7 +2223,7 @@
       "help": ""
     },
     "Mode": {
-      "name": "选择训练模式",
+      "name": "训练模式",
       "help": "无缝练猫将每隔 2.5 ~ 3.5 小时收取指挥喵\n每天收一只意思是每天收一只，周日收全部、强化并重新填充队列，以完成每周任务",
       "seamlessly": "无缝练猫",
       "once_a_day": "每天收一只"
@@ -2306,6 +2317,36 @@
     "CollectWeeklyMission": {
       "name": "领取周任务奖励",
       "help": ""
+    }
+  },
+  "Secretary": {
+    "_info": {
+      "name": "秘书舰设置",
+      "help": "配置秘书舰自动更换及推送通知"
+    },
+    "CustomFilter": {
+      "name": "稀有度过滤器",
+      "help": "稀有度包括海上传奇ultra、超稀有super_rare、精锐elite、稀有rare、普通common\n请在下方填入自定义的顺序\n默认ultra > super_rare > elite > rare > common"
+    },
+    "LowFavorabilityPriority": {
+      "name": "低好感度优先",
+      "help": "将按照从低到高的好感度顺序选择"
+    },
+    "BackupEnable": {
+      "name": "候补秘书舰",
+      "help": "将秘书组舰船作为候补秘书舰，优先更换"
+    },
+    "CheckInterval": {
+      "name": "自定义检测时间(小时)",
+      "help": "更换秘书舰后按设定时间检查，当此项值为0时，按好感度自动计算，如果安排秘书舰出击获取好感度时，设定此项可及时更换秘书舰"
+    },
+    "Notify": {
+      "name": "秘书舰推送",
+      "help": "使用 OnePush 推送秘书舰相关信息"
+    },
+    "OnePushConfig": {
+      "name": "OnePush 推送配置",
+      "help": "用于秘书舰更换通知，留空则使用全局配置"
     }
   },
   "Awaken": {
@@ -2587,7 +2628,7 @@
       "6": "六期科研"
     },
     "ShipIndex": {
-      "name": "选择第 X 艘科研船",
+      "name": "舰船序号",
       "help": "从左往右数，从 1 开始",
       "0": "不购买",
       "1": "1",
@@ -2622,7 +2663,7 @@
       "6": "六期科研"
     },
     "ShipIndex": {
-      "name": "选择第 X 艘科研船",
+      "name": "舰船序号",
       "help": "从左往右数，从1开始",
       "0": "不购买",
       "1": "1",
@@ -2656,7 +2697,7 @@
       "wishing_well": "祈愿池"
     },
     "Amount": {
-      "name": "每天建造 X 次",
+      "name": "抽卡数量",
       "help": "",
       "1": "1",
       "2": "2",
@@ -2972,7 +3013,7 @@
       "help": "推荐 1.0 ~ 3.0，因为人物立绘会遮挡血条，所以需要一定的时间确认血量是否真的低于阈值"
     },
     "OpponentRefreshValue": {
-      "name": "今日已刷新对手 X 次",
+      "name": "今日演习对手已刷新 X 次",
       "help": "自动更新的数值，过0点重置\n如果你手动刷新的对手，应该修改这个数值"
     },
     "OpponentRefreshRecord": {
@@ -3018,7 +3059,7 @@
       "help": "每次进入仓库的时候，使用所有的使用坐标记录仪"
     },
     "BuyActionPointLimit": {
-      "name": "购买行动力 X 次",
+      "name": "买行动力X次",
       "help": "买行动力的最大次数",
       "0": "不买",
       "1": "1次 (1000油, 100行动力)",
@@ -3045,7 +3086,7 @@
     },
     "RepairPackThresholdHazard1": {
       "name": "任意舰船血量低于 X 后，使用维修箱修理（侵蚀1）",
-      "help": "仅在开启“使用维修箱修船”时生效\n仅在“侵蚀1练级Plus”任务中尝试维修\n0.0 ~ 1.0"
+      "help": "仅在开启“使用维修箱修船”时生效\n仅在“侵蚀1练级+”任务中尝试维修\n0.0 ~ 1.0"
     },
     "DoRandomMapEvent": {
       "name": "完成地图随机事件",
@@ -3139,7 +3180,7 @@
   },
   "OpsiExplore": {
     "_info": {
-      "name": "每月开荒Plus",
+      "name": "每月开荒+",
       "help": "每月月初开荒大世界的所有海域，不需要买战役信息记录仪（5000油道具）\n这个功能将每隔27分钟清理一个海域，以保证空域搜索冷却\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场"
     },
     "SpecialRadar": {
@@ -3159,14 +3200,14 @@
       "help": "开启后将不会推迟侵蚀1练级任务，慎用，没体力开荒就老实了。"
     },
     "ExploreProgress": {
-      "name": "每月开荒Plus进度",
-      "help": "显示当前每月开荒Plus的完成百分比"
+      "name": "每月开荒+进度",
+      "help": "显示当前每月开荒+的完成百分比"
     }
   },
   "OpsiShop": {
     "_info": {
-      "name": "大世界商店Plus",
-      "help": "使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒Plus任务或使用战役信息记录仪（5000油道具）\n- 通关大世界主线后的下一个月，即港口商店变为新版商店后才可使用"
+      "name": "大世界商店+",
+      "help": "使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒+任务或使用战役信息记录仪（5000油道具）\n- 通关大世界主线后的下一个月，即港口商店变为新版商店后才可使用"
     },
     "PresetFilter": {
       "name": "港口商店过滤器",
@@ -3182,8 +3223,8 @@
       "help": "使用自定义过滤器需将 \"港口商店过滤器\" 设置为 \"自定义\"，并使用 https://filter.nanoda.work/ 生成过滤器，自己瞎几把设置过滤器出问题了别叫"
     },
     "DisableBeforeDate": {
-      "name": "每月 X 号前，不购买大世界商店Plus",
-      "help": "从指定日期的后一天开始，每天买一次大世界商店Plus\n0 表示不限制，每天都购买"
+      "name": "每月 X 号前，不购买大世界商店+",
+      "help": "从指定日期的后一天开始，每天买一次大世界商店+\n0 表示不限制，每天都购买"
     }
   },
   "OpsiVoucher": {
@@ -3198,11 +3239,11 @@
   },
   "OpsiDaily": {
     "_info": {
-      "name": "大世界每日Plus",
-      "help": "使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒Plus任务或使用战役信息记录仪（5000油道具）"
+      "name": "大世界每日+",
+      "help": "使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒+任务或使用战役信息记录仪（5000油道具）"
     },
     "DoMission": {
-      "name": "做大世界每日Plus",
+      "name": "做大世界每日+",
       "help": "在港口接每日，并完成所有每日"
     },
     "UseTuningSample": {
@@ -3229,7 +3270,7 @@
   "OpsiObscure": {
     "_info": {
       "name": "隐秘海域",
-      "help": "每隔27分钟清理一个隐秘海域，以保证空域搜索冷却\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒Plus任务或使用战役信息记录仪（5000油道具）"
+      "help": "每隔27分钟清理一个隐秘海域，以保证空域搜索冷却\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒+任务或使用战役信息记录仪（5000油道具）"
     },
     "SkipHazard2Obscure": {
       "name": "不清理2级坐标",
@@ -3243,7 +3284,7 @@
   "OpsiAbyssal": {
     "_info": {
       "name": "深渊坐标",
-      "help": "清理仓库中的深渊坐标\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒Plus任务或使用战役信息记录仪（5000油道具）"
+      "help": "清理仓库中的深渊坐标\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒+任务或使用战役信息记录仪（5000油道具）"
     },
     "ForceRun": {
       "name": "无视运行间隔强制运行",
@@ -3253,7 +3294,7 @@
   "OpsiStronghold": {
     "_info": {
       "name": "塞壬要塞",
-      "help": "清理每周的塞壬要塞\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒Plus任务或使用战役信息记录仪（5000油道具）"
+      "help": "清理每周的塞壬要塞\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒+任务或使用战役信息记录仪（5000油道具）"
     },
     "SubmarineEveryCombat": {
       "name": "潜艇每战出击",
@@ -3271,7 +3312,7 @@
   "OpsiMonthBoss": {
     "_info": {
       "name": "月度Boss",
-      "help": "清理（简单/困难）月度Boss，简单难度失败会继续出击直到击破，困难难度失败则直接终止任务\n使用此功能需要满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒Plus任务或使用战役信息记录仪（5000油道具）"
+      "help": "清理（简单/困难）月度Boss，简单难度失败会继续出击直到击破，困难难度失败则直接终止任务\n使用此功能需要满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒+任务或使用战役信息记录仪（5000油道具）"
     },
     "Mode": {
       "name": "清理月度Boss的难度",
@@ -3291,7 +3332,7 @@
   "OpsiMeowfficerFarming": {
     "_info": {
       "name": "耄耋相接",
-      "help": "按顺时针出击指定侵蚀等级的海域\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒Plus任务或使用战役信息记录仪（5000油道具）"
+      "help": "按顺时针出击指定侵蚀等级的海域\n使用此功能前必须满足以下条件：\n- 通关大世界主线并完成模拟战+塞壬试验场\n- 启用每月开荒+任务或使用战役信息记录仪（5000油道具）"
     },
     "ActionPointPreserve": {
       "name": "保留 X 点行动力",
@@ -3447,6 +3488,12 @@
       "True": "已启用",
       "False": "未启用"
     },
+    "AnyShipReached": {
+      "name": "任意舰船达到等级后更换",
+      "help": "启用后，当任意检测舰船达到目标等级时执行自动配队\n关闭时，需要所有检测舰船达到目标等级才执行自动配队",
+      "True": "已启用",
+      "False": "未启用"
+    },
     "CooldownHours": {
       "name": "冷却时间(小时)",
       "help": "每次自动配队后的冷却时间，避免频繁触发",
@@ -3462,11 +3509,11 @@
   },
   "OpsiScheduling": {
     "_info": {
-      "name": "智能调度Plus",
-      "help": "智能调度Plus相关配置"
+      "name": "智能调度+",
+      "help": "智能调度+相关配置"
     },
     "UseSmartSchedulingOperationCoinsPreserve": {
-      "name": "保留 X 个作战补给凭证",
+      "name": "获取 X 个作战补给凭证",
       "help": "启用后将使用下方设置的 获取 X 个作战补给凭证 的配置，禁用则使用侵蚀1练级 黄币保留配置",
       "True": "开启",
       "False": "关闭"
@@ -3480,30 +3527,30 @@
       "help": "行动力低于 X 后停止，自动打开行动力箱子，X 包含箱子中的行动力，建议保留1000行动力给侵蚀1练级"
     },
     "OperationCoinsReturnThreshold": {
-      "name": "作战补给凭证低于 X 时返航",
+      "name": "获取 X 个作战补给凭证",
       "help": "在黄币获取任务时 共获取(增加) X 个作战补给凭证后返回侵蚀1练级"
     },
     "EnableMeowfficerFarming": {
       "name": "启用耄耋相接",
-      "help": "智能调度Plus中是否启用耄耋相接任务来补充黄币",
+      "help": "智能调度+中是否启用耄耋相接任务来补充黄币",
       "True": "已启用",
       "False": "未启用"
     },
     "EnableObscure": {
       "name": "启用隐秘海域",
-      "help": "智能调度Plus中是否启用隐秘海域任务来补充黄币",
+      "help": "智能调度+中是否启用隐秘海域任务来补充黄币",
       "True": "已启用",
       "False": "未启用"
     },
     "EnableAbyssal": {
       "name": "启用深渊坐标",
-      "help": "智能调度Plus中是否启用深渊坐标任务来补充黄币",
+      "help": "智能调度+中是否启用深渊坐标任务来补充黄币",
       "True": "已启用",
       "False": "未启用"
     },
     "EnableStronghold": {
       "name": "启用塞壬要塞",
-      "help": "智能调度Plus中是否启用塞壬要塞任务来补充黄币",
+      "help": "智能调度+中是否启用塞壬要塞任务来补充黄币",
       "True": "已启用",
       "False": "未启用"
     },
@@ -3530,16 +3577,31 @@
       "help": "月末清理行动力时是否执行大世界商店购买。关闭后月末清理循环将跳过商店购买步骤。",
       "True": "True",
       "False": "False"
+    },
+    "BuyActionPointMode": {
+      "name": "买行动力模式",
+      "help": "购买行动力专用模式，与现有黄币/行动力调度互斥。开启后将用石油购买行动力并执行对应任务。需先在「大世界通用设置 → 买行动力X次」设置每周购买上限。",
+      "off": "关闭",
+      "hazard1_leveling": "侵蚀1练级",
+      "meowfficer_farming": "短猫补黄币"
+    },
+    "BuyActionPointUpperThreshold": {
+      "name": "买行动力上限阈值",
+      "help": "仅「短猫补黄币」模式使用。当前真实行动力超过此值时跳过购买，直接执行海域任务。默认 200（大世界行动力自然回复上限）。"
+    },
+    "BuyActionPointLowerThreshold": {
+      "name": "买行动力下限阈值",
+      "help": "仅「短猫补黄币」模式使用。当前真实行动力低于此值时停止执行海域任务，回到购买步骤。默认 100。"
     }
   },
   "OpsiPreventActionPointOverflow": {
     "_info": {
       "name": "防止行动力溢出",
-      "help": "当前行动力达到上限时执行大世界任务消耗行动力\n选择智能调度Plus时，如果行动力和黄币都不足导致没有可运行任务，将运行耄耋相接清理当前行动力"
+      "help": "当前行动力达到上限时执行大世界任务消耗行动力\n选择智能调度+时，如果行动力和黄币都不足导致没有可运行任务，将运行耄耋相接清理当前行动力"
     },
     "Task": {
       "name": "执行任务",
-      "help": "推荐选择智能调度Plus，防止行动力溢出任务对此有专门处理",
+      "help": "推荐选择智能调度+，防止行动力溢出任务对此有专门处理",
       "OpsiScheduling": "智能调度+（推荐）",
       "OpsiHazard1Leveling": "侵蚀1练级",
       "OpsiMeowfficerFarming": "耄耋相接"
@@ -3582,7 +3644,7 @@
     },
     "WorkerFilter": {
       "name": "农田使用角色",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinFarm": {
       "name": "农田作物底线",
@@ -3613,7 +3675,7 @@
     },
     "WorkerFilter": {
       "name": "果园使用角色",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinOrchard": {
       "name": "水果底线",
@@ -3650,7 +3712,7 @@
     },
     "WorkerFilter": {
       "name": "苗圃使用角色",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinNursery": {
       "name": "苗圃作物底线",
@@ -3679,7 +3741,7 @@
     },
     "ChickenFilter": {
       "name": "养鸡使用角色",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinPork": {
       "name": "猪肉底线",
@@ -3687,7 +3749,7 @@
     },
     "PigFilter": {
       "name": "养猪使用角色",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Milk": {
       "name": "养牛",
@@ -3695,7 +3757,7 @@
     },
     "RancherFilter": {
       "name": "使用角色",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Wool": {
       "name": "养羊",
@@ -3703,7 +3765,7 @@
     },
     "WoolWorkerFilter": {
       "name": "养羊使用角色",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     }
   },
   "IslandFishery": {
@@ -3760,7 +3822,7 @@
     },
     "RancherFilter": {
       "name": "使用角色",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     }
   },
   "IslandMine": {
@@ -3769,7 +3831,7 @@
       "help": ""
     },
     "Positions": {
-      "name": "安排 X 个矿工岗位",
+      "name": "岗位数量",
       "help": "",
       "1": "1",
       "2": "2",
@@ -3787,7 +3849,7 @@
     },
     "WorkerFilter": {
       "name": "矿山使用角色",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinCopper": {
       "name": "铜矿最低库存",
@@ -3816,7 +3878,7 @@
       "help": ""
     },
     "Positions": {
-      "name": "安排 X 个伐木工岗位",
+      "name": "岗位数量",
       "help": "",
       "1": "1",
       "2": "2",
@@ -3834,7 +3896,7 @@
     },
     "WorkerFilter": {
       "name": "林场使用角色",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinElegant": {
       "name": "优雅木材最低库存",
@@ -3856,7 +3918,7 @@
     },
     "WorkerFilter": {
       "name": "采集角色",
-      "help": "以>连接，最多填写3个角色，分别对应第1~3个采集槽位。\n以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n每日采集不能选择 WorkerJuu，填写后会自动忽略。\n仅识别默认排序前两排；指定角色不可用时该槽位回退现有采集逻辑。"
+      "help": "以>连接，最多填写3个角色，分别对应第1~3个采集槽位。\n以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n每日采集不能选择 WorkerJuu，填写后会自动忽略。\n仅识别默认排序前两排；指定角色不可用时该槽位回退现有采集逻辑。"
     }
   },
   "IslandRestaurant": {
@@ -3865,14 +3927,14 @@
       "help": "餐品会按从1~8的顺序依次生产，生产目标为餐品X数量选项，完全满足前一项后才会执行下一项，后一项在运行时不会影响之前几项任务的达成\n餐品1-8中的凉拌双笋和芦笋炒虾仁会根据当前季节自动切换为对应季节餐品"
     },
     "PostNumber": {
-      "name": "安排 X 个厨师岗位",
+      "name": "岗位数量",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "厨师",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "DoubleBambooShoots": {
       "name": "季节餐优先制作",
@@ -3898,7 +3960,7 @@
       "persimmon_cake": "柿子饼"
     },
     "MealNumber1": {
-      "name": "生产餐品1至 X 份",
+      "name": "餐品1数量",
       "help": ""
     },
     "Meal2": {
@@ -3921,7 +3983,7 @@
       "persimmon_cake": "柿子饼"
     },
     "MealNumber2": {
-      "name": "生产餐品2至 X 份",
+      "name": "餐品2数量",
       "help": ""
     },
     "Meal3": {
@@ -3944,7 +4006,7 @@
       "persimmon_cake": "柿子饼"
     },
     "MealNumber3": {
-      "name": "生产餐品3至 X 份",
+      "name": "餐品3数量",
       "help": ""
     },
     "Meal4": {
@@ -3967,7 +4029,7 @@
       "persimmon_cake": "柿子饼"
     },
     "MealNumber4": {
-      "name": "生产餐品4至 X 份",
+      "name": "餐品4数量",
       "help": ""
     },
     "Meal5": {
@@ -3990,7 +4052,7 @@
       "persimmon_cake": "柿子饼"
     },
     "MealNumber5": {
-      "name": "生产餐品5至 X 份",
+      "name": "餐品5数量",
       "help": ""
     },
     "Meal6": {
@@ -4013,7 +4075,7 @@
       "persimmon_cake": "柿子饼"
     },
     "MealNumber6": {
-      "name": "生产餐品6至 X 份",
+      "name": "餐品6数量",
       "help": ""
     },
     "Meal7": {
@@ -4036,7 +4098,7 @@
       "persimmon_cake": "柿子饼"
     },
     "MealNumber7": {
-      "name": "生产餐品7至 X 份",
+      "name": "餐品7数量",
       "help": ""
     },
     "Meal8": {
@@ -4059,7 +4121,7 @@
       "persimmon_cake": "柿子饼"
     },
     "MealNumber8": {
-      "name": "生产餐品8至 X 份",
+      "name": "餐品8数量",
       "help": ""
     }
   },
@@ -4091,17 +4153,17 @@
   "IslandTeahouse": {
     "_info": {
       "name": "白熊饮品",
-      "help": "餐品会按从1~8的顺序依次生产，生产目标为餐品X数量选项，完全满足前一项后才会执行下一项，后一项在运行时不会影响之前几项任务的达成\n蜂蜜制品支持自动生产，需保证蜂蜜库存充足\n餐品中的迎春花茶和鲜榨菠萝汁会根据当前季节自动切换为对应季节餐品"
+      "help": "餐品会按从1~8的顺序依次生产，生产目标为餐品X数量选项，完全满足前一项后才会执行下一项，后一项在运行时不会影响之前几项任务的达成\n请手动制作蜂蜜制品\n餐品中的迎春花茶和鲜榨菠萝汁会根据当前季节自动切换为对应季节餐品"
     },
     "PostNumber": {
-      "name": "安排 X 个调饮师岗位",
+      "name": "岗位数量",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "厨师",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Seasonal": {
       "name": "季节饮品优先制作",
@@ -4125,7 +4187,7 @@
       "carrot_pear_juice": "胡萝卜秋梨汁"
     },
     "MealNumber1": {
-      "name": "生产餐品1至 X 份",
+      "name": "餐品1数量",
       "help": ""
     },
     "Meal2": {
@@ -4146,7 +4208,7 @@
       "carrot_pear_juice": "胡萝卜秋梨汁"
     },
     "MealNumber2": {
-      "name": "生产餐品2至 X 份",
+      "name": "餐品2数量",
       "help": ""
     },
     "Meal3": {
@@ -4167,7 +4229,7 @@
       "carrot_pear_juice": "胡萝卜秋梨汁"
     },
     "MealNumber3": {
-      "name": "生产餐品3至 X 份",
+      "name": "餐品3数量",
       "help": ""
     },
     "Meal4": {
@@ -4188,7 +4250,7 @@
       "carrot_pear_juice": "胡萝卜秋梨汁"
     },
     "MealNumber4": {
-      "name": "生产餐品4至 X 份",
+      "name": "餐品4数量",
       "help": ""
     },
     "Meal5": {
@@ -4209,7 +4271,7 @@
       "carrot_pear_juice": "胡萝卜秋梨汁"
     },
     "MealNumber5": {
-      "name": "生产餐品5至 X 份",
+      "name": "餐品5数量",
       "help": ""
     },
     "Meal6": {
@@ -4230,7 +4292,7 @@
       "carrot_pear_juice": "胡萝卜秋梨汁"
     },
     "MealNumber6": {
-      "name": "生产餐品6至 X 份",
+      "name": "餐品6数量",
       "help": ""
     },
     "Meal7": {
@@ -4251,7 +4313,7 @@
       "carrot_pear_juice": "胡萝卜秋梨汁"
     },
     "MealNumber7": {
-      "name": "生产餐品7至 X 份",
+      "name": "餐品7数量",
       "help": ""
     },
     "Meal8": {
@@ -4272,7 +4334,7 @@
       "carrot_pear_juice": "胡萝卜秋梨汁"
     },
     "MealNumber8": {
-      "name": "生产餐品8至 X 份",
+      "name": "餐品8数量",
       "help": ""
     }
   },
@@ -4305,14 +4367,14 @@
       "help": "餐品会按从1~8的顺序依次生产，生产目标为餐品X数量选项，完全满足前一项后才会执行下一项，后一项在运行时不会影响之前几项任务的达成"
     },
     "PostNumber": {
-      "name": "安排 X 个烧烤师岗位",
+      "name": "岗位数量",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "厨师",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Meal1": {
       "name": "餐品1",
@@ -4328,7 +4390,7 @@
       "double_energy": "能量双拼套餐"
     },
     "MealNumber1": {
-      "name": "生产餐品1至 X 份",
+      "name": "餐品1数量",
       "help": ""
     },
     "Meal2": {
@@ -4345,7 +4407,7 @@
       "double_energy": "能量双拼套餐"
     },
     "MealNumber2": {
-      "name": "生产餐品2至 X 份",
+      "name": "餐品2数量",
       "help": ""
     },
     "Meal3": {
@@ -4362,7 +4424,7 @@
       "double_energy": "能量双拼套餐"
     },
     "MealNumber3": {
-      "name": "生产餐品3至 X 份",
+      "name": "餐品3数量",
       "help": ""
     },
     "Meal4": {
@@ -4379,7 +4441,7 @@
       "double_energy": "能量双拼套餐"
     },
     "MealNumber4": {
-      "name": "生产餐品4至 X 份",
+      "name": "餐品4数量",
       "help": ""
     },
     "Meal5": {
@@ -4396,7 +4458,7 @@
       "double_energy": "能量双拼套餐"
     },
     "MealNumber5": {
-      "name": "生产餐品5至 X 份",
+      "name": "餐品5数量",
       "help": ""
     },
     "Meal6": {
@@ -4413,7 +4475,7 @@
       "double_energy": "能量双拼套餐"
     },
     "MealNumber6": {
-      "name": "生产餐品6至 X 份",
+      "name": "餐品6数量",
       "help": ""
     },
     "Meal7": {
@@ -4430,7 +4492,7 @@
       "double_energy": "能量双拼套餐"
     },
     "MealNumber7": {
-      "name": "生产餐品7至 X 份",
+      "name": "餐品7数量",
       "help": ""
     },
     "Meal8": {
@@ -4447,7 +4509,7 @@
       "double_energy": "能量双拼套餐"
     },
     "MealNumber8": {
-      "name": "生产餐品8至 X 份",
+      "name": "餐品8数量",
       "help": ""
     }
   },
@@ -4476,14 +4538,14 @@
       "help": "餐品会按从1~8的顺序依次生产，生产目标为餐品X数量选项，完全满足前一项后才会执行下一项，后一项在运行时不会影响之前几项任务的达成"
     },
     "PostNumber": {
-      "name": "安排 X 个简餐师岗位",
+      "name": "岗位数量",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "厨师",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Meal1": {
       "name": "餐品1",
@@ -4501,7 +4563,7 @@
       "seafood_rice": "海鲜饭"
     },
     "MealNumber1": {
-      "name": "生产餐品1至 X 份",
+      "name": "餐品1数量",
       "help": ""
     },
     "Meal2": {
@@ -4520,7 +4582,7 @@
       "seafood_rice": "海鲜饭"
     },
     "MealNumber2": {
-      "name": "生产餐品2至 X 份",
+      "name": "餐品2数量",
       "help": ""
     },
     "Meal3": {
@@ -4539,7 +4601,7 @@
       "seafood_rice": "海鲜饭"
     },
     "MealNumber3": {
-      "name": "生产餐品3至 X 份",
+      "name": "餐品3数量",
       "help": ""
     },
     "Meal4": {
@@ -4558,7 +4620,7 @@
       "seafood_rice": "海鲜饭"
     },
     "MealNumber4": {
-      "name": "生产餐品4至 X 份",
+      "name": "餐品4数量",
       "help": ""
     },
     "Meal5": {
@@ -4577,7 +4639,7 @@
       "seafood_rice": "海鲜饭"
     },
     "MealNumber5": {
-      "name": "生产餐品5至 X 份",
+      "name": "餐品5数量",
       "help": ""
     },
     "Meal6": {
@@ -4596,7 +4658,7 @@
       "seafood_rice": "海鲜饭"
     },
     "MealNumber6": {
-      "name": "生产餐品6至 X 份",
+      "name": "餐品6数量",
       "help": ""
     },
     "Meal7": {
@@ -4615,7 +4677,7 @@
       "seafood_rice": "海鲜饭"
     },
     "MealNumber7": {
-      "name": "生产餐品7至 X 份",
+      "name": "餐品7数量",
       "help": ""
     },
     "Meal8": {
@@ -4634,7 +4696,7 @@
       "seafood_rice": "海鲜饭"
     },
     "MealNumber8": {
-      "name": "生产餐品8至 X 份",
+      "name": "餐品8数量",
       "help": ""
     }
   },
@@ -4665,14 +4727,14 @@
       "help": "餐品会按从1~8的顺序依次生产，生产目标为餐品X数量选项，完全满足前一项后才会执行下一项，后一项在运行时不会影响之前几项任务的达成"
     },
     "PostNumber": {
-      "name": "安排 X 个咖啡师岗位",
+      "name": "岗位数量",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "厨师",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei\n恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire\n镇海：ChenHai > 威廉D波特：WilliamDPorter\n海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune\n仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Friedrich": {
       "name": "大帝",
@@ -4693,7 +4755,7 @@
       "fruity_fruitier": "果香双杯乐"
     },
     "MealNumber1": {
-      "name": "生产餐品1至 X 份",
+      "name": "餐品1数量",
       "help": ""
     },
     "Meal2": {
@@ -4711,7 +4773,7 @@
       "fruity_fruitier": "果香双杯乐"
     },
     "MealNumber2": {
-      "name": "生产餐品2至 X 份",
+      "name": "餐品2数量",
       "help": ""
     },
     "Meal3": {
@@ -4729,7 +4791,7 @@
       "fruity_fruitier": "果香双杯乐"
     },
     "MealNumber3": {
-      "name": "生产餐品3至 X 份",
+      "name": "餐品3数量",
       "help": ""
     },
     "Meal4": {
@@ -4747,7 +4809,7 @@
       "fruity_fruitier": "果香双杯乐"
     },
     "MealNumber4": {
-      "name": "生产餐品4至 X 份",
+      "name": "餐品4数量",
       "help": ""
     },
     "Meal5": {
@@ -4765,7 +4827,7 @@
       "fruity_fruitier": "果香双杯乐"
     },
     "MealNumber5": {
-      "name": "生产餐品5至 X 份",
+      "name": "餐品5数量",
       "help": ""
     },
     "Meal6": {
@@ -4783,7 +4845,7 @@
       "fruity_fruitier": "果香双杯乐"
     },
     "MealNumber6": {
-      "name": "生产餐品6至 X 份",
+      "name": "餐品6数量",
       "help": ""
     },
     "Meal7": {
@@ -4801,7 +4863,7 @@
       "fruity_fruitier": "果香双杯乐"
     },
     "MealNumber7": {
-      "name": "生产餐品7至 X 份",
+      "name": "餐品7数量",
       "help": ""
     },
     "Meal8": {
@@ -4819,7 +4881,7 @@
       "fruity_fruitier": "果香双杯乐"
     },
     "MealNumber8": {
-      "name": "生产餐品8至 X 份",
+      "name": "餐品8数量",
       "help": ""
     }
   },
@@ -5056,8 +5118,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Char2": {
       "name": "角色2",
@@ -5095,8 +5156,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Product1": {
       "name": "餐品1",
@@ -5222,8 +5282,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Char2": {
       "name": "角色2",
@@ -5261,8 +5320,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Product1": {
       "name": "餐品1",
@@ -5400,8 +5458,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Char2": {
       "name": "角色2",
@@ -5439,8 +5496,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Product1": {
       "name": "餐品1",
@@ -5538,8 +5594,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Char2": {
       "name": "角色2",
@@ -5577,8 +5632,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Product1": {
       "name": "餐品1",
@@ -5681,8 +5735,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Char2": {
       "name": "角色2",
@@ -5720,8 +5773,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Product1": {
       "name": "餐品1",
@@ -5869,7 +5921,7 @@
       "help": "当前版本搭建点击流程：船坞、第一艘、快速更换、装备中、占位换装逻辑、下一艘。"
     },
     "ShipLimit": {
-      "name": "处理前 X 艘舰船",
+      "name": "处理舰船上限",
       "help": "0 表示一直处理到无法切换下一艘；调试时可设置为 1 或其他较小数量。"
     },
     "EnableSlot1": {
@@ -5909,7 +5961,7 @@
       "help": "测试哪个截图方案和控制方案速度更快，速度因模拟器和电脑配置而异\n测试完成后，在 \"AzurPilot\" - \"模拟器设置\" 内选择最快的截图和控制方案"
     },
     "DeviceType": {
-      "name": "选择设备类型",
+      "name": "设备类型",
       "help": "",
       "emulator": "模拟器",
       "plone_cloud_with_adb": "云手机 有公网ADB",
@@ -6116,7 +6168,7 @@
     },
     "Status": {
       "Running": "秘书舰正在处理",
-      "Inactive": "茗正在偷走你的箱子",
+      "Inactive": "正在从别人那打劫金行动力箱子",
       "Warning": "发生错误",
       "Updating": "等待更新"
     },

--- a/module/config/i18n/zh-MIAO.json
+++ b/module/config/i18n/zh-MIAO.json
@@ -186,6 +186,10 @@
       "name": "认知觉醒喵",
       "help": "觉醒舰娘潜力，消耗心智单元，突破极限喵！( •̀ ω •́ )✧"
     },
+    "Secretary": {
+      "name": "秘书舰轮值喵",
+      "help": "自动检测秘书舰好感度，达到90后自动换人，让舰娘们都能陪伴指挥官喵！( •̀ᴗ-)✧"
+    },
     "Daily": {
       "name": "每日任务清剿喵",
       "help": "每日挑战、商船护送等，完成有丰厚奖励喵！(＾▽＾)"
@@ -571,7 +575,6 @@
       "en-3": "[EN] Washington",
       "en-4": "[EN] Amagi",
       "en-5": "[EN] Little Enterprise",
-      "en-6": "[EN] Belfast",
       "jp-0": "[JP] ブレスト",
       "jp-1": "[JP] 横須賀",
       "jp-2": "[JP] 佐世保",
@@ -589,12 +592,7 @@
       "jp-14": "[JP] キール",
       "jp-15": "[JP] 若松",
       "jp-16": "[JP] オデッサ",
-      "jp-17": "[JP] スイートバン",
-      "tw-0": "[TW] 珍珠港",
-      "tw-1": "[TW] 珊瑚海",
-      "tw-2": "[TW] 中途島",
-      "tw-3": "[TW] 瓜達康納爾",
-      "tw-4": "[TW] 雷伊泰灣"
+      "jp-17": "[JP] スイートバン"
     },
     "ScreenshotMethod": {
       "name": "模拟器截图法术 ∩",
@@ -794,37 +792,38 @@
     },
     "OcrModelVersionEnglish": {
       "name": "OCR英文模型版本喵",
-      "help": "选择英文OCR模型档位喵。lite轻量最快喵，standard均衡喵，pro精度最高喵。auto使用standard喵。alocr_en_v2_6为旧版AlOCR专用英文模型喵，仅ONNX后端可用喵。该项影响英文Azur Lane模型。",
+      "help": "选择英文 OCR 模型版本喵。auto 使用英文推荐模型 AlOCR v2.6。该项影响英文 Azur Lane 模型；ncnn 后端会忽略此选择喵。",
       "auto": "自动推荐喵",
-      "lite": "Lite 轻量喵",
-      "standard": "Standard 标准喵",
-      "pro": "Pro 高精度喵",
-      "alocr_en_v2_6": "AlOCR v2.6（旧版）喵"
+      "alocr_en_900k": "alocr_en_900k",
+      "azur_lane_v6_6": "英文 v6.6 (Azur Lane)",
+      "azur_lane_v6_5": "英文 v6.5 (Azur Lane)",
+      "ppocr_v6": "通用 PP-OCRv6",
+      "alocr_en_v2_6": "英文 AlOCR v2.6",
+      "alocr_en_v2_0": "英文 AlOCR v2.0",
+      "alocr_en_v1_0": "英文 AlOCR v1.0"
     },
     "OcrModelVersionChinese": {
       "name": "OCR中文模型版本喵",
-      "help": "选择简体中文OCR模型档位喵。lite轻量最快喵，standard均衡喵，pro精度最高喵。auto使用standard喵。alocr_cn_v3为旧版AlOCR专用中文模型喵，仅ONNX后端可用喵。该项影响cnocr/中文模型。",
+      "help": "选择简体中文 OCR 模型版本喵。auto 使用中文推荐模型 v6.1。该项影响 cnocr/中文模型；ncnn 后端会忽略此选择喵。",
       "auto": "自动推荐喵",
-      "lite": "Lite 轻量喵",
-      "standard": "Standard 标准喵",
-      "pro": "Pro 高精度喵",
-      "alocr_cn_v3": "AlOCR v3（旧版）喵"
+      "cn_v6_1": "中文 v6.1",
+      "cn_v6": "中文 v6",
+      "ppocr_v6": "通用 PP-OCRv6",
+      "alocr_cn_v3": "中文 AlOCR v3",
+      "alocr_cn_v2_5": "中文 AlOCR v2.5"
     },
     "OcrModelVersionJapanese": {
       "name": "OCR日文模型版本喵",
-      "help": "选择日文OCR模型档位喵。lite轻量最快但不支持日语喵，standard均衡喵，pro精度最高喵。auto使用standard喵。该项影响日文模型。",
+      "help": "选择日文 OCR 模型版本喵。auto 使用日文 Azur Lane v6。该项影响日文模型；ncnn 后端会忽略此选择喵。",
       "auto": "自动推荐喵",
-      "lite": "Lite 轻量喵",
-      "standard": "Standard 标准喵",
-      "pro": "Pro 高精度喵"
+      "azur_lane_jp_v6": "日文 v6 (Azur Lane JP)",
+      "ppocr_v6": "通用 PP-OCRv6"
     },
     "OcrModelVersionTraditionalChinese": {
       "name": "OCR繁中模型版本喵",
-      "help": "选择繁体中文OCR模型档位喵。lite轻量最快喵，standard均衡喵，pro精度最高喵。auto使用standard喵。",
+      "help": "选择繁体中文 OCR 模型版本喵。当前仅提供通用 PP-OCRv6，保留独立选项以便后续扩展。ncnn 后端会忽略此选择喵。",
       "auto": "自动推荐喵",
-      "lite": "Lite 轻量喵",
-      "standard": "Standard 标准喵",
-      "pro": "Pro 高精度喵"
+      "ppocr_v6": "通用 PP-OCRv6"
     },
     "ScreenshotInterval": {
       "name": "放慢截图至 X 秒一张",
@@ -900,6 +899,14 @@
       "save": "保存喵",
       "upload": "上传喵",
       "save_and_upload": "保存并上传喵"
+    },
+    "OpsiShopRecord": {
+      "name": "DropRecord.OpsiShopRecord.name",
+      "help": "DropRecord.OpsiShopRecord.help",
+      "do_not": "do_not",
+      "save": "save",
+      "upload": "upload",
+      "save_and_upload": "save_and_upload"
     },
     "MeowfficerBuy": {
       "name": "指挥喵购买截图",
@@ -1095,7 +1102,7 @@
       "coalition_20250626": "The Neon City Investigator",
       "coalition_20251120": "DATE A LANE",
       "coalition_20260122": "Light & Shadow Fashion Shoot!",
-      "coalition_20260723": "Authentic Horror Story",
+      "coalition_20260723": "怪谈纪实：逃离白夜山庄",
       "event_20200227_cn": "Northern Overture",
       "event_20200312_cn": "The Solomon Ranger Rerun",
       "event_20200326_cn": "Microlayer Medley",
@@ -1181,7 +1188,7 @@
       "event_20260417_cn": "Vacation Lane – Beachside Brilliance",
       "event_20260520_cn": "Alliance Before the Hagiobull",
       "event_20260625_cn": "Miracle by Midnight",
-      "event_20260813_cn": "Depths of the Astrarium",
+      "event_20260813_cn": "沉溺于星光之城",
       "raid_20200624": "Air Raid Drills with Essex Rerun",
       "raid_20210708": "Cross Wave rerun",
       "raid_20220127": "Mystery Investigation",
@@ -1992,13 +1999,21 @@
       "name": "做主要委托 (1200油/1000油)",
       "help": "1200油委现已过时收益低，建议关闭喵。 (´・ω・`)"
     },
+    "GemNotify": {
+      "name": "钻石委托执行通知喵",
+      "help": "开始新的钻石委托后，把当前正在执行的钻石委托列表推给主人喵~"
+    },
     "CommissionNotifyReward": {
-      "name": "委托奖励推送通知喵~",
-      "help": "获得委托奖励时推送通知喵（特别关注钻石奖励）！"
+      "name": "委托成功获取钻石推送喵",
+      "help": "注意，请开启错误推送设置并配置，否则此功能不生效喵。 (´・ω・`)"
     },
     "CommissionNotifyRewardStatistics": {
-      "name": "推送含统计信息喵~",
-      "help": "通知里会显示今日/本周/本月累计钻石数量喵！"
+      "name": "钻石推送详情喵",
+      "help": "开启后，AzurPilot在推送本次委托获取钻石数量的同时推送当日/本周/本月的钻石获取数量喵。 (´・ω・`)"
+    },
+    "CommissionNotifyRewardCube": {
+      "name": "Commission.CommissionNotifyRewardCube.name",
+      "help": "Commission.CommissionNotifyRewardCube.help"
     }
   },
   "Tactical": {
@@ -2306,6 +2321,36 @@
     "CollectWeeklyMission": {
       "name": "领取周任务奖励喵",
       "help": ""
+    }
+  },
+  "Secretary": {
+    "_info": {
+      "name": "秘书舰设置喵",
+      "help": "设置秘书舰自动轮换和通知，让舰娘们轮流陪伴指挥官喵！(◕ᴗ◕✿)"
+    },
+    "CustomFilter": {
+      "name": "稀有度筛选器喵",
+      "help": "稀有度包含海上传奇ultra、超稀有super_rare、精锐elite、稀有rare、普通common喵\n请在下方填入自定义的顺序喵～\n默认优先顺序为ultra > super_rare > elite > rare > common"
+    },
+    "LowFavorabilityPriority": {
+      "name": "低好感度优先喵",
+      "help": "会按照好感度从低到高的顺序选择秘书舰喵，让更多秘书舰获得培养机会喵"
+    },
+    "BackupEnable": {
+      "name": "候补秘书舰喵",
+      "help": "把秘书组里的舰船当作候补秘书舰喵，优先进行更换喵！"
+    },
+    "CheckInterval": {
+      "name": "自定义检测时间（小时）喵",
+      "help": "更换秘书舰后会按设定时间重新检查喵！设为 0 时会根据好感度自动计算喵～如果安排秘书舰出击提升好感，设置此项就能更及时地更换秘书舰喵！"
+    },
+    "Notify": {
+      "name": "秘书舰推送喵",
+      "help": "使用 OnePush 推送秘书舰相关信息喵～"
+    },
+    "OnePushConfig": {
+      "name": "秘书舰推送通知喵",
+      "help": "秘书舰轮换完成后发送通知喵，不填写的话就使用全局推送配置喵~ (≧▽≦)"
     }
   },
   "Awaken": {
@@ -3447,6 +3492,12 @@
       "True": "已启用",
       "False": "未启用"
     },
+    "AnyShipReached": {
+      "name": "任意舰船达到等级后更换喵",
+      "help": "开启后，当任意检测舰船达到目标等级时执行自动配队\n关闭时，需要所有检测舰船达到目标等级才执行自动配队 (´・ω・`)",
+      "True": "已启用喵",
+      "False": "未启用喵"
+    },
     "CooldownHours": {
       "name": "冷却时间",
       "help": "每次自动配队后的冷却时间，避免频繁触发 (´・ω・`)",
@@ -3530,6 +3581,21 @@
       "help": "OpsiScheduling.MonthEndShopPurchase.help",
       "True": "True",
       "False": "False"
+    },
+    "BuyActionPointMode": {
+      "name": "买行动力模式喵~",
+      "help": "购买行动力专用模式喵，与现有黄币/行动力调度互斥喵~ 开启后将用石油购买行动力并执行对应任务喵。需先在「大世界通用设置 → 买行动力X次」设置每周购买上限喵~",
+      "off": "关闭喵",
+      "hazard1_leveling": "侵蚀1练级喵",
+      "meowfficer_farming": "短猫补黄币喵"
+    },
+    "BuyActionPointUpperThreshold": {
+      "name": "买行动力上限阈值喵~",
+      "help": "仅「短猫补黄币」模式使用喵~ 当前真实行动力超过此值时跳过购买，直接执行海域任务喵。默认 200（大世界行动力自然回复上限）喵~"
+    },
+    "BuyActionPointLowerThreshold": {
+      "name": "买行动力下限阈值喵~",
+      "help": "仅「短猫补黄币」模式使用喵~ 当前真实行动力低于此值时停止执行海域任务，回到购买步骤喵。默认 100 喵~"
     }
   },
   "OpsiPreventActionPointOverflow": {
@@ -3582,7 +3648,7 @@
     },
     "WorkerFilter": {
       "name": "农田使用角色喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinFarm": {
       "name": "田里庄稼底线喵",
@@ -3613,7 +3679,7 @@
     },
     "WorkerFilter": {
       "name": "果园使用角色喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinOrchard": {
       "name": "水果收割线喵",
@@ -3650,7 +3716,7 @@
     },
     "WorkerFilter": {
       "name": "苗圃使用角色喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinNursery": {
       "name": "苗圃作物底线喵",
@@ -3679,7 +3745,7 @@
     },
     "ChickenFilter": {
       "name": "养鸡使用角色喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinPork": {
       "name": "猪肉底线喵",
@@ -3687,7 +3753,7 @@
     },
     "PigFilter": {
       "name": "养猪使用角色喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Milk": {
       "name": "养牛喵",
@@ -3695,7 +3761,7 @@
     },
     "RancherFilter": {
       "name": "使用角色喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Wool": {
       "name": "养羊喵",
@@ -3703,7 +3769,7 @@
     },
     "WoolWorkerFilter": {
       "name": "养羊使用角色喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     }
   },
   "IslandFishery": {
@@ -3760,7 +3826,7 @@
     },
     "RancherFilter": {
       "name": "使用角色喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     }
   },
   "IslandMine": {
@@ -3787,7 +3853,7 @@
     },
     "WorkerFilter": {
       "name": "矿山使用角色喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinCopper": {
       "name": "铜矿底线喵",
@@ -3834,7 +3900,7 @@
     },
     "WorkerFilter": {
       "name": "林场使用角色喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "MinElegant": {
       "name": "优雅木材底线喵",
@@ -3856,7 +3922,7 @@
     },
     "WorkerFilter": {
       "name": "采集角色喵",
-      "help": "以>连接，最多填写3个角色，分别对应第1~3个采集槽位。 以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 每日采集不能选择 WorkerJuu，填写后会自动忽略。 仅识别默认排序前两排；指定角色不可用时该槽位回退现有采集逻辑。"
+      "help": "以>连接，最多填写3个角色，分别对应第1~3个采集槽位。 以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 每日采集不能选择 WorkerJuu，填写后会自动忽略。 仅识别默认排序前两排；指定角色不可用时该槽位回退现有采集逻辑。"
     }
   },
   "IslandRestaurant": {
@@ -3872,7 +3938,7 @@
     },
     "ChefFilter": {
       "name": "厨师喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "DoubleBambooShoots": {
       "name": "季节餐优先制作喵",
@@ -4101,7 +4167,7 @@
     },
     "ChefFilter": {
       "name": "厨师喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Seasonal": {
       "name": "季节饮品优先制作喵",
@@ -4312,7 +4378,7 @@
     },
     "ChefFilter": {
       "name": "厨师喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Meal1": {
       "name": "餐品1喵",
@@ -4483,7 +4549,7 @@
     },
     "ChefFilter": {
       "name": "厨师喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Meal1": {
       "name": "餐品1喵",
@@ -4672,7 +4738,7 @@
     },
     "ChefFilter": {
       "name": "厨师喵",
-      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune > 达芬奇：DaVinci 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
+      "help": "以>连接，例如肇和 新泽西 小天城：ChaoHo > NewJersey > Amagi_chan 小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 应瑞：YingSwei 恶毒：LeMalin > 独角兽：Unicorn > 岛风：Shimakaze > 柴郡：Cheshire 镇海：ChenHai > 威廉D波特：WilliamDPorter 海伦娜：Helena > 大帝：Friedrich > 愛宕：Atago 逸仙：Yixian > 奥古斯特：August > 欧根亲王：Eugen > 胡德：Hood > 标枪：Javelin > 拉菲：Laffey > 探索者：Explorer > 领航员：Navigator > 领洋者：OceanCrosser > 飞云：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 贝尔法斯特：Belfast > 长风：ChangFeng > 莫加多尔：Mogador > 皇家财富号：RoyalFortune 仅识别默认排序前两排；指定舰娘不可用时回退 WorkerJuu。"
     },
     "Friedrich": {
       "name": "大帝",
@@ -5056,8 +5122,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Char2": {
       "name": "角色2喵",
@@ -5095,8 +5160,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Product1": {
       "name": "餐品1喵",
@@ -5222,8 +5286,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Char2": {
       "name": "角色2喵",
@@ -5261,8 +5324,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Product1": {
       "name": "餐品1喵",
@@ -5400,8 +5462,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Char2": {
       "name": "角色2喵",
@@ -5439,8 +5500,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Product1": {
       "name": "餐品1喵",
@@ -5538,8 +5598,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Char2": {
       "name": "角色2喵",
@@ -5577,8 +5636,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Product1": {
       "name": "餐品1喵",
@@ -5681,8 +5739,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Char2": {
       "name": "角色2喵",
@@ -5720,8 +5777,7 @@
       "Belfast": "贝尔法斯特",
       "ChangFeng": "长风",
       "Mogador": "莫加多尔",
-      "RoyalFortune": "皇家财富号",
-      "DaVinci": "达芬奇"
+      "RoyalFortune": "皇家财富号"
     },
     "Product1": {
       "name": "餐品1喵",

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -1,15 +1,15 @@
 {
   "Menu": {
     "Alas": {
-      "name": "智慧港區Plus",
+      "name": "智慧港區+",
       "help": ""
     },
     "Farm": {
-      "name": "出擊Plus",
+      "name": "出擊+",
       "help": ""
     },
     "Event": {
-      "name": "活動Plus",
+      "name": "活動+",
       "help": ""
     },
     "EventDaily": {
@@ -25,7 +25,7 @@
       "help": ""
     },
     "Opsi": {
-      "name": "大世界Plus",
+      "name": "大世界+",
       "help": ""
     },
     "Island": {
@@ -37,7 +37,7 @@
       "help": ""
     },
     "Tool": {
-      "name": "工具Plus",
+      "name": "工具+",
       "help": ""
     }
   },
@@ -55,23 +55,23 @@
       "help": ""
     },
     "Main": {
-      "name": "主線圖-1Plus",
+      "name": "主線圖-1+",
       "help": ""
     },
     "Main2": {
-      "name": "主線圖-2Plus",
+      "name": "主線圖-2+",
       "help": ""
     },
     "Main3": {
-      "name": "主線圖-3Plus",
+      "name": "主線圖+",
       "help": ""
     },
     "GemsFarming": {
-      "name": "緊急委託Plus",
+      "name": "緊急委託+",
       "help": ""
     },
     "ThreeOilLowCost": {
-      "name": "三油低耗Plus",
+      "name": "三油低耗+",
       "help": "使用三油低耗陣容進行戰鬥，在旗艦達到32級時自動更換旗艦並退役。"
     },
     "Ambush11": {
@@ -83,23 +83,23 @@
       "help": ""
     },
     "Event": {
-      "name": "活動圖-1Plus",
+      "name": "活動圖-1+",
       "help": ""
     },
     "Event2": {
-      "name": "活動圖-2Plus",
+      "name": "活動圖-2+",
       "help": ""
     },
     "Event3": {
-      "name": "活動圖-3Plus",
+      "name": "活動圖-3+",
       "help": ""
     },
     "Raid": {
-      "name": "共鬥活動Plus",
+      "name": "共鬥活動+",
       "help": ""
     },
     "RaidScuttle": {
-      "name": "共鬥沉船Plus",
+      "name": "共鬥沉船+",
       "help": ""
     },
     "Hospital": {
@@ -111,8 +111,8 @@
       "help": ""
     },
     "CoalitionScuttle": {
-      "name": "聯盟沉船Plus",
-      "help": "聯盟活動中艦船被擊沉後刷取好感度，建議多隊出擊，第一隊就沉，建議看相關教程"
+      "name": "Task.CoalitionScuttle.name",
+      "help": "Task.CoalitionScuttle.help"
     },
     "MaritimeEscort": {
       "name": "商路護航Plus",
@@ -151,7 +151,7 @@
       "help": ""
     },
     "CoalitionSp": {
-      "name": "怪談紀實：逃離白夜山莊SP",
+      "name": "怪谈纪实：逃离白夜山庄SP",
       "help": ""
     },
     "Commission": {
@@ -185,6 +185,10 @@
     "Awaken": {
       "name": "認知覺醒",
       "help": ""
+    },
+    "Secretary": {
+      "name": "秘書艦",
+      "help": "自動檢測秘書艦好感度，達到 90 後自動更換秘書艦"
     },
     "Daily": {
       "name": "每日任務",
@@ -239,11 +243,11 @@
       "help": ""
     },
     "OpsiExplore": {
-      "name": "每月開荒Plus",
+      "name": "每月開荒+",
       "help": ""
     },
     "OpsiShop": {
-      "name": "大世界商店Plus",
+      "name": "大世界商店+",
       "help": ""
     },
     "OpsiVoucher": {
@@ -251,7 +255,7 @@
       "help": ""
     },
     "OpsiDaily": {
-      "name": "大世界每日Plus",
+      "name": "大世界-每日+",
       "help": ""
     },
     "OpsiObscure": {
@@ -275,16 +279,16 @@
       "help": ""
     },
     "OpsiMeowfficerFarming": {
-      "name": "短貓相接",
+      "name": "短貓相接+",
       "help": ""
     },
     "OpsiHazard1Leveling": {
-      "name": "侵蝕1練級",
+      "name": "侵蝕1練級+",
       "help": ""
     },
     "OpsiScheduling": {
-      "name": "智慧排程Plus",
-      "help": "大世界智慧排程Plus功能，開啟後無需重複開啟侵蝕1等任務，智慧排程Plus將全部接管"
+      "name": "智慧排程+",
+      "help": "大世界智慧排程功能，用於協調侵蝕1練級與黃幣補充任務之間的切換\n啟用後將根據黃幣和行動力自動在不同任務之間切換並傳送推送通知"
     },
     "OpsiPreventActionPointOverflow": {
       "name": "防止行動力溢出",
@@ -571,7 +575,6 @@
       "en-3": "[EN] Washington",
       "en-4": "[EN] Amagi",
       "en-5": "[EN] Little Enterprise",
-      "en-6": "[EN] Belfast",
       "jp-0": "[JP] ブレスト",
       "jp-1": "[JP] 横須賀",
       "jp-2": "[JP] 佐世保",
@@ -589,15 +592,10 @@
       "jp-14": "[JP] キール",
       "jp-15": "[JP] 若松",
       "jp-16": "[JP] オデッサ",
-      "jp-17": "[JP] スイートバン",
-      "tw-0": "[TW] 珍珠港",
-      "tw-1": "[TW] 珊瑚海",
-      "tw-2": "[TW] 中途島",
-      "tw-3": "[TW] 瓜達康納爾",
-      "tw-4": "[TW] 雷伊泰灣"
+      "jp-17": "[JP] スイートバン"
     },
     "ScreenshotMethod": {
-      "name": "選擇截圖方案",
+      "name": "模擬器截圖方案",
       "help": "使用自動選擇時，將執行一次效能測試並自動更改為最快的截圖方案\n一般情況下的速度: DroidCast_raw >> aScreenCap_nc > ADB_nc >>> aScreenCap > uiautomator2 ~= ADB\n執行 工具 - 效能測試 以尋找最快的方案",
       "auto": "自動選擇最快的",
       "ADB": "ADB",
@@ -611,7 +609,7 @@
       "ldopengl": "ldopengl"
     },
     "ControlMethod": {
-      "name": "選擇控制方案",
+      "name": "模擬器控制方案",
       "help": "速度: minitouch > Hermit >>> uiautomator2 ~= ADB\n建議選minitouch，不建議選Hermit除非在vmos下",
       "ADB": "ADB",
       "uiautomator2": "uiautomator2",
@@ -640,7 +638,7 @@
       "help": "下列數值是根據Serial自動填充的，如果不懂請不要隨意修改，修改埠即可自動啟動對應例項"
     },
     "Emulator": {
-      "name": "選擇模擬器類型",
+      "name": "模擬器類型",
       "help": "",
       "auto": "自動檢測",
       "NoxPlayer": "夜神模擬器",
@@ -718,7 +716,7 @@
       "help": "執行敏感任務出錯時停止AzurPilot，而不是重啟遊戲\n敏感任務包含隱秘海域、深淵海域、跨月每日"
     },
     "SaveErrorCount": {
-      "name": "最多保存 X 個錯誤日誌",
+      "name": "Error Log 儲存上限",
       "help": "超出上限的錯誤日誌將被刪除，若為0或負值則沒有限制"
     },
     "OnePushConfig": {
@@ -734,7 +732,7 @@
       "help": "在遊戲連續卡死（觸發GameStuckError）達到指定次數後，嘗試重啟模擬器。可能有助於解決模擬器假死或視訊記憶體溢位等問題。"
     },
     "GameStuckThreshold": {
-      "name": "遊戲卡死超過 X 秒後重啟",
+      "name": "遊戲卡死重啟閾值",
       "help": "連續卡死多少次後觸發重啟。"
     },
     "AdbOfflineRestart": {
@@ -742,7 +740,7 @@
       "help": "在連續檢測不到裝置（ADB離線或連線失敗）達到指定次數後，嘗試重啟模擬器。"
     },
     "AdbOfflineThreshold": {
-      "name": "偵測不到裝置超過 X 秒後重啟",
+      "name": "檢測不到裝置重啟閾值",
       "help": "連續檢測不到裝置多少次後觸發重啟。"
     },
     "LlmAnalysis": {
@@ -794,37 +792,38 @@
     },
     "OcrModelVersionEnglish": {
       "name": "OCR 英文模型版本",
-      "help": "選擇英文 OCR 模型檔位。lite 輕量最快，standard 均衡，pro 精度最高。auto 使用 standard。alocr_en_v2_6 為舊版 AlOCR 專用英文模型，僅 ONNX 後端可用。此項影響英文 Azur Lane 模型。",
+      "help": "選擇英文 OCR 模型版本。auto 使用英文推薦模型 AlOCR v2.6。此項影響英文 Azur Lane 模型；ncnn 後端會忽略此選擇。",
       "auto": "自動推薦",
-      "lite": "Lite 輕量",
-      "standard": "Standard 標準",
-      "pro": "Pro 高精度",
-      "alocr_en_v2_6": "AlOCR v2.6（舊版）"
+      "alocr_en_900k": "alocr_en_900k",
+      "azur_lane_v6_6": "英文 v6.6 (Azur Lane)",
+      "azur_lane_v6_5": "英文 v6.5 (Azur Lane)",
+      "ppocr_v6": "通用 PP-OCRv6",
+      "alocr_en_v2_6": "英文 AlOCR v2.6",
+      "alocr_en_v2_0": "英文 AlOCR v2.0",
+      "alocr_en_v1_0": "英文 AlOCR v1.0"
     },
     "OcrModelVersionChinese": {
       "name": "OCR 簡中模型版本",
-      "help": "選擇簡體中文 OCR 模型檔位。lite 輕量最快，standard 均衡，pro 精度最高。auto 使用 standard。alocr_cn_v3 為舊版 AlOCR 專用中文模型，僅 ONNX 後端可用。此項影響 cnocr/中文模型。",
+      "help": "選擇簡體中文 OCR 模型版本。auto 使用中文推薦模型 v6.1。此項影響 cnocr/中文模型；ncnn 後端會忽略此選擇。",
       "auto": "自動推薦",
-      "lite": "Lite 輕量",
-      "standard": "Standard 標準",
-      "pro": "Pro 高精度",
-      "alocr_cn_v3": "AlOCR v3（舊版）"
+      "cn_v6_1": "中文 v6.1",
+      "cn_v6": "中文 v6",
+      "ppocr_v6": "通用 PP-OCRv6",
+      "alocr_cn_v3": "中文 AlOCR v3",
+      "alocr_cn_v2_5": "中文 AlOCR v2.5"
     },
     "OcrModelVersionJapanese": {
       "name": "OCR 日文模型版本",
-      "help": "選擇日文 OCR 模型檔位。lite 輕量最快但不支援日語，standard 均衡，pro 精度最高。auto 使用 standard。此項影響日文模型。",
+      "help": "選擇日文 OCR 模型版本。auto 使用日文 Azur Lane v6。此項影響日文模型；ncnn 後端會忽略此選擇。",
       "auto": "自動推薦",
-      "lite": "Lite 輕量",
-      "standard": "Standard 標準",
-      "pro": "Pro 高精度"
+      "azur_lane_jp_v6": "日文 v6 (Azur Lane JP)",
+      "ppocr_v6": "通用 PP-OCRv6"
     },
     "OcrModelVersionTraditionalChinese": {
       "name": "OCR 繁中模型版本",
-      "help": "選擇繁體中文 OCR 模型檔位。lite 輕量最快，standard 均衡，pro 精度最高。auto 使用 standard。",
+      "help": "選擇繁體中文 OCR 模型版本。目前僅提供通用 PP-OCRv6，保留獨立選項以便後續擴充。ncnn 後端會忽略此選擇。",
       "auto": "自動推薦",
-      "lite": "Lite 輕量",
-      "standard": "Standard 標準",
-      "pro": "Pro 高精度"
+      "ppocr_v6": "通用 PP-OCRv6"
     },
     "ScreenshotInterval": {
       "name": "放慢截圖速度至 X 秒一張",
@@ -901,6 +900,14 @@
       "upload": "上傳",
       "save_and_upload": "儲存並上傳"
     },
+    "OpsiShopRecord": {
+      "name": "DropRecord.OpsiShopRecord.name",
+      "help": "DropRecord.OpsiShopRecord.help",
+      "do_not": "do_not",
+      "save": "save",
+      "upload": "upload",
+      "save_and_upload": "save_and_upload"
+    },
     "MeowfficerBuy": {
       "name": "指揮喵購買截圖",
       "help": "",
@@ -955,7 +962,7 @@
       "help": ""
     },
     "RetireMode": {
-      "name": "選擇退役模式",
+      "name": "退役模式",
       "help": "若選擇強化，強化材料不足時回退到一鍵退役",
       "one_click_retire": "一鍵退役",
       "enhance": "強化",
@@ -1045,7 +1052,7 @@
       "help": "格式: \"cv > bb > ...\"，\n留空則使用預設強化方式"
     },
     "CheckPerCategory": {
-      "name": "每個分類檢查 X 艘",
+      "name": "每分類強化數量",
       "help": "每個艦船分類最多強化多少艦船，\n在戰鬥中的艦船會被跳過且不計入，\n優先判斷是否有強化材料"
     }
   },
@@ -1071,7 +1078,7 @@
       "help": ""
     },
     "RetireAmount": {
-      "name": "每次退役 X 艘",
+      "name": "退役數量",
       "help": "",
       "retire_all": "退役全部",
       "retire_10": "退役10個"
@@ -1095,7 +1102,7 @@
       "coalition_20250626": "迷彩都市的尋蹤者",
       "coalition_20251120": "DATE A LANE",
       "coalition_20260122": "光影風尚-拍攝進行時",
-      "coalition_20260723": "怪談紀實",
+      "coalition_20260723": "怪谈纪实：逃离白夜山庄",
       "event_20200227_cn": "Northern Overture",
       "event_20200312_cn": "斯圖爾特的硝煙",
       "event_20200326_cn": "Microlayer Medley",
@@ -1181,7 +1188,7 @@
       "event_20260417_cn": "假日航線閃耀海濱",
       "event_20260520_cn": "聖印前的同盟",
       "event_20260625_cn": "美夢巡演奇秒夜",
-      "event_20260813_cn": "Depths of the Astrarium",
+      "event_20260813_cn": "沉溺于星光之城",
       "raid_20200624": "特別演習埃塞克斯級(復刻)",
       "raid_20210708": "復刻穿越彼方的水線",
       "raid_20220127": "演習神秘事件調查",
@@ -1243,7 +1250,7 @@
       "war_archives_20240725_cn": "檔案 幻夢間奏曲"
     },
     "Mode": {
-      "name": "選擇關卡模式",
+      "name": "關卡模式",
       "help": "僅適用於主線圖",
       "normal": "普通",
       "hard": "困難"
@@ -1326,7 +1333,7 @@
       "help": ""
     },
     "DailyRunCount": {
-      "name": "每日出擊 X 次",
+      "name": "每日出擊次數",
       "help": "每天最多執行作戰檔案多少次。\n0 表示不限制。\n達到次數後會延遲到下一次伺服器刷新，不會關閉任務。"
     },
     "DailyRunCountRemain": {
@@ -1348,7 +1355,7 @@
       "help": ""
     },
     "Fleet1": {
-      "name": "一隊使用第 X 支艦隊",
+      "name": "一隊編號",
       "help": "",
       "1": "1 ",
       "2": "2 ",
@@ -1365,7 +1372,7 @@
       "diamond": "輪形陣"
     },
     "Fleet1Mode": {
-      "name": "一隊自律戰鬥模式",
+      "name": "一隊自律模式",
       "help": "",
       "combat_auto": "自律戰鬥",
       "combat_manual": "手操",
@@ -1382,7 +1389,7 @@
       "5": "5 "
     },
     "Fleet2": {
-      "name": "二隊使用第 X 支艦隊",
+      "name": "二隊編號",
       "help": "",
       "0": "不使用",
       "1": "1 ",
@@ -1400,7 +1407,7 @@
       "diamond": "輪形陣"
     },
     "Fleet2Mode": {
-      "name": "二隊自律戰鬥模式",
+      "name": "二隊自律模式",
       "help": "",
       "combat_auto": "自律戰鬥",
       "combat_manual": "手操",
@@ -1425,8 +1432,8 @@
       "fleet1_standby_fleet2_all": "一隊待機二隊全清"
     },
     "SkipPreparation": {
-      "name": "跳過編隊檢測",
-      "help": "開啟後將跳過編隊介面的艦隊選擇步驟，直接使用遊戲內當前預選的艦隊出擊\n適用於艦隊槽位未完全解鎖的帳號，避免下拉選單檢測卡死\n開啟前請確保遊戲內已手動選好艦隊1和艦隊2"
+      "name": "Fleet.SkipPreparation.name",
+      "help": "Fleet.SkipPreparation.help"
     }
   },
   "Submarine": {
@@ -1435,14 +1442,14 @@
       "help": ""
     },
     "Fleet": {
-      "name": "使用第 X 潛艇編隊",
+      "name": "潛艇艦隊編號",
       "help": "",
       "0": "不使用",
       "1": "1 ",
       "2": "2 "
     },
     "Mode": {
-      "name": "選擇潛艇出擊方案",
+      "name": "潛艇出擊方案",
       "help": "僅在自律尋敵關閉的情況下生效，提醒: '狩獵及BOSS戰'為'僅狩獵'與'僅BOSS戰'的混合，它會在道中進行狩獵打擊，並在BOSS戰嘗試召喚潛艇。",
       "do_not_use": "不使用",
       "hunt_only": "僅狩獵",
@@ -1451,14 +1458,14 @@
       "every_combat": "每戰出擊"
     },
     "AutoSearchMode": {
-      "name": "選擇潛艇自律方案",
+      "name": "潛艇自律方案",
       "help": "僅在自律尋敵下生效",
       "sub_standby": "待機",
       "sub_auto_call": "自動召喚潛艇"
     },
     "DistanceToBoss": {
       "name": "BOSS戰前將潛艇移動到BOSS附近",
-      "help": "僅在\"潛艇出擊方案\"為\"僅BOSS戰\"及\"狩獵及BOSS戰\"時生效",
+      "help": "僅在\"潛艇出擊方案\"為\"僅BOSS戰\"及\"狩獵及BOSS戰\",時生效\n選擇\"距離BOSS X格\"需要保證潛艇狩獵範圍能覆蓋到BOSS，距離使用曼哈頓距離計算，選擇\"使用遠洋支援\"需要潛艇隊伍裡有U522/達芬奇",
       "to_boss_position": "至 BOSS 所在位置",
       "1_grid_to_boss": "距離 BOSS 1 格",
       "2_grid_to_boss": "距離 BOSS 2 格",
@@ -1603,7 +1610,7 @@
   },
   "C72MysteryFarming": {
     "_info": {
-      "name": "7-2 三戰揀垃圾",
+      "name": "7-2 三站揀垃圾",
       "help": "打三戰，揀完問號後撤退"
     },
     "StepOnA3": {
@@ -1752,7 +1759,7 @@
       "help": ""
     },
     "PtLimit": {
-      "name": "活動PT達到 X 後停止",
+      "name": "活動 PT 限制",
       "help": "當累計 PT 達到給定數值時，停用所有活動任務，0 表示不限制，使用自律尋敵時不能即時觸發\n開啟後，你只需要開啟所有活動任務，而不需要計算一共打多少次"
     },
     "TimeLimit": {
@@ -1770,7 +1777,7 @@
       "help": "啟用後，將於每次出擊後檢查物資量"
     },
     "CoinLimit": {
-      "name": "保持物資大於 X",
+      "name": "保持物資大於X",
       "help": ""
     },
     "TaskCall": {
@@ -1903,15 +1910,15 @@
   },
   "CoalitionScuttle": {
     "_info": {
-      "name": "聯盟沉船",
-      "help": "聯盟活動沉船設定，選擇被擊沉艦船位置"
+      "name": "CoalitionScuttle._info.name",
+      "help": "CoalitionScuttle._info.help"
     },
     "Sacrifice": {
-      "name": "犧牲船位置",
-      "help": "選擇被擊沉的艦船位置，前排/旗艦/前排+旗艦",
-      "vanguard": "前排",
-      "flagship": "旗艦",
-      "vanguard_flagship": "前排+旗艦"
+      "name": "CoalitionScuttle.Sacrifice.name",
+      "help": "CoalitionScuttle.Sacrifice.help",
+      "vanguard": "vanguard",
+      "flagship": "flagship",
+      "vanguard_flagship": "vanguard_flagship"
     }
   },
   "EventShop": {
@@ -1992,13 +1999,21 @@
       "name": "做主要委託（1200油/1000油委託）",
       "help": "1200油委託現在已經過時，收益很低，建議關閉"
     },
+    "GemNotify": {
+      "name": "Commission.GemNotify.name",
+      "help": "Commission.GemNotify.help"
+    },
     "CommissionNotifyReward": {
-      "name": "委託獎勵推送通知",
-      "help": "獲得委託獎勵時推送通知（特別關注鑽石獎勵）"
+      "name": "委託成功獲取鑽石推送",
+      "help": "注意，請啟用並設定「錯誤推送設定」，否則此功能將不會生效。"
     },
     "CommissionNotifyRewardStatistics": {
-      "name": "推送包含統計資訊",
-      "help": "在通知中顯示今日/本週/本月累計鑽石數量"
+      "name": "鑽石推送詳情",
+      "help": "開啟後，AzurPilot在推送本次委託獲取鑽石數量的同時推送當日/本週/本月的鑽石獲取數量"
+    },
+    "CommissionNotifyRewardCube": {
+      "name": "Commission.CommissionNotifyRewardCube.name",
+      "help": "Commission.CommissionNotifyRewardCube.help"
     }
   },
   "Tactical": {
@@ -2036,19 +2051,19 @@
       "help": ""
     },
     "T4Allow": {
-      "name": "允許T4技能書溢出 X 點經驗",
+      "name": "允許 T4 技能書溢位 X 點經驗",
       "help": ""
     },
     "T3Allow": {
-      "name": "允許T3技能書溢出 X 點經驗",
+      "name": "允許 T3 技能書溢位 X 點經驗",
       "help": ""
     },
     "T2Allow": {
-      "name": "允許T2技能書溢出 X 點經驗",
+      "name": "允許 T2 技能書溢位 X 點經驗",
       "help": ""
     },
     "T1Allow": {
-      "name": "允許T1技能書溢出 X 點經驗",
+      "name": "允許 T1 技能書溢位 X 點經驗",
       "help": ""
     }
   },
@@ -2066,7 +2081,7 @@
       "help": ""
     },
     "MinLevel": {
-      "name": "僅添加等級 >= X 的角色",
+      "name": "僅新增等級 >= X 的角色",
       "help": ""
     }
   },
@@ -2212,7 +2227,7 @@
       "help": ""
     },
     "Mode": {
-      "name": "選擇訓練模式",
+      "name": "訓練模式",
       "help": "無縫練貓將每隔 2.5 ~ 3.5 小時收取指揮貓\n每天收一隻意思是每天收一隻，週日收全部、強化並重新填充佇列，以完成每週任務",
       "seamlessly": "無縫練貓",
       "once_a_day": "每天收一隻"
@@ -2308,6 +2323,36 @@
       "help": ""
     }
   },
+  "Secretary": {
+    "_info": {
+      "name": "秘書艦設定",
+      "help": "設定秘書艦自動更換及推播通知"
+    },
+    "CustomFilter": {
+      "name": "稀有度篩選器",
+      "help": "稀有度包含海上傳奇ultra、超稀有super_rare、精銳elite、稀有rare、普通common\n請在下方填入自訂的順序\n預設排序為ultra > super_rare > elite > rare > common"
+    },
+    "LowFavorabilityPriority": {
+      "name": "低好感度優先",
+      "help": "將按照好感度由低到高的順序選擇"
+    },
+    "BackupEnable": {
+      "name": "候補秘書艦",
+      "help": "將秘書組艦船作為候補秘書艦，優先進行更換"
+    },
+    "CheckInterval": {
+      "name": "自訂檢測時間（小時）",
+      "help": "更換秘書艦後依照設定時間進行檢測。當此項為 0 時，將依好感度自動計算；若安排秘書艦出擊提升好感度，設定此項可及時更換秘書艦。"
+    },
+    "Notify": {
+      "name": "秘書艦推播",
+      "help": "使用 OnePush 推播秘書艦相關資訊"
+    },
+    "OnePushConfig": {
+      "name": "OnePush 推播設定",
+      "help": "用於秘書艦更換通知，留空則使用全域設定"
+    }
+  },
   "Awaken": {
     "_info": {
       "name": "認知覺醒",
@@ -2331,7 +2376,7 @@
     },
     "Enable": {
       "name": "商店開關",
-      "help": "開啟後才會執行該商店，關閉後會在任務中跳過該商店"
+      "help": ""
     },
     "UseGems": {
       "name": "使用鑽石",
@@ -2365,7 +2410,7 @@
     },
     "Enable": {
       "name": "商店開關",
-      "help": "開啟後才會執行該商店，關閉後會在任務中跳過該商店"
+      "help": ""
     },
     "Refresh": {
       "name": "重新整理商店",
@@ -2482,7 +2527,7 @@
     },
     "Enable": {
       "name": "商店開關",
-      "help": "開啟後才會執行該商店，關閉後會在任務中跳過該商店"
+      "help": ""
     },
     "Filter": {
       "name": "商店過濾器",
@@ -2587,7 +2632,7 @@
       "6": "六期科研"
     },
     "ShipIndex": {
-      "name": "選擇第 X 艘科研船",
+      "name": "艦船序號",
       "help": "從左往右數，從 1 開始",
       "0": "不購買",
       "1": "1",
@@ -2622,7 +2667,7 @@
       "6": "六期科研"
     },
     "ShipIndex": {
-      "name": "選擇第 X 艘科研船",
+      "name": "艦船序號",
       "help": "從左往右數，從1開始",
       "0": "不購買",
       "1": "1",
@@ -2656,7 +2701,7 @@
       "wishing_well": "祈願池"
     },
     "Amount": {
-      "name": "每天建造 X 次",
+      "name": "抽卡數量",
       "help": "",
       "1": "1",
       "2": "2",
@@ -2781,7 +2826,7 @@
       "new_jersey": "紐澤西",
       "taihou": "大鳳",
       "aegir": "埃吉爾",
-      "nakhimov": "納希莫夫"
+      "nakhimov": "纳希莫夫"
     }
   },
   "Daily": {
@@ -2972,7 +3017,7 @@
       "help": "推薦 1.0 ~ 3.0，因為人物立繪會遮擋血條，所以需要一定的時間確認血量是否真的低於閾值"
     },
     "OpponentRefreshValue": {
-      "name": "今日已重新整理對手 X 次",
+      "name": "今日演習對手已重新整理 X 次",
       "help": "自動更新的數值，過0點重置\n如果你手動重新整理的對手，應該修改這個數值"
     },
     "OpponentRefreshRecord": {
@@ -3018,7 +3063,7 @@
       "help": "每次進入倉庫的時候，使用所有的使用坐標記錄儀"
     },
     "BuyActionPointLimit": {
-      "name": "購買行動力 X 次",
+      "name": "買行動力X次",
       "help": "買行動力的最大次數",
       "0": "不買",
       "1": "1次 (1000油, 100行動力)",
@@ -3045,7 +3090,7 @@
     },
     "RepairPackThresholdHazard1": {
       "name": "任意艦船血量低於 X 後，使用維修箱修理（侵蝕1）",
-      "help": "僅在開啟“使用維修箱修船”時生效\n僅在「侵蝕1練級Plus」任務中嘗試維修\n0.0 ~ 1.0"
+      "help": "僅在開啟“使用維修箱修船”時生效\n僅在「侵蝕1練級+」任務中嘗試維修\n0.0 ~ 1.0"
     },
     "DoRandomMapEvent": {
       "name": "完成地圖隨機事件",
@@ -3139,7 +3184,7 @@
   },
   "OpsiExplore": {
     "_info": {
-      "name": "大世界開荒Plus",
+      "name": "大世界開荒",
       "help": "每月月初開荒大世界的所有海域，不需要買戰役資訊記錄儀（5000油道具）\n這個功能將每隔27分鐘清理一個海域，以保證空域搜尋冷卻\n使用此功能前必須滿足以下條件：\n- 通關大世界主線並完成模擬戰+塞壬試驗場"
     },
     "SpecialRadar": {
@@ -3165,7 +3210,7 @@
   },
   "OpsiShop": {
     "_info": {
-      "name": "大世界商店Plus",
+      "name": "大世界商店",
       "help": "使用此功能前必須滿足以下條件：\n- 通關大世界主線並完成模擬戰+塞壬試驗場\n- 啟用大世界開荒任務或使用戰役資訊記錄儀（5000油道具）\n- 通關大世界主線後的下一個月，即港口商店變為新版商店後才可使用"
     },
     "PresetFilter": {
@@ -3182,7 +3227,7 @@
       "help": "使用自定義過濾器需將 \"港口商店過濾器\" 設定為 \"自定義\"，並閱讀 https://github.com/LmeSzinc/AzurLaneAutoScript/wiki/filter_string_cn"
     },
     "DisableBeforeDate": {
-      "name": "每月 X 號前，不購買大世界商店Plus",
+      "name": "每月 X 號前，不購買大世界商店",
       "help": "從指定日期的後一天開始，每天買一次大世界商店\n0 表示不限制，每天都購買"
     }
   },
@@ -3198,11 +3243,11 @@
   },
   "OpsiDaily": {
     "_info": {
-      "name": "大世界每日Plus",
+      "name": "大世界每日",
       "help": "使用此功能前必須滿足以下條件：\n- 通關大世界主線並完成模擬戰+塞壬試驗場\n- 啟用大世界開荒任務或使用戰役資訊記錄儀（5000油道具）"
     },
     "DoMission": {
-      "name": "做大世界每日Plus",
+      "name": "做大世界每日",
       "help": "在港口接每日，並完成所有每日"
     },
     "UseTuningSample": {
@@ -3447,6 +3492,12 @@
       "True": "開啟",
       "False": "關閉"
     },
+    "AnyShipReached": {
+      "name": "任意艦船達到等級後更換",
+      "help": "啟用後，當任意檢查中的艦船達到目標等級時執行自動配隊。\n停用時，需要所有檢查中的艦船達到目標等級才執行自動配隊",
+      "True": "開啟",
+      "False": "關閉"
+    },
     "CooldownHours": {
       "name": "冷卻時間(小時)",
       "help": "每次自動配隊後的冷卻時間，避免頻繁觸發",
@@ -3462,11 +3513,11 @@
   },
   "OpsiScheduling": {
     "_info": {
-      "name": "智慧排程Plus",
+      "name": "智慧排程",
       "help": "大世界智慧排程功能，用於協調侵蝕1練級與黃幣補充任務之間的切換\n啟用後將根據黃幣和行動力自動在不同任務之間切換並傳送推送通知\n\n原版 AzurPilot 的一些防呆限制已被解除，請謹慎設定引數"
     },
     "UseSmartSchedulingOperationCoinsPreserve": {
-      "name": "保留 X 個作戰補給憑證",
+      "name": "獲取 X 個作戰補給憑證",
       "help": "啟用後將使用下方設定的 獲取 X 個作戰補給憑證 的配置，停用則使用侵蝕1練級 黃幣保留配置\n關閉後將使用行動力控制\n開啟後使用黃幣控制",
       "True": "開啟",
       "False": "關閉"
@@ -3480,7 +3531,7 @@
       "help": "行動力低於 X 後停止，自動開啟行動力箱子，X 包含箱子中的行動力，建議保留1000行動力給侵蝕1練級"
     },
     "OperationCoinsReturnThreshold": {
-      "name": "作戰補給憑證低於 X 時返航",
+      "name": "獲取 X 個作戰補給憑證",
       "help": "在黃幣獲取任務時 共獲取(增加) X 個作戰補給憑證後返回侵蝕1練級"
     },
     "EnableMeowfficerFarming": {
@@ -3530,6 +3581,21 @@
       "help": "OpsiScheduling.MonthEndShopPurchase.help",
       "True": "True",
       "False": "False"
+    },
+    "BuyActionPointMode": {
+      "name": "買行動力模式",
+      "help": "購買行動力專用模式，與現有黃幣/行動力調度互斥。開啟後將用石油購買行動力並執行對應任務。需先在「大世界通用設定 → 買行動力X次」設定每週購買上限。",
+      "off": "關閉",
+      "hazard1_leveling": "侵蝕1練級",
+      "meowfficer_farming": "短貓補黃幣"
+    },
+    "BuyActionPointUpperThreshold": {
+      "name": "買行動力上限閾值",
+      "help": "僅「短貓補黃幣」模式使用。當前真實行動力超過此值時跳過購買，直接執行海域任務。預設 200（大世界行動力自然回覆上限）。"
+    },
+    "BuyActionPointLowerThreshold": {
+      "name": "買行動力下限閾值",
+      "help": "僅「短貓補黃幣」模式使用。當前真實行動力低於此值時停止執行海域任務，回到購買步驟。預設 100。"
     }
   },
   "OpsiPreventActionPointOverflow": {
@@ -3582,7 +3648,7 @@
     },
     "WorkerFilter": {
       "name": "農田使用角色",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "MinFarm": {
       "name": "農田作物底線",
@@ -3613,7 +3679,7 @@
     },
     "WorkerFilter": {
       "name": "果園使用角色",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "MinOrchard": {
       "name": "水果底線",
@@ -3650,7 +3716,7 @@
     },
     "WorkerFilter": {
       "name": "苗圃使用角色",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "MinNursery": {
       "name": "苗圃作物底線",
@@ -3679,7 +3745,7 @@
     },
     "ChickenFilter": {
       "name": "養雞使用角色",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "MinPork": {
       "name": "豬肉底線",
@@ -3687,7 +3753,7 @@
     },
     "PigFilter": {
       "name": "養豬使用角色",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "Milk": {
       "name": "養牛",
@@ -3695,7 +3761,7 @@
     },
     "RancherFilter": {
       "name": "使用角色",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "Wool": {
       "name": "養羊",
@@ -3703,7 +3769,7 @@
     },
     "WoolWorkerFilter": {
       "name": "養羊使用角色",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     }
   },
   "IslandFishery": {
@@ -3760,7 +3826,7 @@
     },
     "RancherFilter": {
       "name": "使用角色",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     }
   },
   "IslandMine": {
@@ -3769,7 +3835,7 @@
       "help": ""
     },
     "Positions": {
-      "name": "安排 X 個礦工崗位",
+      "name": "崗位數量",
       "help": "",
       "1": "1",
       "2": "2",
@@ -3787,7 +3853,7 @@
     },
     "WorkerFilter": {
       "name": "礦山使用角色",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "MinCopper": {
       "name": "銅礦最低庫存",
@@ -3816,7 +3882,7 @@
       "help": ""
     },
     "Positions": {
-      "name": "安排 X 個伐木工崗位",
+      "name": "崗位數量",
       "help": "",
       "1": "1",
       "2": "2",
@@ -3834,7 +3900,7 @@
     },
     "WorkerFilter": {
       "name": "林場使用角色",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "MinElegant": {
       "name": "優雅木材最低庫存",
@@ -3856,7 +3922,7 @@
     },
     "WorkerFilter": {
       "name": "採集角色",
-      "help": "以>連接，最多填寫3個角色，分別對應第1~3個採集槽位。\n以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n每日採集不能選擇 WorkerJuu，填寫後會自動忽略。\n僅識別預設排序前兩排；指定角色不可用時該槽位回退現有採集邏輯。"
+      "help": "以>連接，最多填寫3個角色，分別對應第1~3個採集槽位。\n以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n每日採集不能選擇 WorkerJuu，填寫後會自動忽略。\n僅識別預設排序前兩排；指定角色不可用時該槽位回退現有採集邏輯。"
     }
   },
   "IslandRestaurant": {
@@ -3865,14 +3931,14 @@
       "help": "餐品會按從1~8的順序依次生產，生產目標為餐品X數量選項，完全滿足前一項後才會執行下一項，後一項在運行時不會影響之前幾項任務的達成\n餐品1-8中的涼拌雙筍和蘆筍炒蝦仁會根據當前季節自動切換為對應季節餐品"
     },
     "PostNumber": {
-      "name": "安排 X 個廚師崗位",
+      "name": "崗位數量",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "廚師",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "DoubleBambooShoots": {
       "name": "季節餐優先製作",
@@ -3898,7 +3964,7 @@
       "persimmon_cake": "柿子餅"
     },
     "MealNumber1": {
-      "name": "生產餐品1至 X 份",
+      "name": "餐品1數量",
       "help": ""
     },
     "Meal2": {
@@ -3921,7 +3987,7 @@
       "persimmon_cake": "柿子餅"
     },
     "MealNumber2": {
-      "name": "生產餐品2至 X 份",
+      "name": "餐品2數量",
       "help": ""
     },
     "Meal3": {
@@ -3944,7 +4010,7 @@
       "persimmon_cake": "柿子餅"
     },
     "MealNumber3": {
-      "name": "生產餐品3至 X 份",
+      "name": "餐品3數量",
       "help": ""
     },
     "Meal4": {
@@ -3967,7 +4033,7 @@
       "persimmon_cake": "柿子餅"
     },
     "MealNumber4": {
-      "name": "生產餐品4至 X 份",
+      "name": "餐品4數量",
       "help": ""
     },
     "Meal5": {
@@ -3990,7 +4056,7 @@
       "persimmon_cake": "柿子餅"
     },
     "MealNumber5": {
-      "name": "生產餐品5至 X 份",
+      "name": "餐品5數量",
       "help": ""
     },
     "Meal6": {
@@ -4013,7 +4079,7 @@
       "persimmon_cake": "柿子餅"
     },
     "MealNumber6": {
-      "name": "生產餐品6至 X 份",
+      "name": "餐品6數量",
       "help": ""
     },
     "Meal7": {
@@ -4036,7 +4102,7 @@
       "persimmon_cake": "柿子餅"
     },
     "MealNumber7": {
-      "name": "生產餐品7至 X 份",
+      "name": "餐品7數量",
       "help": ""
     },
     "Meal8": {
@@ -4059,7 +4125,7 @@
       "persimmon_cake": "柿子餅"
     },
     "MealNumber8": {
-      "name": "生產餐品8至 X 份",
+      "name": "餐品8數量",
       "help": ""
     }
   },
@@ -4091,17 +4157,17 @@
   "IslandTeahouse": {
     "_info": {
       "name": "白熊飲品",
-      "help": "餐品會按從1~8的順序依次生產，生產目標為餐品X數量選項，完全滿足前一項後才會執行下一項，後一項在運行時不會影響之前幾項任務的達成\n蜂蜜製品支援自動生產，需保證蜂蜜庫存充足\n餐品中的迎春花茶和鮮榨鳳梨汁會根據當前季節自動切換為對應季節餐品"
+      "help": "餐品會按從1~8的順序依次生產，生產目標為餐品X數量選項，完全滿足前一項後才會執行下一項，後一項在運行時不會影響之前幾項任務的達成\n請手動製作蜂蜜製品\n餐品中的迎春花茶和鮮榨鳳梨汁會根據當前季節自動切換為對應季節餐品"
     },
     "PostNumber": {
-      "name": "安排 X 個調飲師崗位",
+      "name": "崗位數量",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "廚師",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "Seasonal": {
       "name": "季節飲品優先製作",
@@ -4125,7 +4191,7 @@
       "carrot_pear_juice": "胡蘿蔔秋梨汁"
     },
     "MealNumber1": {
-      "name": "生產餐品1至 X 份",
+      "name": "餐品1數量",
       "help": ""
     },
     "Meal2": {
@@ -4146,7 +4212,7 @@
       "carrot_pear_juice": "胡蘿蔔秋梨汁"
     },
     "MealNumber2": {
-      "name": "生產餐品2至 X 份",
+      "name": "餐品2數量",
       "help": ""
     },
     "Meal3": {
@@ -4167,7 +4233,7 @@
       "carrot_pear_juice": "胡蘿蔔秋梨汁"
     },
     "MealNumber3": {
-      "name": "生產餐品3至 X 份",
+      "name": "餐品3數量",
       "help": ""
     },
     "Meal4": {
@@ -4188,7 +4254,7 @@
       "carrot_pear_juice": "胡蘿蔔秋梨汁"
     },
     "MealNumber4": {
-      "name": "生產餐品4至 X 份",
+      "name": "餐品4數量",
       "help": ""
     },
     "Meal5": {
@@ -4209,7 +4275,7 @@
       "carrot_pear_juice": "胡蘿蔔秋梨汁"
     },
     "MealNumber5": {
-      "name": "生產餐品5至 X 份",
+      "name": "餐品5數量",
       "help": ""
     },
     "Meal6": {
@@ -4230,7 +4296,7 @@
       "carrot_pear_juice": "胡蘿蔔秋梨汁"
     },
     "MealNumber6": {
-      "name": "生產餐品6至 X 份",
+      "name": "餐品6數量",
       "help": ""
     },
     "Meal7": {
@@ -4251,7 +4317,7 @@
       "carrot_pear_juice": "胡蘿蔔秋梨汁"
     },
     "MealNumber7": {
-      "name": "生產餐品7至 X 份",
+      "name": "餐品7數量",
       "help": ""
     },
     "Meal8": {
@@ -4272,7 +4338,7 @@
       "carrot_pear_juice": "胡蘿蔔秋梨汁"
     },
     "MealNumber8": {
-      "name": "生產餐品8至 X 份",
+      "name": "餐品8數量",
       "help": ""
     }
   },
@@ -4305,14 +4371,14 @@
       "help": "餐品會按從1~8的順序依次生產，生產目標為餐品X數量選項，完全滿足前一項後才會執行下一項，後一項在運行時不會影響之前幾項任務的達成"
     },
     "PostNumber": {
-      "name": "安排 X 個燒烤師崗位",
+      "name": "崗位數量",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "廚師",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "Meal1": {
       "name": "餐品1",
@@ -4328,7 +4394,7 @@
       "double_energy": "能量雙拼套餐"
     },
     "MealNumber1": {
-      "name": "生產餐品1至 X 份",
+      "name": "餐品1數量",
       "help": ""
     },
     "Meal2": {
@@ -4345,7 +4411,7 @@
       "double_energy": "能量雙拼套餐"
     },
     "MealNumber2": {
-      "name": "生產餐品2至 X 份",
+      "name": "餐品2數量",
       "help": ""
     },
     "Meal3": {
@@ -4362,7 +4428,7 @@
       "double_energy": "能量雙拼套餐"
     },
     "MealNumber3": {
-      "name": "生產餐品3至 X 份",
+      "name": "餐品3數量",
       "help": ""
     },
     "Meal4": {
@@ -4379,7 +4445,7 @@
       "double_energy": "能量雙拼套餐"
     },
     "MealNumber4": {
-      "name": "生產餐品4至 X 份",
+      "name": "餐品4數量",
       "help": ""
     },
     "Meal5": {
@@ -4396,7 +4462,7 @@
       "double_energy": "能量雙拼套餐"
     },
     "MealNumber5": {
-      "name": "生產餐品5至 X 份",
+      "name": "餐品5數量",
       "help": ""
     },
     "Meal6": {
@@ -4413,7 +4479,7 @@
       "double_energy": "能量雙拼套餐"
     },
     "MealNumber6": {
-      "name": "生產餐品6至 X 份",
+      "name": "餐品6數量",
       "help": ""
     },
     "Meal7": {
@@ -4430,7 +4496,7 @@
       "double_energy": "能量雙拼套餐"
     },
     "MealNumber7": {
-      "name": "生產餐品7至 X 份",
+      "name": "餐品7數量",
       "help": ""
     },
     "Meal8": {
@@ -4447,7 +4513,7 @@
       "double_energy": "能量雙拼套餐"
     },
     "MealNumber8": {
-      "name": "生產餐品8至 X 份",
+      "name": "餐品8數量",
       "help": ""
     }
   },
@@ -4476,14 +4542,14 @@
       "help": "餐品會按從1~8的順序依次生產，生產目標為餐品X數量選項，完全滿足前一項後才會執行下一項，後一項在運行時不會影響之前幾項任務的達成"
     },
     "PostNumber": {
-      "name": "安排 X 個簡餐師崗位",
+      "name": "崗位數量",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "廚師",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "Meal1": {
       "name": "餐品1",
@@ -4501,7 +4567,7 @@
       "seafood_rice": "海鮮飯"
     },
     "MealNumber1": {
-      "name": "生產餐品1至 X 份",
+      "name": "餐品1數量",
       "help": ""
     },
     "Meal2": {
@@ -4520,7 +4586,7 @@
       "seafood_rice": "海鮮飯"
     },
     "MealNumber2": {
-      "name": "生產餐品2至 X 份",
+      "name": "餐品2數量",
       "help": ""
     },
     "Meal3": {
@@ -4539,7 +4605,7 @@
       "seafood_rice": "海鮮飯"
     },
     "MealNumber3": {
-      "name": "生產餐品3至 X 份",
+      "name": "餐品3數量",
       "help": ""
     },
     "Meal4": {
@@ -4558,7 +4624,7 @@
       "seafood_rice": "海鮮飯"
     },
     "MealNumber4": {
-      "name": "生產餐品4至 X 份",
+      "name": "餐品4數量",
       "help": ""
     },
     "Meal5": {
@@ -4577,7 +4643,7 @@
       "seafood_rice": "海鮮飯"
     },
     "MealNumber5": {
-      "name": "生產餐品5至 X 份",
+      "name": "餐品5數量",
       "help": ""
     },
     "Meal6": {
@@ -4596,7 +4662,7 @@
       "seafood_rice": "海鮮飯"
     },
     "MealNumber6": {
-      "name": "生產餐品6至 X 份",
+      "name": "餐品6數量",
       "help": ""
     },
     "Meal7": {
@@ -4615,7 +4681,7 @@
       "seafood_rice": "海鮮飯"
     },
     "MealNumber7": {
-      "name": "生產餐品7至 X 份",
+      "name": "餐品7數量",
       "help": ""
     },
     "Meal8": {
@@ -4634,7 +4700,7 @@
       "seafood_rice": "海鮮飯"
     },
     "MealNumber8": {
-      "name": "生產餐品8至 X 份",
+      "name": "餐品8數量",
       "help": ""
     }
   },
@@ -4665,14 +4731,14 @@
       "help": "餐品會按從1~8的順序依次生產，生產目標為餐品X數量選項，完全滿足前一項後才會執行下一項，後一項在運行時不會影響之前幾項任務的達成"
     },
     "PostNumber": {
-      "name": "安排 X 個咖啡師崗位",
+      "name": "崗位數量",
       "help": "",
       "1": "1",
       "2": "2"
     },
     "ChefFilter": {
       "name": "廚師",
-      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune > 達芬奇：DaVinci\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
+      "help": "以>連接，例如肇和 新澤西 小天城：ChaoHo > NewJersey > Amagi_chan\n小加加：Saratoga > 明石：Akashi > 塔什干：Tashkent > 應瑞：YingSwei\n惡毒：LeMalin > 獨角獸：Unicorn > 島風：Shimakaze > 柴郡：Cheshire\n鎮海：ChenHai > 威廉D波特：WilliamDPorter\n海倫娜：Helena > 大帝：Friedrich > 愛宕：Atago\n逸仙：Yixian > 奧古斯特：August > 歐根親王：Eugen > 胡德：Hood > 標槍：Javelin > 拉菲：Laffey > 探索者：Explorer > 領航員：Navigator > 領洋者：OceanCrosser > 飛雲：FeiYun > 高雄：Takao > 安克雷奇：Anchorage > 貝爾法斯特：Belfast > 長風：ChangFeng > 莫加多爾：Mogador > 皇家財富號：RoyalFortune\n僅識別預設排序前兩排；指定艦娘不可用時回退 WorkerJuu。"
     },
     "Friedrich": {
       "name": "大帝",
@@ -4693,7 +4759,7 @@
       "fruity_fruitier": "果香雙杯樂"
     },
     "MealNumber1": {
-      "name": "生產餐品1至 X 份",
+      "name": "餐品1數量",
       "help": ""
     },
     "Meal2": {
@@ -4711,7 +4777,7 @@
       "fruity_fruitier": "果香雙杯樂"
     },
     "MealNumber2": {
-      "name": "生產餐品2至 X 份",
+      "name": "餐品2數量",
       "help": ""
     },
     "Meal3": {
@@ -4729,7 +4795,7 @@
       "fruity_fruitier": "果香雙杯樂"
     },
     "MealNumber3": {
-      "name": "生產餐品3至 X 份",
+      "name": "餐品3數量",
       "help": ""
     },
     "Meal4": {
@@ -4747,7 +4813,7 @@
       "fruity_fruitier": "果香雙杯樂"
     },
     "MealNumber4": {
-      "name": "生產餐品4至 X 份",
+      "name": "餐品4數量",
       "help": ""
     },
     "Meal5": {
@@ -4765,7 +4831,7 @@
       "fruity_fruitier": "果香雙杯樂"
     },
     "MealNumber5": {
-      "name": "生產餐品5至 X 份",
+      "name": "餐品5數量",
       "help": ""
     },
     "Meal6": {
@@ -4783,7 +4849,7 @@
       "fruity_fruitier": "果香雙杯樂"
     },
     "MealNumber6": {
-      "name": "生產餐品6至 X 份",
+      "name": "餐品6數量",
       "help": ""
     },
     "Meal7": {
@@ -4801,7 +4867,7 @@
       "fruity_fruitier": "果香雙杯樂"
     },
     "MealNumber7": {
-      "name": "生產餐品7至 X 份",
+      "name": "餐品7數量",
       "help": ""
     },
     "Meal8": {
@@ -4819,7 +4885,7 @@
       "fruity_fruitier": "果香雙杯樂"
     },
     "MealNumber8": {
-      "name": "生產餐品8至 X 份",
+      "name": "餐品8數量",
       "help": ""
     }
   },
@@ -5056,8 +5122,7 @@
       "Belfast": "貝爾法斯特",
       "ChangFeng": "長風",
       "Mogador": "莫加多爾",
-      "RoyalFortune": "皇家財富號",
-      "DaVinci": "達芬奇"
+      "RoyalFortune": "皇家財富號"
     },
     "Char2": {
       "name": "角色2",
@@ -5095,8 +5160,7 @@
       "Belfast": "貝爾法斯特",
       "ChangFeng": "長風",
       "Mogador": "莫加多爾",
-      "RoyalFortune": "皇家財富號",
-      "DaVinci": "達芬奇"
+      "RoyalFortune": "皇家財富號"
     },
     "Product1": {
       "name": "餐品1",
@@ -5222,8 +5286,7 @@
       "Belfast": "貝爾法斯特",
       "ChangFeng": "長風",
       "Mogador": "莫加多爾",
-      "RoyalFortune": "皇家財富號",
-      "DaVinci": "達芬奇"
+      "RoyalFortune": "皇家財富號"
     },
     "Char2": {
       "name": "角色2",
@@ -5261,8 +5324,7 @@
       "Belfast": "貝爾法斯特",
       "ChangFeng": "長風",
       "Mogador": "莫加多爾",
-      "RoyalFortune": "皇家財富號",
-      "DaVinci": "達芬奇"
+      "RoyalFortune": "皇家財富號"
     },
     "Product1": {
       "name": "餐品1",
@@ -5400,8 +5462,7 @@
       "Belfast": "貝爾法斯特",
       "ChangFeng": "長風",
       "Mogador": "莫加多爾",
-      "RoyalFortune": "皇家財富號",
-      "DaVinci": "達芬奇"
+      "RoyalFortune": "皇家財富號"
     },
     "Char2": {
       "name": "角色2",
@@ -5439,8 +5500,7 @@
       "Belfast": "貝爾法斯特",
       "ChangFeng": "長風",
       "Mogador": "莫加多爾",
-      "RoyalFortune": "皇家財富號",
-      "DaVinci": "達芬奇"
+      "RoyalFortune": "皇家財富號"
     },
     "Product1": {
       "name": "餐品1",
@@ -5538,8 +5598,7 @@
       "Belfast": "貝爾法斯特",
       "ChangFeng": "長風",
       "Mogador": "莫加多爾",
-      "RoyalFortune": "皇家財富號",
-      "DaVinci": "達芬奇"
+      "RoyalFortune": "皇家財富號"
     },
     "Char2": {
       "name": "角色2",
@@ -5577,8 +5636,7 @@
       "Belfast": "貝爾法斯特",
       "ChangFeng": "長風",
       "Mogador": "莫加多爾",
-      "RoyalFortune": "皇家財富號",
-      "DaVinci": "達芬奇"
+      "RoyalFortune": "皇家財富號"
     },
     "Product1": {
       "name": "餐品1",
@@ -5681,8 +5739,7 @@
       "Belfast": "貝爾法斯特",
       "ChangFeng": "長風",
       "Mogador": "莫加多爾",
-      "RoyalFortune": "皇家財富號",
-      "DaVinci": "達芬奇"
+      "RoyalFortune": "皇家財富號"
     },
     "Char2": {
       "name": "角色2",
@@ -5720,8 +5777,7 @@
       "Belfast": "貝爾法斯特",
       "ChangFeng": "長風",
       "Mogador": "莫加多爾",
-      "RoyalFortune": "皇家財富號",
-      "DaVinci": "達芬奇"
+      "RoyalFortune": "皇家財富號"
     },
     "Product1": {
       "name": "餐品1",
@@ -5869,7 +5925,7 @@
       "help": "目前版本搭建點擊流程：船塢、第一艘、快速更換、裝備中、佔位換裝邏輯、下一艘。"
     },
     "ShipLimit": {
-      "name": "處理前 X 艘艦船",
+      "name": "處理艦船上限",
       "help": "0 表示一直處理到無法切換下一艘；除錯時可設定為 1 或其他較小數量。"
     },
     "EnableSlot1": {
@@ -5909,7 +5965,7 @@
       "help": "測試哪個截圖方案和控制方案速度更快，速度因模擬器和電腦配置而異\n測試完成後，在 \"AzurPilot\" - \"模擬器設定\" 內選擇最快的截圖和控制方案"
     },
     "DeviceType": {
-      "name": "選擇裝置類型",
+      "name": "裝置類型",
       "help": "",
       "emulator": "模擬器",
       "plone_cloud_with_adb": "雲手機 有公網ADB",
@@ -6116,7 +6172,7 @@
     },
     "Status": {
       "Running": "秘書艦正在處理",
-      "Inactive": "茗正在偷走你的箱子",
+      "Inactive": "墨丶非正在抢金行动力箱子给你",
       "Warning": "發生錯誤",
       "Updating": "等待更新"
     },

--- a/module/daily/daily.py
+++ b/module/daily/daily.py
@@ -44,7 +44,7 @@ class Daily(Combat):
         emergency_module_development (bool): 是否为紧急模块开发任务。
     """
     daily_current: int
-    daily_checked: list
+    daily_checked: list[int]
     emergency_module_development = False
 
     def is_active(self):
@@ -289,7 +289,7 @@ class Daily(Combat):
     def daily_check(self, n=None):
         if not n:
             n = self.daily_current
-        self.daily_checked.append(n)
+        self.daily_checked.append(int(n))
         logger.info(f'已检查每日 {n}')
         logger.info(f'已检查列表: {self.daily_checked}')
 

--- a/module/os/map.py
+++ b/module/os/map.py
@@ -862,6 +862,13 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
         ):
             return
 
+        # 智能调度+上下文外层已查询行动力，跳过搜敌前的冗余弹窗刷新
+        if getattr(self, "_smart_scheduling_context", False) \
+                or getattr(self.config, "_smart_scheduling_context", False):
+            self._meow_search_start_time = time.time()
+            self._meow_search_start_ap = getattr(self, "_action_point_current", None)
+            return
+
         # 将计时器存储在地图对象上，因为匹配的结束钩子可能在自动搜索、重扫或事件处理后才到达。
         self._meow_search_start_time, self._meow_search_start_ap = (
             start_meow_search_timer(self)

--- a/module/os/tasks/hazard_leveling.py
+++ b/module/os/tasks/hazard_leveling.py
@@ -140,7 +140,7 @@ class OpsiHazard1Leveling(CoinTaskMixin, OSMap):
             self.run_hazard1_leveling_once()
             self.config.check_task_switch()
 
-    def run_hazard1_leveling_once(self, ap_preserve=None):
+    def run_hazard1_leveling_once(self, ap_preserve=None, ap_checked=False):
         """执行一轮侵蚀 1 练级，由独立任务或 OpsiScheduling 调用。"""
         # 启用随机事件以获得收益。调度器直接调用单轮时也需要保持该行为。
         self.config.override(
@@ -174,9 +174,11 @@ class OpsiHazard1Leveling(CoinTaskMixin, OSMap):
             raise
 
         # 侵蚀 1 练级时，行动力优先用于此任务，而非耄耋相接。
-        self.action_point_set(
-            cost=120, keep_current_ap=True, check_rest_ap=True
-        )
+        # ap_checked=True 表示调度器已确认行动力充足（>=120），无需重复弹窗
+        if not ap_checked:
+            self.action_point_set(
+                cost=120, keep_current_ap=True, check_rest_ap=True
+            )
 
         yellow_coins = self.get_yellow_coins()
         if not self.is_running_smart_scheduling_task():

--- a/module/os/tasks/meowfficer_farming.py
+++ b/module/os/tasks/meowfficer_farming.py
@@ -193,7 +193,9 @@ class OpsiMeowfficerFarming(MeowfficerTargetZoneMixin, CoinTaskMixin, OSMap):
         if self.zone.zone_id != zone.zone_id or not self.is_zone_name_hidden:
             self.globe_goto(zone, types='SAFE', refresh=True)
 
-        self.action_point_set(cost=120, keep_current_ap=True, check_rest_ap=True)
+        # 智能调度+上下文外层已查询行动力，跳过冗余弹窗
+        if not self.is_running_smart_scheduling_task():
+            self.action_point_set(cost=120, keep_current_ap=True, check_rest_ap=True)
         self.fleet_set(self.config.OpsiFleet_Fleet)
         self.os_order_execute(recon_scan=False, submarine_call=self.config.OpsiFleet_Submarine)
 

--- a/module/os/tasks/scheduling.py
+++ b/module/os/tasks/scheduling.py
@@ -30,7 +30,7 @@ from datetime import timedelta
 from module.config.config import Function, name_to_function
 from module.config.deep import deep_get
 from module.config.time_source import now as current_time
-from module.config.utils import get_os_reset_remain
+from module.config.utils import get_os_reset_remain, server_time_offset
 
 from module.logger import logger
 from module.os.map import OSMap
@@ -88,6 +88,19 @@ class CoinTaskMixin:
     # 各任务的配置路径常量（集中管理，避免硬编码）
     CONFIG_PATH_MEOW_AP_PRESERVE = 'OpsiMeowfficerFarming.OpsiMeowfficerFarming.ActionPointPreserve'
     CONFIG_PATH_CL1_MIN_AP_RESERVE = 'OpsiHazard1Leveling.OpsiHazard1Leveling.MinimumActionPointReserve'
+
+    # ==================== 买行动力功能相关常量 ====================
+    # 买行动力功能状态键（持久化到 OpsiScheduling.Storage.Storage）
+    STATE_KEY_BUY_AP_COUNT = 'BuyActionPointCount'       # 本周已购买行动力次数（int）
+    STATE_KEY_BUY_AP_WEEK_ID = 'BuyActionPointWeekId'    # 上次购买时所在的 ISO 周标识（str，如 "2026-W32"）
+    # 买行动力模式常量（与 argument.yaml 中 BuyActionPointMode.option 对应）
+    BUY_AP_MODE_OFF = 'off'
+    BUY_AP_MODE_HAZARD1 = 'hazard1_leveling'
+    BUY_AP_MODE_MEOWFFICER = 'meowfficer_farming'
+    # 买行动力配置路径
+    CONFIG_PATH_BUY_AP_MODE = 'OpsiScheduling.OpsiScheduling.BuyActionPointMode'
+    CONFIG_PATH_BUY_AP_UPPER = 'OpsiScheduling.OpsiScheduling.BuyActionPointUpperThreshold'
+    CONFIG_PATH_BUY_AP_LOWER = 'OpsiScheduling.OpsiScheduling.BuyActionPointLowerThreshold'
     
     # 耄耋相接任务名称
     TASK_NAME_MEOWFFICER_FARMING = 'OpsiMeowfficerFarming'
@@ -746,7 +759,607 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
         1. 黄币管理 - 当黄币不足时代理执行补充任务
         2. 行动力监控 - 监控行动力并发送阈值通知
         3. 任务协调 - 统一决定并代理执行子任务
+        4. 买行动力模式 - 与现有调度互斥的两种买行动力工作模式
     """
+
+    # ==================== 买行动力模式：配置读取 ====================
+
+    def _get_buy_action_point_mode(self):
+        """
+        读取买行动力模式。
+
+        Returns:
+            str: 'off' / 'hazard1_leveling' / 'meowfficer_farming'
+        """
+        return self.config.cross_get(
+            keys=self.CONFIG_PATH_BUY_AP_MODE,
+            default=self.BUY_AP_MODE_OFF,
+        )
+
+    def _is_buy_action_point_hazard1_mode(self):
+        """判断是否是功能1（侵蚀1练级）模式。"""
+        return self._get_buy_action_point_mode() == self.BUY_AP_MODE_HAZARD1
+
+    def _is_buy_action_point_meowfficer_mode(self):
+        """判断是否是功能2（短猫补黄币）模式。"""
+        return self._get_buy_action_point_mode() == self.BUY_AP_MODE_MEOWFFICER
+
+    def _is_buy_action_point_mode_active(self):
+        """判断是否启用了买行动力模式（任何一种）。"""
+        return self._is_buy_action_point_hazard1_mode() \
+            or self._is_buy_action_point_meowfficer_mode()
+
+    def _get_buy_action_point_upper_threshold(self):
+        """
+        读取买行动力上限阈值（仅功能2使用）。
+
+        Returns:
+            int: 当前真实行动力超过此值时跳过购买，默认 200
+        """
+        value = self.config.cross_get(
+            keys=self.CONFIG_PATH_BUY_AP_UPPER,
+            default=200,
+        )
+        try:
+            return max(1, int(value or 200))
+        except (TypeError, ValueError):
+            return 200
+
+    def _get_buy_action_point_lower_threshold(self):
+        """
+        读取买行动力下限阈值（仅功能2使用）。
+
+        Returns:
+            int: 当前真实行动力低于此值时停止执行海域任务，回到购买步骤，默认 100
+        """
+        value = self.config.cross_get(
+            keys=self.CONFIG_PATH_BUY_AP_LOWER,
+            default=100,
+        )
+        try:
+            return max(0, int(value or 100))
+        except (TypeError, ValueError):
+            return 100
+
+    # ==================== 买行动力模式：计数器管理 ====================
+
+    def _get_current_purchase_week_id(self):
+        """
+        获取行动力购买周期的周标识（基于服务器时间）。
+
+        行动力购买次数每周一刷新。返回 ISO 周标识字符串，如 "2026-W32"。
+        跨周时通过比较周标识判断是否需要重置计数器。
+
+        Returns:
+            str: 当前服务器时间所在的 ISO 周标识
+        """
+        diff = server_time_offset()
+        server_now = current_time() - diff
+        iso_year, iso_week, _ = server_now.isocalendar()
+        return f'{iso_year}-W{iso_week:02d}'
+
+    def _get_buy_action_point_count(self):
+        """
+        读取本周已购买行动力次数。
+
+        跨周时会自动重置为 0。
+
+        Returns:
+            int: 本周已购买次数
+        """
+        self._reset_buy_action_point_count_if_new_week()
+        count = self._get_smart_scheduling_state_value(
+            self.STATE_KEY_BUY_AP_COUNT,
+            default=0,
+        )
+        try:
+            return int(count or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def _set_buy_action_point_count(self, count):
+        """
+        写入本周已购买行动力次数，并同步周标识。
+
+        Args:
+            count (int): 已购买次数
+        """
+        self._set_smart_scheduling_state_value(
+            self.STATE_KEY_BUY_AP_COUNT,
+            int(count),
+        )
+        self._set_smart_scheduling_state_value(
+            self.STATE_KEY_BUY_AP_WEEK_ID,
+            self._get_current_purchase_week_id(),
+        )
+
+    def _reset_buy_action_point_count_if_new_week(self):
+        """
+        检测跨周时重置购买计数器。
+
+        与 _reset_month_end_cleanup_first_run_if_new_month() 类似的模式：
+        比较持久化的周标识与当前周标识，不一致时重置计数器。
+        """
+        current_week_id = self._get_current_purchase_week_id()
+        stored_week_id = self._get_smart_scheduling_state_value(
+            self.STATE_KEY_BUY_AP_WEEK_ID,
+        )
+        if stored_week_id != current_week_id:
+            logger.info(
+                f'[大世界-买行动力] 检测到跨周 ({stored_week_id} -> {current_week_id})，'
+                f'重置购买计数器'
+            )
+            self._set_smart_scheduling_state_value(
+                self.STATE_KEY_BUY_AP_COUNT,
+                0,
+            )
+            self._set_smart_scheduling_state_value(
+                self.STATE_KEY_BUY_AP_WEEK_ID,
+                current_week_id,
+            )
+
+    def _is_buy_action_point_ocr_valid(self):
+        """
+        验证购买剩余次数 OCR 区域是否成功提取到文字像素。
+
+        返回 True 时 action_point_get_buy_remain() 的结果可信；
+        返回 False 时 OCR 未识别到内容，返回的 0 是失败回退值，不可信。
+
+        Returns:
+            bool: True 表示 OCR 成功识别到文字。
+        """
+        from module.base.utils import crop, extract_letters
+        from module.config import server
+        import numpy as np
+        from module.os_handler.assets import ACTION_POINT_BUY_REMAIN
+
+        letter = (148, 247, 99) if server.server != 'jp' else (255, 255, 255)
+        area = ACTION_POINT_BUY_REMAIN.area
+        cropped = crop(self.device.image, area)
+        extracted = extract_letters(cropped, letter=letter, threshold=128)
+        text_pixel_count = int(np.sum(extracted > 0))
+        return text_pixel_count > 20
+
+    def _sync_buy_action_point_count_with_game(self):
+        """
+        从游戏 OCR 同步本周已购买行动力次数。
+
+        进入买行动力模式时调用，确保持久化计数器与游戏一致。
+        游戏显示"剩余购买次数"，反推已购买次数 = 5 - remain。
+
+        OCR 失败保护：如果 OCR 区域没有提取到文字像素，
+        则认为 OCR 未成功识别（返回的 0 是失败回退值），
+        保留持久化计数器的值，不覆盖。
+
+        Returns:
+            int: 同步后的已购买次数
+        """
+        self.action_point_enter()
+        self.action_point_safe_get()
+        # 必须选中石油按钮，否则 OCR 区域读到的是药箱数量而非购买剩余次数
+        self.action_point_set_button(0)
+        try:
+            remain = self.action_point_get_buy_remain()
+            ocr_valid = self._is_buy_action_point_ocr_valid()
+        finally:
+            self.action_point_quit()
+
+        if not ocr_valid:
+            stored_count = self._get_buy_action_point_count()
+            logger.warning(
+                f'[大世界-买行动力] OCR 未能识别购买剩余次数（区域无文字像素），'
+                f'保留持久化计数器值 {stored_count}'
+            )
+            return stored_count
+
+        self._reset_buy_action_point_count_if_new_week()
+        actual_count = max(0, 5 - remain)
+        self._set_buy_action_point_count(actual_count)
+
+        # 同步更新行动力缓存，后续 _get_scheduling_action_point 无需重复弹窗
+        self._ap_cache = (
+            int(getattr(self, '_action_point_total', 0) or 0),
+            int(getattr(self, '_action_point_current', 0) or 0),
+            current_time(),
+        )
+        logger.info(
+            f'[大世界-买行动力] 同步购买计数: 已购买 {actual_count} 次 '
+            f'(游戏剩余 {remain})'
+        )
+        return actual_count
+
+    # ==================== 买行动力模式：购买与优先级表 ====================
+
+    def _buy_one_action_point(self):
+        """
+        买一次行动力（使用石油）。
+
+        进入行动力弹窗，调用 action_point_buy 完成一次购买，然后退出弹窗。
+        action_point_buy 内部已处理：
+            - 月末封锁周（不购买）
+            - 游戏内剩余购买次数（OCR 识别 buy_remain = 5 - remain）
+            - 用户设置的 BuyActionPointLimit 上限
+            - 石油是否足够（保留 OilLimit 后再购买）
+        成功购买后递增持久化计数器，用于动态优先级表判断。
+
+        Returns:
+            bool: True 表示购买成功；False 表示未购买（已达上限/月末封锁/石油不足）。
+
+        Pages:
+            in: page_os
+            out: page_os
+        """
+        self.action_point_enter()
+        self.action_point_safe_get()
+        try:
+            success = self.action_point_buy(
+                preserve=self.config.OpsiGeneral_OilLimit
+            )
+        finally:
+            self.action_point_quit()
+
+        if success:
+            current_count = self._get_buy_action_point_count()
+            new_count = current_count + 1
+            self._set_buy_action_point_count(new_count)
+            logger.info(
+                f'[大世界-买行动力] 购买一次行动力成功，'
+                f'本周已购买 {new_count} 次'
+            )
+        else:
+            logger.info('[大世界-买行动力] 本次未购买行动力')
+
+        return success
+
+    def _get_priority_table_for_buy_count(self, buy_count):
+        """
+        根据本次购买次数返回智能调度+优先级表。
+
+        仅功能2（短猫补黄币）使用。优先级表已根据用户最终确认的顺序：
+            第 1 次: 隐秘海域 > 耄耋相接
+            第 2-4 次: 隐秘海域 > 深渊坐标 > 耄耋相接
+            第 5 次: 隐秘海域 > 深渊坐标 > 塞壬要塞 > 耄耋相接
+
+        Args:
+            buy_count (int): 已购买次数（1 表示第 1 次，5 表示第 5 次）。
+
+        Returns:
+            list[str]: 任务名称优先级列表，从高到低。
+        """
+        if buy_count <= 1:
+            return [
+                self.TASK_NAME_OBSCURE,
+                self.TASK_NAME_MEOWFFICER_FARMING,
+            ]
+        elif buy_count <= 4:
+            return [
+                self.TASK_NAME_OBSCURE,
+                self.TASK_NAME_ABYSSAL,
+                self.TASK_NAME_MEOWFFICER_FARMING,
+            ]
+        else:
+            # buy_count >= 5
+            return [
+                self.TASK_NAME_OBSCURE,
+                self.TASK_NAME_ABYSSAL,
+                self.TASK_NAME_STRONGHOLD,
+                self.TASK_NAME_MEOWFFICER_FARMING,
+            ]
+
+    def _get_filtered_priority_table(self, priority_table):
+        """
+        根据智能调度+中已启用的任务过滤优先级表。
+
+        用户在智能调度+中关闭的任务会被跳过，即使优先级表中位置靠前也不执行。
+        例如：第 1 次购买行动力，优先级为"隐秘海域>耄耋相接"，
+        但用户未启用隐秘海域时，过滤后只剩 [耄耋相接]。
+
+        Args:
+            priority_table (list[str]): 原始优先级表。
+
+        Returns:
+            list[str]: 过滤后的优先级表（只包含已启用的任务，保持原顺序）。
+        """
+        enabled_tasks = self._get_enabled_coin_tasks()
+        filtered = [task for task in priority_table if task in enabled_tasks]
+        skipped = [task for task in priority_table if task not in enabled_tasks]
+        if skipped:
+            skipped_names = '、'.join(
+                self.TASK_NAMES.get(task, task) for task in skipped
+            )
+            logger.info(
+                f'[大世界-买行动力] 智能调度+未启用以下任务，已从优先级表跳过: {skipped_names}'
+            )
+        return filtered
+
+    # ==================== 买行动力模式：主循环 ====================
+
+    def _run_buy_action_point_mode(self):
+        """
+        买行动力模式总入口。
+
+        由 run_smart_scheduling_once 在检测到 BuyActionPointMode 启用时分发到此。
+        与现有的黄币/行动力调度逻辑互斥。
+
+        流程:
+            1. 同步持久化计数器与游戏内剩余购买次数（防重启状态不一致）
+            2. 读取 OpsiGeneral.BuyActionPointLimit 作为本周购买上限
+            3. 检查是否已达上限，是则返回 False（不延迟，交由正常调度接管）
+            4. 根据模式分发到对应主循环
+
+        Returns:
+            bool: True 表示已延迟到服务器刷新（正常调度无需继续）；
+                  False 表示买行动力模式自然结束，正常调度应接管剩余行动力。
+
+        Pages:
+            in: page_os
+            out: page_os
+        """
+        logger.hr('大世界-买行动力模式', level=1)
+
+        # 同步购买计数器与游戏内剩余次数（重启后可能不一致）
+        sync_result = self._sync_buy_action_point_count_with_game()
+
+        buy_limit = self.config.OpsiGeneral_BuyActionPointLimit
+        if buy_limit <= 0:
+            # 检查是否是暂停恢复导致的临时覆盖残留
+            if sync_result > 0:
+                logger.info(
+                    f'[大世界-买行动力] 检测到 BuyActionPointLimit 为 0（临时覆盖残留），'
+                    f'本周已购买 {sync_result} 次，按游戏上限 5 次恢复'
+                )
+                buy_limit = 5
+            else:
+                logger.warning(
+                    '[大世界-买行动力] OpsiGeneral.BuyActionPointLimit 为 0，'
+                    '未配置每周购买上限'
+                )
+                self.notify_push(
+                    title='[AzurPilot] 大世界-买行动力未配置上限',
+                    content='请在「大世界通用设置 → 买行动力X次」中设置每周购买上限（大于 0）',
+                )
+                self._delay_smart_scheduling_to_server_update('未配置购买上限')
+                return True
+
+        current_count = self._get_buy_action_point_count()
+        if current_count >= buy_limit:
+            logger.info(
+                f'[大世界-买行动力] 已达本周购买上限 {buy_limit} 次'
+                f'（已购买 {current_count} 次），买行动力模式结束，剩余行动力交由正常调度'
+            )
+            return False
+
+        logger.info(
+            f'[大世界-买行动力] 本周已购买 {current_count}/{buy_limit} 次，'
+            f'剩余 {buy_limit - current_count} 次'
+        )
+
+        if self._is_buy_action_point_hazard1_mode():
+            return self._run_buy_ap_hazard1_loop(buy_limit)
+        elif self._is_buy_action_point_meowfficer_mode():
+            return self._run_buy_ap_meowfficer_loop(buy_limit)
+
+        return False
+
+    def _run_buy_ap_hazard1_loop(self, buy_limit):
+        """
+        功能1：买行动力全部去侵蚀1练级。
+
+        流程: 买1次行动力 → 持续侵蚀1练级直到行动力耗尽 → 检查上限 → 继续买下一次
+
+        - 不使用 200/100 阈值检查，使用现有 OS_ACTION_POINT_PRESERVE 机制
+        - 每次购买只买1次，子任务执行期间临时禁用 BuyActionPointLimit
+          （防止 handle_action_point 自动购买 5 次）
+        - 行动力耗尽由 ActionPointLimit 异常判断
+
+        Args:
+            buy_limit (int): 本周购买行动力上限。
+
+        Pages:
+            in: page_os
+            out: page_os
+        """
+        logger.info('[大世界-买行动力] 进入功能1：侵蚀1练级模式')
+
+        cl1_ap_preserve = self._get_effective_cl1_ap_preserve()
+        logger.info(
+            f'[大世界-买行动力] 侵蚀1练级行动力保留值: {cl1_ap_preserve}'
+        )
+
+        while True:
+            current_count = self._get_buy_action_point_count()
+            if current_count >= buy_limit:
+                logger.info(
+                    f'[大世界-买行动力] 已达本周购买上限 {buy_limit} 次，'
+                    f'退出功能1主循环'
+                )
+                break
+
+            buy_round = current_count + 1
+            logger.info(
+                f'[大世界-买行动力] 准备第 {buy_round}/{buy_limit} 次购买行动力'
+                f'（用于侵蚀1练级）'
+            )
+            if not self._buy_one_action_point():
+                logger.warning(
+                    '[大世界-买行动力] 购买失败（石油不足/月末封锁/已达游戏内上限），'
+                    '退出功能1主循环'
+                )
+                break
+
+            # 临时禁用 BuyActionPointLimit，持续练级直到行动力耗尽
+            # 这样 handle_action_point 不会自动购买，只会抛出 ActionPointLimit
+            logger.info(
+                f'[大世界-买行动力] 第 {buy_round} 次购买完成，'
+                f'开始侵蚀1练级，持续消耗行动力'
+            )
+            with self.config.temporary(OpsiGeneral_BuyActionPointLimit=0):
+                while True:
+                    try:
+                        self._run_scheduled_hazard1_leveling(cl1_ap_preserve)
+                    except ActionPointLimit as e:
+                        logger.info(
+                            f'[大世界-买行动力] 侵蚀1练级行动力已耗尽: {e}，'
+                            f'准备购买下一次行动力'
+                        )
+                        break
+
+        logger.info('[大世界-买行动力] 功能1主循环结束')
+        return False
+
+    def _run_buy_ap_meowfficer_loop(self, buy_limit):
+        """
+        功能2：买行动力去短猫/耄耋相接补充黄币。
+
+        流程:
+            1. 检查当前行动力
+               - 超过上限阈值（默认 200）：跳过购买，直接执行海域任务
+               - 否则：买一次行动力
+            2. 按动态优先级表执行海域任务（一次购买可执行多个海域）
+            3. 检查行动力是否低于下限阈值（默认 100）
+               - 是：回到步骤1（继续购买）
+               - 否：继续执行下一个海域任务
+            4. 达上限或所有海域无可执行内容时退出
+
+        动态优先级表（按购买次数）:
+            第 1 次: 隐秘海域 > 耄耋相接
+            第 2-4 次: 隐秘海域 > 深渊坐标 > 耄耋相接
+            第 5 次: 隐秘海域 > 深渊坐标 > 塞壬要塞 > 耄耋相接
+
+        Args:
+            buy_limit (int): 本周购买行动力上限。
+
+        Pages:
+            in: page_os
+            out: page_os
+        """
+        logger.info('[大世界-买行动力] 进入功能2：短猫补黄币模式')
+
+        upper_threshold = self._get_buy_action_point_upper_threshold()
+        lower_threshold = self._get_buy_action_point_lower_threshold()
+        logger.info(
+            f'[大世界-买行动力] 阈值配置: 上限={upper_threshold}（低于则触发购买），'
+            f'下限={lower_threshold}（任务执行中AP低于此值则回购买）'
+        )
+        while True:
+            current_count = self._get_buy_action_point_count()
+            if current_count >= buy_limit:
+                logger.info(
+                    f'[大世界-买行动力] 已达本周购买上限 {buy_limit} 次，'
+                    f'退出功能2主循环'
+                )
+                break
+
+            # 步骤1：检查当前行动力，决定是否需要购买
+            _, current_ap = self._get_scheduling_action_point()
+            if current_ap >= upper_threshold:
+                logger.info(
+                    f'[大世界-买行动力] 当前行动力 {current_ap} >= 上限阈值 {upper_threshold}，'
+                    f'行动力充足，跳过购买直接执行海域任务'
+                )
+            else:
+                buy_round = current_count + 1
+                logger.info(
+                    f'[大世界-买行动力] 当前行动力 {current_ap} < 上限阈值 {upper_threshold}，'
+                    f'准备第 {buy_round}/{buy_limit} 次购买行动力'
+                )
+                if not self._buy_one_action_point():
+                    logger.warning(
+                        '[大世界-买行动力] 购买失败（石油不足/月末封锁/已达游戏内上限），'
+                        '退出功能2主循环'
+                    )
+                    break
+
+                # 购买成功后 OCR 已读到新行动力，使用缓存值避免重复弹窗
+                current_ap = int(
+                    getattr(self, '_action_point_current', current_ap) or current_ap
+                )
+
+            # 步骤2：按动态优先级表执行海域任务
+            buy_count = self._get_buy_action_point_count()
+            priority_table = self._get_priority_table_for_buy_count(buy_count)
+            filtered_table = self._get_filtered_priority_table(priority_table)
+            if not filtered_table:
+                logger.warning(
+                    '[大世界-买行动力] 智能调度+未启用任何海域任务，无法执行功能2'
+                )
+                self.notify_push(
+                    title='[AzurPilot] 大世界-买行动力未启用海域任务',
+                    content='请至少启用耄耋相接、隐秘海域、深渊坐标或塞壬要塞中的一项',
+                )
+                self._delay_smart_scheduling_to_server_update('未启用海域任务')
+                return
+
+            task_names = '、'.join(
+                self.TASK_NAMES.get(task, task) for task in filtered_table
+            )
+            logger.info(
+                f'[大世界-买行动力] 第 {buy_count} 次购买后优先级表: {task_names}'
+            )
+
+            # 推送本轮购买状态和下一步任务
+            if bought_this_round:
+                push_content = (
+                    f'第 {buy_round}/{buy_limit} 次购买行动力完成\n'
+                    f'下一步任务：{task_names}'
+                )
+            else:
+                push_content = (
+                    f'行动力充足（>= {upper_threshold}），跳过购买\n'
+                    f'下一步任务：{task_names}'
+                )
+            self.notify_push(
+                title='[AzurPilot] 大世界-买行动力',
+                content=push_content,
+            )
+            # 临时禁用 BuyActionPointLimit，防止子任务自动购买
+            executed_any = False
+            # 复用步骤1已查询的行动力，避免 for 循环首任务重复弹窗
+            for_ap = current_ap
+            with self.config.temporary(OpsiGeneral_BuyActionPointLimit=0):
+                for task_name in filtered_table:
+                    if for_ap < lower_threshold:
+                        logger.info(
+                            f'[大世界-买行动力] 行动力 {for_ap} < 下限阈值 {lower_threshold}，'
+                            f'停止执行海域任务，回到购买步骤'
+                        )
+                        break
+
+                    task_display = self.TASK_NAMES.get(task_name, task_name)
+                    logger.info(f'[大世界-买行动力] 执行海域任务: {task_display}')
+                    try:
+                        success = self._run_scheduled_coin_task_once(task_name, 0)
+                    except ActionPointLimit as e:
+                        logger.warning(
+                            f'[大世界-买行动力] {task_display} 行动力不足: {e}，'
+                            f'回到购买步骤'
+                        )
+                        break
+
+                    if success:
+                        executed_any = True
+                        logger.info(
+                            f'[大世界-买行动力] {task_display} 执行完成'
+                        )
+                    else:
+                        logger.info(
+                            f'[大世界-买行动力] {task_display} 无可执行内容，'
+                            f'尝试下一个任务'
+                        )
+
+                    # 仅子任务成功执行后才重新查询行动力，"无内容"跳过刷新避免冗余弹窗
+                    if success:
+                        _, for_ap = self._get_scheduling_action_point(force_refresh=True)
+
+            if not executed_any:
+                logger.warning(
+                    '[大世界-买行动力] 所有海域任务均无可执行内容，'
+                    f'退出功能2主循环'
+                )
+                return False
+
+        logger.info('[大世界-买行动力] 功能2主循环结束')
+        return False
 
     def _make_opsi_task_function(self, task_name):
         """从当前配置数据构造临时代跑任务对象。"""
@@ -808,21 +1421,35 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
                 self.config._bind_task_override = previous_bind
                 self.config.bind(previous_bind)
 
-    def _get_scheduling_action_point(self):
+    def _get_scheduling_action_point(self, force_refresh=False):
         """
         读取智能调度+决策所需的行动力。
+
+        缓存机制：最近一次 OCR 读取后 60 秒内直接复用缓存值，不再弹窗。
+        跨任务执行后（如海域/练级）必须使用 force_refresh=True 强制刷新。
 
         Returns:
             tuple[int, int]: (总行动力, 当前真实行动力)
         """
+        cache_ttl_seconds = 60
+        cached = getattr(self, '_ap_cache', (None, None, None))
+        cached_total, cached_current, cached_at = cached
+        if (
+            not force_refresh
+            and cached_at is not None
+            and cached_total is not None
+            and (current_time() - cached_at).total_seconds() < cache_ttl_seconds
+        ):
+            return cached_total, cached_current
+
         self.action_point_enter()
         self.action_point_safe_get()
         self.action_point_quit()
+        total_ap = int(getattr(self, '_action_point_total', 0) or 0)
+        current_ap = int(getattr(self, '_action_point_current', 0) or 0)
+        self._ap_cache = (total_ap, current_ap, current_time())
         self.check_and_notify_action_point_threshold()
-        return (
-            int(getattr(self, '_action_point_total', 0) or 0),
-            int(getattr(self, '_action_point_current', 0) or 0),
-        )
+        return total_ap, current_ap
 
     def _run_scheduled_meowfficer_farming(self, ap_preserve):
         """
@@ -833,25 +1460,13 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
             self.config.task_stop()
 
         logger.info('[大世界-智能调度+] 执行一轮耄耋相接')
-        # 耄耋相接会通过共享的手动配置项控制本轮行动力下限。
-        # 代跑结束后必须恢复，否则其保留值会泄漏到后续侵蚀 1 调度。
-        with self.config.temporary(
-            OS_ACTION_POINT_PRESERVE=self.config.OS_ACTION_POINT_PRESERVE,
-        ):
-            try:
-                self._run_with_opsi_task_context(
-                    self.TASK_NAME_MEOWFFICER_FARMING,
-                    self.run_meowfficer_farming_once,
-                    ap_preserve=ap_preserve,
-                )
-            except ActionPointLimit as e:
-                if ap_preserve > 0 and getattr(e, 'preserve', None) == ap_preserve:
-                    logger.info(
-                        f'[大世界-智能调度+] 耄耋相接已达到行动力保留值 '
-                        f'({e.total} <= {ap_preserve})，返回智能调度+'
-                    )
-                    return
-                raise
+# 智能调度上下文外层已查询行动力，跳过子任务内的冗余弹窗
+        self._run_with_opsi_task_context(
+            self.TASK_NAME_MEOWFFICER_FARMING,
+            self.run_meowfficer_farming_once,
+            ap_preserve=ap_preserve,
+            ap_checked=True,
+        )
 
     def handle_first_auto_search(self, run):
         """由智能调度+决策是否执行 os_init 阶段跳过的首次自律寻敌。"""
@@ -904,6 +1519,8 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
     def _run_scheduled_hazard1_leveling(self, ap_preserve):
         """
         由智能调度+执行一轮侵蚀 1 练级。
+
+        ap_checked=True 表示已确认行动力充足（>=120），跳过 action_point_set 弹窗。
         """
         if not hasattr(self, 'run_hazard1_leveling_once'):
             logger.error('[大世界-智能调度+] 当前实例不支持执行侵蚀 1 练级')
@@ -911,6 +1528,17 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
 
         logger.info('[大世界-智能调度+] 执行一轮侵蚀 1 练级')
         self.handle_first_auto_search(run=False)
+
+        # 检查缓存行动力是否充足（>=120 且缓存 < 60 秒）
+        cached = getattr(self, '_ap_cache', (None, None, None))
+        _, cached_current, cached_at = cached
+        ap_checked = (
+            cached_at is not None
+            and cached_current is not None
+            and cached_current >= 120
+            and (current_time() - cached_at).total_seconds() < 60
+        )
+
         if hasattr(self, 'os_check_leveling'):
             self._run_with_opsi_task_context(
                 self.TASK_NAME_HAZARD1_LEVELING,
@@ -920,6 +1548,7 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
             self.TASK_NAME_HAZARD1_LEVELING,
             self.run_hazard1_leveling_once,
             ap_preserve=ap_preserve,
+            ap_checked=ap_checked,
         )
 
     def _run_scheduled_coin_task_once(self, task_name, ap_preserve):
@@ -984,6 +1613,16 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
             and self._delay_smart_scheduling_for_opsi_explore()
         ):
             return
+
+        # 买行动力模式：与现有黄币/行动力调度互斥，仅由主调度（OpsiScheduling）执行。
+        # 防溢出任务代跑时不进入买行动力模式，避免循环购买打断防溢出逻辑。
+        if (
+            self._is_buy_action_point_mode_active()
+            and not self.is_running_prevent_action_point_overflow_task()
+        ):
+            bought_delay = self._run_buy_action_point_mode()
+            if bought_delay:
+                return
 
         yellow_coins = self.get_yellow_coins()
         total_ap, current_ap = self._get_scheduling_action_point()
@@ -1430,7 +2069,7 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
             logger.hr(f'大世界-月末清理 第{round_num}轮', level=3)
 
             # 检查行动力是否已降到保留值
-            total_ap, current_ap = self._get_scheduling_action_point()
+            total_ap, current_ap = self._get_scheduling_action_point(force_refresh=True)
             if total_ap <= month_end_preserve:
                 logger.info(
                     f'[大世界-月末清理] 总行动力 {total_ap} <= 保留值 {month_end_preserve}，'
@@ -1476,7 +2115,7 @@ class OpsiScheduling(CoinTaskMixin, OSMap):
                 break
 
         # 月末清理结束，刷新行动力并通知
-        total_ap, current_ap = self._get_scheduling_action_point()
+        total_ap, current_ap = self._get_scheduling_action_point(force_refresh=True)
         logger.info(
             f'[大世界-月末清理] 清理结束: 总行动力={total_ap}, '
             f'当前行动力={current_ap}, 保留值={month_end_preserve}'

--- a/module/os_handler/action_point.py
+++ b/module/os_handler/action_point.py
@@ -386,6 +386,12 @@ class ActionPointHandler(UI, MapEventHandler):
         buy_max = 5  # 当前版本中，玩家每周可购买 5 次行动力
         buy_count = buy_max - current
         buy_limit = self.config.OpsiGeneral_BuyActionPointLimit
+        if buy_limit <= 0 and current < buy_max:
+            logger.info(
+                f'[大世界-行动点] BuyActionPointLimit 为 {buy_limit}（临时覆盖残留），'
+                f'OCR 显示剩余 {current} 次，按游戏上限 {buy_max} 恢复'
+            )
+            buy_limit = buy_max
         if self._is_in_month_end_purchase_block_week():
             logger.info('[大世界-行动点] 跳过本周购买行动点，因为是月末封锁周')
             return False

--- a/module/webui/lang.py
+++ b/module/webui/lang.py
@@ -74,4 +74,6 @@ def reload():
 
     for key in dic_lang["ja-JP"].keys():
         if dic_lang["ja-JP"][key] == key:
-            dic_lang["ja-JP"][key] = dic_lang["en-US"][key]
+            fallback = dic_lang["en-US"].get(key)
+            if fallback is not None:
+                dic_lang["ja-JP"][key] = fallback


### PR DESCRIPTION
## 📋 PR 概览

本 PR 将 16 个提交合并为单个提交，专注于 **大世界（OS）智能调度+购买行动力双模式** 及关联修复。

| 统计项 | 数值 |
|--------|------|
| 合并提交数 | 16 |
| 变更文件数 | 15 |
| 新增行数 | 2,257 |
| 删除行数 | 1,115 |

---

## 一、版本对比

| 对比项 | 旧版 | 新版 |
|--------|------|------|
| **行动力购买模式** | 单一 `BuyActionPointLimit`，按购买次数上限控制 | 双模式：`BuyActionPointLimit`（次数限制）+ `BuyActionPointUpperThreshold`（上限阈值），通过 `BuyActionPointMode` 切换 |
| **购买时机判断** | 使用上限阈值判断 | 模式1使用**下限阈值**决定购买时机；模式2**仅使用上限阈值** |
| **OCR 识别可靠性** | 可能读到药箱数量，错误覆盖计数器 | 购买前强制选中石油按钮（`action_point_set_button(0)`）；新增 OCR 有效性校验 |
| **购买后 AP 数据** | 使用过期本地变量 | 购买后重新 OCR 获取最新 AP（缓存值） |
| **BuyActionPointLimit 残留** | 临时覆盖后未恢复，导致后续误判"已满" | 检测到残留值 ≤0 时，按游戏上限 5 次自动恢复 |
| **智能调度弹窗** | 高频弹窗易触发 `TooManyClickError` | 智能调度上下文中跳过搜敌前的冗余弹窗刷新，耄耋相接跳过重复 `action_point_set` |
| **月末购买** | 无处理 | 月末封锁周自动跳过本周购买 |
| **推送通知** | 无 | 行动力阈值推送（30 分钟最小间隔），支持 OnePush + 启动器双通道 |
| `daily_checked` 类型 | `list` 无注解，`append(n)` 类型不安全 | `list[int]` 注解 + `append(int(n))` |
| **GUI 翻译 fallback** | `dic_lang["ja-JP"][key] = dic_lang["en-US"][key]` 直接取值，key 缺失时 KeyError 崩溃 | `en-US.get(key)` 安全回退 |

---

## 二、功能新增

### 2.1 购买行动力双模式（`BuyActionPointMode`）

| 项目 | 内容 |
|------|------|
| **功能描述** | 在 `OpsiScheduling` 中新增购买行动力模式配置，用户可选择 `off`（关闭）、`hazard1_leveling`（侵蚀1练级模式）、`meowfficer_farming`（耄耋相接模式）。 |
| **实现方式** | 在 `CoinTaskMixin` 中新增状态管理：`STATE_KEY_BUY_AP_COUNT`（本周已购次数）、`STATE_KEY_BUY_AP_WEEK_ID`（ISO 周标识），通过 `BuyActionPointUpperThreshold` / `BuyActionPointLowerThreshold` 控制阈值。 |
| **预期效果** | 用户可按不同任务类型精细化控制购买策略，避免行动力溢出或石油浪费。 |

### 2.2 月末行动力清理（`MonthEndActionPointCleanupEnable`）

| 项目 | 内容 |
|------|------|
| **功能描述** | 在月末前自动检测是否处于"月末封锁周"，自动跳过本周购买。 |
| **实现方式** | `action_point.py` 中 `_is_in_month_end_purchase_block_week()`：基于服务器时间计算当前自然周与下月首周的重合关系。 |
| **预期效果** | 月末前一周不再浪费石油购买行动力，避免溢出。 |

### 2.3 推送通知增强

| 项目 | 内容 |
|------|------|
| **功能描述** | 行动力阈值变化时自动推送通知，支持 OnePush + 启动器双通道，30 分钟最小间隔防重复。 |
| **实现方式** | `CoinTaskMixin.notify_push()`：校验推送配置有效性（`_is_push_config_valid`），格式化启动器通知文案（`_format_launcher_notification`，喵~风格），发送成功后记录时间戳。 |

---

## 三、问题修复

| # | 问题 | 根因 | 修复文件 | 修复方案 |
|---|------|------|---------|---------|
| 1 | 购买行动力 OCR 读到药箱数量，错误覆盖计数器 | OCR 区域未限定为石油按钮 | `scheduling.py` | 购买前执行 `action_point_set_button(0)` 选中石油 |
| 2 | OCR 结果无效（斜杠 `/` 误识别为 `1`） | 缺少 OCR 有效性校验 | `scheduling.py` | 新增 `_is_buy_action_point_ocr_valid` 校验逻辑 |
| 3 | `server` 未导入导致 `ModuleNotFoundError` | 缺少 `import module.config.server` | `scheduling.py` | 添加导入语句 |
| 4 | `BuyActionPointLimit` 临时覆盖残留导致错误延迟 | 覆盖后未恢复，后续判断"已满" | `action_point.py` | 检测到 `buy_limit <= 0` 时按游戏上限 5 次恢复 |
| 5 | `action_point_buy` 与 `BuyActionPointLimit` 冲突 | 同上覆盖残留 | `action_point.py` | 同上 |
| 6 | 买行动力模式使用上限阈值判断（应为下限） | 逻辑反向 | `scheduling.py` | 模式1改用 `BuyActionPointLowerThreshold` |
| 7 | 行动力弹窗频率过高触发 `TooManyClickError` | 智能调度+ 中每次循环都刷新弹窗 | `scheduling.py` | 减少弹窗触发频率，增加间隔控制 |
| 8 | 智能调度下搜敌前冗余弹窗刷新 | 外层已查询行动力，内层重复查询 | `map.py` + `meowfficer_farming.py` | `map.py`：检测到 `_smart_scheduling_context` 时跳过；`meowfficer_farming.py`：仅在非智能调度上下文时调用 `action_point_set` |
| 9 | 购买后使用过期本地变量中的 AP 值 | 未重新获取 | `scheduling.py` | 购买后使用缓存的 AP 值 |
| 10 | `BuyActionPointUpperThreshold` 未生效 | 逻辑同时检查 Limit 和 UpperThreshold | `scheduling.py` | 模式2仅使用 UpperThreshold |
| 11 | `daily_checked` 类型不一致 | 无类型注解，`append(n)` 可能存非 int | `daily.py` | `daily_checked: list[int]` + `append(int(n))` |
| 12 | GUI 启动时 KeyError 崩溃 | `en-US` 直接 `[]` 取值，key 缺失抛出异常 | `lang.py` | 改为 `en-US.get(key)` 安全回退 |

---

## 四、实现说明

### 4.1 变更文件一览

| 文件 | 变更类型 | 行数变化 | 说明 |
|------|---------|---------|------|
| `module/os/tasks/scheduling.py` | 修改 | **+693** | 核心：双模式、推送、月末清理、OCR 校验、11 处修复 |
| `module/os_handler/action_point.py` | 修改 | +6 | `BuyActionPointLimit` 残留恢复逻辑 |
| `module/os/map.py` | 修改 | +7 | 智能调度上下文跳过冗余弹窗 |
| `module/os/tasks/meowfficer_farming.py` | 修改 | +4-1 | 智能调度上下文跳过重复 `action_point_set` |
| `module/daily/daily.py` | 修改 | +4-2 | `daily_checked` 类型注解 |
| `module/webui/lang.py` | 修改 | +4-1 | `en-US.get(key)` 安全回退 |
| `config/template.json` | 修改 | 配置模板更新 |
| `module/config/argument/argument.yaml` | 修改 | 新增配置项定义 |
| `module/config/argument/args.json` | 修改 | 配置定义生成 |
| `module/config/config_generated.py` | 修改 | 配置类生成 |
| `module/config/i18n/*.json` (×5) | 修改 | 五种语言翻译 |

### 4.2 双模式决策逻辑

**配置常量**（`CoinTaskMixin`）：

```python
STATE_KEY_BUY_AP_COUNT = 'BuyActionPointCount'       # 本周已购买次数
STATE_KEY_BUY_AP_WEEK_ID = 'BuyActionPointWeekId'    # ISO 周标识 "2026-W32"
BUY_AP_MODE_OFF = 'off'
BUY_AP_MODE_HAZARD1 = 'hazard1_leveling'
BUY_AP_MODE_MEOWFFICER = 'meowfficer_farming'
CONFIG_PATH_BUY_AP_UPPER = 'OpsiScheduling.OpsiScheduling.BuyActionPointUpperThreshold'
CONFIG_PATH_BUY_AP_LOWER = 'OpsiScheduling.OpsiScheduling.BuyActionPointLowerThreshold'
```

**模式读取**（`OpsiScheduling`）：

```python
def _get_buy_action_point_mode(self):
    return self.config.cross_get(
        keys=self.CONFIG_PATH_BUY_AP_MODE,
        default=self.BUY_AP_MODE_OFF,
    )

def _is_buy_action_point_hazard1_mode(self):
    return self._get_buy_action_point_mode() == self.BUY_AP_MODE_HAZARD1

def _is_buy_action_point_meowfficer_mode(self):
    return self._get_buy_action_point_mode() == self.BUY_AP_MODE_MEOWFFICER
```

**阈值读取**（含容错，避免非法配置值）：

```python
def _get_buy_action_point_upper_threshold(self):
    """上限阈值（仅功能2使用），默认 200"""
    value = self.config.cross_get(keys=self.CONFIG_PATH_BUY_AP_UPPER, default=200)
    try:
        return max(1, int(value or 200))
    except (TypeError, ValueError):
        return 200

def _get_buy_action_point_lower_threshold(self):
    """下限阈值（仅功能1使用），默认 100"""
    value = self.config.cross_get(keys=self.CONFIG_PATH_BUY_AP_LOWER, default=100)
    try:
        return max(0, int(value or 100))
    except (TypeError, ValueError):
        return 100
```

**计数器跨周自动重置**（基于服务器时间 ISO 周标识）：

```python
def _get_current_purchase_week_id(self):
    """基于服务器时间获取 ISO 周标识，如 "2026-W32" """
    diff = server_time_offset()
    server_now = current_time() - diff
    iso_year, iso_week, _ = server_now.isocalendar()
    return f'{iso_year}-W{iso_week:02d}'

def _reset_buy_action_point_count_if_new_week(self):
    """跨周检测：比较持久化的周标识与当前周，不一致时重置计数器"""
    current_week_id = self._get_current_purchase_week_id()
    stored_week_id = self._get_smart_scheduling_state_value(
        self.STATE_KEY_BUY_AP_WEEK_ID,
    )
    if stored_week_id != current_week_id:
        self._set_smart_scheduling_state_value(self.STATE_KEY_BUY_AP_COUNT, 0)
        self._set_smart_scheduling_state_value(
            self.STATE_KEY_BUY_AP_WEEK_ID, current_week_id
        )
```

**双模式决策表**：



### 4.3 智能调度弹窗抑制（双文件联动）

**问题**：智能调度+代跑子任务时，`OpsiScheduling` 外层已查询过行动力，子任务内部的搜敌和进入海域逻辑又会重复触发行动力弹窗，导致高频弹窗，可能触发 `TooManyClickError`。

**抑制点 1 — `module/os/map.py`**（搜敌前跳过冗余弹窗刷新）：

```python
# 智能调度+上下文中，外层已查询过行动力，跳过搜敌前的冗余弹窗刷新
if getattr(self, "_smart_scheduling_context", False) \
        or getattr(self.config, "_smart_scheduling_context", False):
    self._meow_search_start_time = time.time()
    self._meow_search_start_ap = getattr(self, "_action_point_current", None)
    return  # ← 直接返回，不调用 start_meow_search_timer()

# 正常流程（非智能调度上下文时）
self._meow_search_start_time, self._meow_search_start_ap = (
    start_meow_search_timer(self)
)
```

**抑制点 2 — `module/os/tasks/meowfficer_farming.py`**（跳过重复的 `action_point_set`）：

```
python
# 智能调度+上下文中外层已查询行动力，跳过冗余弹窗
if not self.is_running_smart_scheduling_task():
    self.action_point_set(cost=120, keep_current_ap=True, check_rest_ap=True)
self.fleet_set(self.config.OpsiFleet_Fleet)
**`_smart_scheduling_context` 的传递机制**：同时检查 `self` 和 `self.config` 两个位置，确保跨对象传递时可被正确识别。

---

```
**完整调用链路**：
## 五、测试情况

| 测试项 | 范围 | 结果 |
|--------|------|------|
| **模式切换** | `off` / `hazard1_leveling` / `meowfficer_farming` 三模式 | 逻辑分支覆盖完整 |
| **OCR 校验** | `_is_buy_action_point_ocr_valid` 检测斜杠误识别 | 新增校验，失败时跳过购买 |
| **残留恢复** | `BuyActionPointLimit <= 0` 时自动按游戏上限 5 恢复 | 已处理 |
| **月末封锁** | `_is_in_month_end_purchase_block_week()` 服务器时间偏移 | 基于 `server_time_offset()` 计算 |
| **推送间隔** | `AP_NOTIFY_MIN_INTERVAL_MINUTES = 30` | 最小间隔控制已实现 |
| **弹窗抑制** | 智能调度上下文跳过冗余弹窗 | `map.py` + `meowfficer_farming.py` 双点处理 |
| **翻译 fallback** | `en-US.get(key)` 替代 `en-US[key]` | 消除 KeyError |
| **类型安全** | `daily_checked: list[int]` + `append(int(n))` | 类型一致 |

---

## 六、注意事项

1. **首次启用双模式**：切换 `BuyActionPointMode` 后需等待 ISO 周重置（周一凌晨），`BuyActionPointWeekId` 才能正确更新
2. **月末购买跳过**：当前处于月末封锁周时，所有模式的购买均被自动跳过，属预期行为
3. **推送配置**：行动力推送需正确配置 OnePush（`OpsiGeneral_OpsiOnePushConfig` 或 `Error_OnePushConfig`），provider 不能为 `null`
4. **推送间隔**：同一通知类型有 30 分钟最小间隔，频繁刷新不会重复推送
5. **OCR 依赖**：购买计数基于 `cnocr` 模型（日服白色字符），极端模糊截图下可能误识别，系统已自动重试

## Summary by Sourcery

为 OS 智能调度引入可配置的双模式行动点购买机制，包含每周计数和动态任务优先级，以及相关的调度、OCR 和配置增强。

新功能：
- 添加 `BuyActionPointMode`，支持 hazard1 练级和喵菲瑟（meowfficer）刷取两种模式，在 OS 智能调度中驱动不同的行动点购买与执行循环。
- 基于服务器 ISO 周跟踪每周行动点购买次数，并通过游戏内 OCR 同步，用于限制购买次数并驱动动态任务优先级表。
- 为 OS 调度、OCR 模型选择、Opsi 商店记录、委托宝石通知、秘书自动化以及 Opsi 舰队自动更换行为新增配置选项。

错误修复：
- 防止过期的 `BuyActionPointLimit` 覆写导致购买上限被强制为 0，在需要时恢复为游戏内的最大值。
- 校验行动点购买的 OCR 识别区域并确保选择了石油按钮，避免误读药箱数量，在 OCR 失败时安全回退。
- 在智能调度场景中减少多余的行动点弹窗（尤其是喵菲瑟刷取和 hazard1 练级时），避免 `TooManyClickError` 和不必要的提示。
- 修复 GUI 语言回退逻辑，通过安全的字典访问方式避免在缺少 `ja-JP` 键时抛出 `KeyError`。
- 确保 `daily_checked` 始终存储整数，并具有正确的类型注解，避免类型不一致。

改进优化：
- 添加带短 TTL 的行动点读取缓存以及强制刷新选项，以在保持调度决策准确性的同时减少弹窗频率。
- 调整月末清理流程，在做出决策前始终强制刷新行动点数值。
- 优化 hazard1 练级和喵菲瑟任务，使其遵守预先校验的行动点和智能调度上下文，减少重复检查和弹窗。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable dual-mode action point purchasing for OS smart scheduling, with weekly counters and dynamic task prioritization, plus related scheduling, OCR, and config enhancements.

New Features:
- Add BuyActionPointMode with hazard1 leveling and meowfficer farming modes that drive distinct action point purchasing and execution loops in OS smart scheduling.
- Track weekly action point purchase counts based on server ISO week and sync them from in-game OCR, using them to limit buys and drive dynamic task priority tables.
- Introduce new configuration options for OS scheduling, OCR model selection, Opsi shop records, commission gem notifications, secretary automation, and Opsi fleet auto-change behaviour.

Bug Fixes:
- Prevent stale BuyActionPointLimit overrides from forcing zero purchase limits by restoring to the in-game maximum when needed.
- Validate action point purchase OCR regions and ensure the oil button is selected to avoid misreading medicine box counts, falling back safely when OCR fails.
- Reduce redundant action point popups in smart scheduling contexts for meowfficer farming and hazard1 leveling, avoiding TooManyClickError and unnecessary prompts.
- Fix GUI language fallback by using safe dictionary access to avoid KeyError when ja-JP keys are missing.
- Ensure daily_checked always stores integers with proper type annotations to avoid inconsistent types.

Enhancements:
- Add cached action point reads with short TTL and a force-refresh option to reduce popup frequency while keeping scheduling decisions accurate.
- Adjust month-end cleanup to always force-refresh action point values before decisions.
- Refine hazard1 leveling and meowfficer tasks to respect pre-validated action points and smart-scheduling context, reducing duplicate checks and popups.

</details>