### PR TITLE
fix(island): 排产时套餐不再消耗保留线内未达标产品的保底库存

### DIFF
--- a/module/island/island_shop_base.py
+++ b/module/island/island_shop_base.py
@@ -43,6 +43,9 @@ class IslandShopBase(Island, WarehouseOCR):
         self.warehouse_counts = {}  # 仓库识别到的产品
         self.to_post_products = {}
         self.current_totals = {}
+        # 保留线目标 {产品: 断点前槽位最高目标}，
+        # 排产时这些产品的仓库库存只能消耗超出自身目标的部分
+        self._reserved_targets = {}
 
         # 特殊材料（子类可覆盖）
         self.special_materials = {}
@@ -433,6 +436,8 @@ class IslandShopBase(Island, WarehouseOCR):
         max_targets = {}
         for name, target in self.post_products[:break_idx + 1]:
             max_targets[name] = max(max_targets.get(name, 0), target)
+        # 记录保留线目标，供排产阶段限制套餐对其库存的消耗
+        self._reserved_targets = dict(max_targets)
         for name, max_target in max_targets.items():
             current = self.current_totals.get(name, 0)
             if current < max_target:
@@ -749,6 +754,24 @@ class IslandShopBase(Island, WarehouseOCR):
 
         return result
 
+    def _get_usable_stock(self, material, material_stock):
+        """获取套餐原料的可用库存。
+
+        保留线内产品（_reserved_targets）只能消耗仓库库存中超出自身
+        目标的部分，避免套餐消耗其尚未达标的保底库存；其余材料直接用
+        仓库库存。在产数量不计入可用量（做套餐查原料时在产不算）。
+
+        Args:
+            material: 原料名称
+            material_stock: 仓库实际库存
+
+        Returns:
+            int: 可被套餐消耗的库存量
+        """
+        if material in self._reserved_targets:
+            return max(0, material_stock - self._reserved_targets[material])
+        return material_stock
+
     def get_max_producible(self, product, requested_quantity, skip_zero_materials=False):
         """获取最大可生产数量。
 
@@ -771,7 +794,11 @@ class IslandShopBase(Island, WarehouseOCR):
                 quantity_per = composition.get('quantity_per', 1)
                 if quantity_per == 0:
                     continue
-                max_by_material = material_stock // quantity_per
+                # 保留线内的产品只能消耗"仓库超额库存"（见 _get_usable_stock），
+                # 否则套餐会在前置项目因材料不足被跳过时，把其本就不够的
+                # 保底库存吃掉。
+                usable_stock = self._get_usable_stock(material, material_stock)
+                max_by_material = usable_stock // quantity_per
                 if max_by_material <= 0:
                     if skip_zero_materials and material_stock == 0:
                         # 需求计算阶段且真零库存：不阻断，留给 process_meal_requirements 分解
@@ -779,10 +806,13 @@ class IslandShopBase(Island, WarehouseOCR):
                         continue
                     else:
                         # 排产阶段 或 有但不满足一批：严格处理
-                        logger.info(f"[岛屿]   {self._item_cn(product)} 缺少原材料: {self._item_cn(material)} (库存: {material_stock})")
+                        if material in self._reserved_targets:
+                            logger.info(f"[岛屿]   {self._item_cn(product)} 原材料 {self._item_cn(material)} 无超额库存（仓库未超出目标 {self._reserved_targets[material]}），暂不消耗其保底库存")
+                        else:
+                            logger.info(f"[岛屿]   {self._item_cn(product)} 缺少原材料: {self._item_cn(material)} (库存: {material_stock})")
                         return 0
                 max_producible = min(max_producible, max_by_material)
-                logger.info(f"[岛屿]   {self._item_cn(product)} 原材料 {self._item_cn(material)}: 库存 {material_stock}，每个需要 {quantity_per}，最大生产 {max_by_material}")
+                logger.info(f"[岛屿]   {self._item_cn(product)} 原材料 {self._item_cn(material)}: 库存 {material_stock}，可用 {usable_stock}，每个需要 {quantity_per}，最大生产 {max_by_material}")
 
         # 2. 检查岗位数量限制
         max_producible = min(max_producible, self.POST_PRODUCE_LIMIT)


### PR DESCRIPTION
## 问题

岛屿排产中，"保留线"机制只保护了**需求账本**（`current_totals`），排产阶段的 `get_max_producible` 直接读取**仓库库存**（`warehouse_counts`），不认保留线。

当某个前置项目（如啾啾简餐的草莓夏洛特）因材料不足（芝士来自啾咖啡）被跳过、或尚未达到自己的目标时，排在其后的套餐（如莓果香橙甜点组）仍会把其仓库里的保底库存当作原料消耗掉，导致前置项目库存被吃穿、永远达不到自己的目标。

**实际案例**：配置为 甜点组20/夏洛特20/…/甜点组50/夏洛特50 时，芝士长期不足的情况下，观察到甜点组已到 50，而夏洛特始终不足 20。

## 修复

- `_compute_base_demands` 把保留线目标记录为 `self._reserved_targets`（{产品: 断点前槽位最高目标}）
- `get_max_producible` 检查套餐原料时，保留线内产品的可用量 = `max(0, 仓库库存 - 保留目标)`，即只能消耗超出自身目标的**仓库超额库存**；在产数量不计入可用量（"做套餐查原料时在产不算"）
- 未超额时日志明确提示"无超额库存（仓库未超出目标 X），暂不消耗其保底库存"

## 验证

以真实配置（简餐 8 槽位）做多轮排产仿真（逻辑逐行复刻自本文件）：
- 芝士充足：夏洛特全程 ≥ 目标，甜点组 30→50 收敛轮数 8→9，几乎无代价
- 芝士不足（每轮仅产 1 夏洛特）：修复前夏洛特反复 20→14 波动、甜点组爬 50 时夏洛特 <20；修复后夏洛特恒 ≥20，甜点组仅消耗超额部分
- 需求计算阶段行为不变（保留线在需求阶段尚未执行，可用量仍等于仓库库存）

不涉及配置变更，无需运行 config_updater。

## Summary by Sourcery

在岛内生产过程中保护预留线（reserved-line）库存，使后续的餐食包只消耗前置产品的多余库存。

Bug 修复：
- 防止餐食生产在前置产品尚未达到其生产目标时，从预留线产品的低于目标仓库库存中进行消耗。
- 在餐食生产中，仅允许消耗高于预留目标的库存，同时保留前置产品的预留库存。

功能增强：
- 在需求计算过程中跟踪预留线目标，并在没有可用的多余库存时提供更清晰的生产日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Protect reserved-line inventory during island production so downstream meal packages consume only prerequisite products' excess stock.

Bug Fixes:
- Prevent meal production from consuming reserved-line products' below-target warehouse stock when those products have not yet met their production targets.
- Preserve reserved inventory for prerequisite products while allowing meal production to consume only stock above the reserved targets.

Enhancements:
- Track reserved-line targets during demand calculation and provide clearer production logs when no excess inventory is available.

</details>