### PR TITLE
Add emergency mood reset and fix C rating support

### DIFF
--- a/module/coalition/coalition_scuttle.py
+++ b/module/coalition/coalition_scuttle.py
@@ -89,9 +89,9 @@ class CoalitionScuttleCombat(CoalitionCombat):
                 self._withdraw = True
                 self._is_shipwreck = True
                 break
-            # D评价结算界面：S/A/B评价的动画过渡帧可能短暂误匹配D评价模板，
+            # D评价结算界面：S/A/B/C评价的动画过渡帧可能短暂误匹配D评价模板，
             # 但只有真正的沉船才会出现OPTS_INFO_D弹窗。
-            # 此处不设置沉船标记（未经过OPTS_INFO_D确认），让后续S/A/B条件覆盖。
+            # 此处不设置沉船标记（未经过OPTS_INFO_D确认），让后续S/A/B/C条件覆盖。
             if self.appear(BATTLE_STATUS_D) or self.appear(EXP_INFO_D):
                 break
             if confirm_timer.reached():
@@ -101,10 +101,10 @@ class CoalitionScuttleCombat(CoalitionCombat):
                 confirm_timer.reset()
                 break
 
-            # A/B/S评价：联盟沉船中不额外扣减心情
+            # A/B/C/S评价：联盟沉船中不额外扣减心情
             # 游戏服务端只在整个关卡进入时扣1次2点，不按战斗结算类型扣减
-            if self.appear(BATTLE_STATUS_A) or self.appear(BATTLE_STATUS_B) \
-                    or self.appear(EXP_INFO_A) or self.appear(EXP_INFO_B):
+            if self.appear(BATTLE_STATUS_A) or self.appear(BATTLE_STATUS_B) or self.appear(BATTLE_STATUS_C) \
+                    or self.appear(EXP_INFO_A) or self.appear(EXP_INFO_B) or self.appear(EXP_INFO_C):
                 break
 
             # S评价或自动搜索运行中

--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -326,9 +326,9 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
                 self._withdraw = True
                 break
             # D评价结算界面（BATTLE_STATUS_D / EXP_INFO_D）
-            # S/A/B评价的动画过渡帧可能短暂误匹配D评价模板，
+            # S/A/B/C评价的动画过渡帧可能短暂误匹配D评价模板，
             # 但只有真正的沉船才会出现OPTS_INFO_D弹窗。
-            # 此处不设置 _withdraw，让后续S/A/B评价条件覆盖误匹配。
+            # 此处不设置 _withdraw，让后续S/A/B/C评价条件覆盖误匹配。
             # 真正的D评价会先被上方OPTS_INFO_D捕获。
             if self.appear(BATTLE_STATUS_D) or self.appear(EXP_INFO_D):
                 break
@@ -339,10 +339,14 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
                 self._withdraw = True
                 confirm_timer.reset()
                 break
-            if self.appear(BATTLE_STATUS_A) or self.appear(BATTLE_STATUS_B) \
-                    or self.appear(EXP_INFO_A) or self.appear(EXP_INFO_B):
+            # A/B/C评价：自动搜索中非S评价意味着有舰船沉没，扣减沉船心情（10点）
+            # S评价不扣减额外沉船心情，仅保留进入战斗时的基础扣减（2点）
+            # 设置_shipwreck_emotion_reduced防止C评价后续出现OPTS_INFO_D时重复扣减
+            if self.appear(BATTLE_STATUS_A) or self.appear(BATTLE_STATUS_B) or self.appear(BATTLE_STATUS_C) \
+                    or self.appear(EXP_INFO_A) or self.appear(EXP_INFO_B) or self.appear(EXP_INFO_C):
                 if emotion_reduce:
                     self.emotion.reduce(fleet_index, shipwreck=True)
+                    self._shipwreck_emotion_reduced = True
                 break
             if self.appear(BATTLE_STATUS_S) or self.appear(EXP_INFO_S) \
                     or self.appear(GET_MISSION) or self.is_auto_search_running():
@@ -379,18 +383,40 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
         处理舰队切换操作：仅撤退当前战败舰队，切换到另一队继续战斗。
         包含超时保护，避免UI异常时无限循环。
 
