### PR TITLE
修复非自律寻敌模式下不检查潜艇职能的问题

### DIFF
--- a/module/handler/fast_forward.py
+++ b/module/handler/fast_forward.py
@@ -349,7 +349,10 @@ class FastForwardHandler(AutoSearchHandler):
         Pages:
             in: FLEET_PREPARATION
         """
-        if not self.config.FLEET_2 and not self.config.SUBMARINE:
+        if not self.map_is_clear_mode:
+            return False
+
+        if not self.map_is_auto_search and not self.config.SUBMARINE:
             return False
 
         logger.info('自动搜索设置')

--- a/module/handler/fast_forward.py
+++ b/module/handler/fast_forward.py
@@ -349,7 +349,7 @@ class FastForwardHandler(AutoSearchHandler):
         Pages:
             in: FLEET_PREPARATION
         """
-        if not self.map_is_auto_search:
+        if not self.config.FLEET_2 and not self.config.SUBMARINE:
             return False
 
         logger.info('自动搜索设置')


### PR DESCRIPTION
Fixes #144

## Summary by Sourcery

Bug Fixes:
- 确保自动敌方搜索设置仅在清图模式下进行处理，同时在关闭自动搜索时仍允许启用潜艇的舰队继续出击。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure automatic enemy-search settings are processed only in clear-map mode while still allowing submarine-enabled fleets to proceed when automatic search is disabled.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 确保自动敌方搜索设置仅在清图模式下进行处理，同时在关闭自动搜索时仍允许启用潜艇的舰队继续出击。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure automatic enemy-search settings are processed only in clear-map mode while still allowing submarine-enabled fleets to proceed when automatic search is disabled.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 确保自动敌方搜索设置仅在清图模式下进行处理，同时在关闭自动搜索时仍允许启用潜艇的舰队继续出击。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure automatic enemy-search settings are processed only in clear-map mode while still allowing submarine-enabled fleets to proceed when automatic search is disabled.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 确保自动敌方搜索设置仅在清图模式下进行处理，同时在关闭自动搜索时仍允许启用潜艇的舰队继续出击。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure automatic enemy-search settings are processed only in clear-map mode while still allowing submarine-enabled fleets to proceed when automatic search is disabled.

</details>

</details>

</details>