+        沉船后舰队切换流程可能为：
+        EXP_INFO_D → FLEET_SWITCH_CONFIRM(延迟出现) → SWITCH_OVER/FLEET_WITHDRAW → 自动搜索恢复
+        FLEET_SWITCH_CONFIRM可能在结算画面过渡后才延迟出现，
+        因此在此方法中也需要检测，避免错过点击时机。
+
+        SWITCH_OVER点击后，游戏可能显示AUTO_SEARCH_MAP_OPTION_OFF，
+        需要点击它开启自动搜索，否则is_auto_search_running()一直返回False，
+        导致SWITCH_OVER被反复点击触发GameTooManyClickError。
+
         Returns:
             bool: True表示切换成功，False表示超时。
         """
         timeout = Timer(10, count=20).start()
+        switch_over_clicked = 0
         while 1:
             self.device.screenshot()
+            # 舰队切换完成，自动搜索恢复运行
+            if self.is_auto_search_running():
+                break
+            # FLEET_SWITCH_CONFIRM可能在结算过渡后延迟出现
+            if self.appear_then_click(FLEET_SWITCH_CONFIRM, offset=(30, 30)):
+                continue
             if self.appear_then_click(FLEET_WITHDRAW, offset=(30, 30)):
                 break
             if self.appear(FLEET_WITHDRAW_BOSS, offset=(30, 30)):
                 self.withdraw()
                 break
-            if self.appear_then_click(SWITCH_OVER, interval=2):
+            # 限制SWITCH_OVER点击次数，防止GameTooManyClickError
+            # SWITCH_OVER点击后需要处理AUTO_SEARCH_MAP_OPTION_OFF才能恢复自动搜索
+            if switch_over_clicked < 2 and self.appear_then_click(SWITCH_OVER, interval=2):
+                switch_over_clicked += 1
+                continue
+            # 处理自动搜索地图选项（关闭AUTO_SEARCH_MAP_OPTION_OFF，开启自动搜索）
+            if self.handle_auto_search_map_option():
                 continue
             if timeout.reached():
                 logger.warning('舰队切换超时，改为撤退')

--- a/module/combat/emotion.py
+++ b/module/combat/emotion.py
@@ -449,6 +449,35 @@ class Emotion:
         self.record()
         self.show()
 
+    def emergency_reset(self):
+        """心情清零保底。计算模式下出现红脸弹窗时调用。
+
+        将所有舰队的心情值重置为0，强制下次任务等待心情恢复。
+        这是计算模式下的异常保底措施，正常情况下不应被调用——
+        计算模式会在进入战役前预检心情并延迟任务，红脸弹窗仅在
+        ALAS计算错误或用户手动操作后才可能出现。
+
+        重置内容：
+        - FleetEmotion.current 设为 0
+        - config 中的 Value 设为 0
+        - config 中的 Record 设为当前时间（从0开始恢复计时）
+        - _fractional_seconds 清零（丢弃未满1点的恢复余数）
+        """
+        if self.using_public:
+            fleets = [self.public_fleet]
+        else:
+            fleets = self.fleets
+
+        with self.config.multi_set():
+            for fleet in fleets:
+                fleet.current = 0
+                fleet._fractional_seconds = 0
+                record_time = current_time().replace(microsecond=0)
+                setattr(self.config, fleet.value_name, 0)
+                setattr(self.config, fleet.value_name.replace('Value', 'Record'),
+                        record_time)
+        logger.info('[心情-保底] 已将所有舰队心情清零')
+
     @cached_property
     def bug_threshold(self):
         """

--- a/module/handler/info_handler.py
+++ b/module/handler/info_handler.py
@@ -22,10 +22,12 @@ from module.base.base import ModuleBase
 from module.base.button import Button
 from module.base.timer import Timer
 from module.base.utils import *
-from module.exception import GameNotRunningError
+from module.combat.assets import BATTLE_PREPARATION
+from module.exception import CampaignEnd, GameNotRunningError, ScriptEnd
 from module.handler.assets import *
 from module.logger import logger
 from module.os_handler.assets import CLICK_SAFE_AREA as OS_CLICK_SAFE_AREA
+from module.ui.assets import BACK_ARROW
 from module.ui_white.assets import POPUP_CANCEL_WHITE, POPUP_CONFIRM_WHITE, POPUP_SINGLE_WHITE
 
 
@@ -214,6 +216,38 @@ class InfoHandler(ModuleBase):
         return appear
 
     def handle_combat_low_emotion(self):
+        """
+        处理低情绪出击警告弹窗（红脸弹窗）。
+
+        - ignore 模式（含 calculate_ignore）：点击确认继续出击
+        - calculate 模式（不含 ignore）：正常不应出现红脸弹窗（已预检），
+          若出现则视为异常，取消弹窗退出关卡、心情清零、延时任务
+
+        Returns:
+            bool: 是否处理了弹窗。calculate 模式下若触发保底会抛出 ScriptEnd。
+
+        Raises:
+            ScriptEnd: calculate 模式下出现红脸弹窗时，心情清零并延时后抛出。
+        """
+        # calculate 模式保底：正常不应出现红脸弹窗
+        # 若出现则可能是ALAS计算错误或用户手动操作，需异常处理
+        if self.emotion.is_calculate and not self.emotion.is_ignore:
+            if self.handle_popup_cancel('IGNORE_LOW_EMOTION'):
+                logger.warning('[心情-保底] 计算模式下出现红脸弹窗，'
+                               '可能是ALAS计算错误或用户手动操作')
+                logger.hr('心情异常保底')
+                # 退出关卡（弹窗已取消，阻止战斗）
+                # 捕获 withdraw() 抛出的 CampaignEnd，确保后续心情清零和延时被执行
+                try:
+                    self._emotion_emergency_exit()
+                except CampaignEnd:
+                    logger.info('[心情-保底] 撤退完成，已回到关卡页面')
+                # 心情清零，强制下次任务等待恢复
+                self.emotion.emergency_reset()
+                # 延时当前任务至下次服务器刷新
+                self.config.task_delay(server_update=True)
+                raise ScriptEnd('[心情-保底] 计算模式红脸弹窗，心情清零并延时')
+
         if not self.emotion.is_ignore:
             return False
 
@@ -222,6 +256,45 @@ class InfoHandler(ModuleBase):
             # 避免误点 AUTO_SEARCH_MAP_OPTION_OFF
             self.interval_reset(AUTO_SEARCH_MAP_OPTION_OFF)
         return result
+
+    def _emotion_emergency_exit(self):
+        """
+        红脸弹窗保底退出关卡。
+
+        取消弹窗后，依次处理战斗准备界面、自动搜索菜单、地图界面，
+        直到回到关卡选择页面或超时。用于 calculate 模式下出现红脸弹窗的
+        异常保底流程，确保游戏回到关卡选择页面后再延时任务。
+
+        Pages:
+            in: 红脸弹窗已取消，可能在战斗准备/地图/自动搜索菜单
+            out: is_in_stage() 或超时
+        """
+        timeout = Timer(30, count=60).start()
+        while 1:
+            self.device.screenshot()
+
+            if timeout.reached():
+                logger.warning('[心情-保底] 退出关卡超时')
+                break
+
+            if self.handle_popup_cancel('IGNORE_LOW_EMOTION'):
+                continue
+            if self.handle_story_skip():
+                continue
+            # 战斗准备界面：点击返回
+            if self.appear(BATTLE_PREPARATION, offset=(20, 20), interval=2):
+                self.device.click(BACK_ARROW)
+                continue
+            # 自动搜索菜单：退出
+            if self.handle_auto_search_exit():
+                continue
+            # 已回到关卡页面
+            if self.is_in_stage():
+                break
+            # 在地图中：撤退（withdraw 在 MapOperation 中，部分子类可能没有）
+            if self.is_in_map() and hasattr(self, 'withdraw'):
+                self.withdraw()
+                break
 
     def handle_use_data_key(self):
         if not self.config.USE_DATA_KEY:


### PR DESCRIPTION
## Summary by Sourcery

加强低情绪恢复机制，并扩展战斗结果处理以支持 C 评级。

Bug Fixes（错误修复）:
- 在计算模式中处理意外的低情绪战斗警告：通过退出关卡、重置舰队情绪并延迟任务来应对。
- 在自动探索战斗和联合解体流程中识别 C 战斗评级，并应用相应的残骸（船沉）处理逻辑。

Enhancements（增强改进）:
- 改进舰队切换后的恢复能力：处理延迟出现的确认提示，并在切换后安全地恢复自动探索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden low-emotion recovery and extend combat result handling to support C ratings.

Bug Fixes:
- Handle unexpected low-emotion combat warnings in calculate mode by exiting the stage, resetting fleet emotion, and delaying the task.
- Recognize C battle ratings in auto-search combat and coalition scuttle flows, applying the appropriate shipwreck handling.

Enhancements:
- Improve fleet-switch recovery by handling delayed confirmation prompts and restoring auto-search safely after switching.

</details>