### PR TITLE
fix(ocr): 恢复中英文自动推荐的旧版模型

### DIFF
--- a/.agent/OCR.md
+++ b/.agent/OCR.md
@@ -61,7 +61,7 @@ alwaysApply: true
 
 - `L38-58`：`handle_ocr_error()` — OCR 依赖加载失败统一处理，提示安装 VC++ 运行库并抛出 `RequestHumanTakeover`。
 - `L61-71`：导入 RapidOCR 依赖与 `NcnnRecOCR`/`supports_ncnn_model`。失败时调用 `handle_ocr_error()`。
-- `L74-142`：模型路径常量与 `ONNX_MODEL_PARAMS` — 6 个逻辑模型（azur_lane、azur_lane_jp、ppocr_v6、cn、jp、tw）各含 lite/standard/pro 三档 PP-OCRv6 模型 + 旧版 AlOCR 专用模型（alocr_en_v2_6/alocr_cn_v3）；`DEFAULT_ONNX_MODEL_VERSION` 默认 standard 档。azur_lane/azur_lane_jp 使用受限 en 字典。
+- `L74-142`：模型路径常量与 `ONNX_MODEL_PARAMS` — 6 个逻辑模型（azur_lane、azur_lane_jp、ppocr_v6、cn、jp、tw）各含 lite/standard/pro 三档 PP-OCRv6 模型 + 旧版 AlOCR 专用模型（alocr_en_v2_6/alocr_cn_v3）；`DEFAULT_ONNX_MODEL_VERSION` 对英文和简体中文默认使用对应旧版模型，其余语言默认 standard 档。azur_lane/azur_lane_jp 使用受限 en 字典。
 - `L145-177`：`RecOnlyOCR` — 仅加载识别模型，跳过检测和分类（`_initialize()` 重写）。
 - `L180-181`：全局配置加载（`AzurLaneConfig`）。
 - `L184-243`：OCR 工作队列 — `_OcrJob`（任务封装）、`_ocr_queue`（队列）、`_ocr_worker_loop()`（后台线程 `AlOcrQueue`）、`_ensure_ocr_worker()`、`_run_ocr_queued()`（将 OCR 操作排队到单线程执行，避免并发问题）。

--- a/bin/ocr_models/README.md
+++ b/bin/ocr_models/README.md
@@ -39,4 +39,5 @@ ncnn 和 ONNX 后端有不同实现。
 | `zh-CN/alocr-zh-cn-v3.dtk.onnx` | 旧版 AlOCR v3 简体中文识别模型（PP-OCRv5 结构，仅 ONNX 后端） |
 | `zh-CN/cn.txt` | 上述中文模型的字典 |
 
-默认仍使用 PP-OCRv6（`standard`），需要时可在 GUI 中单独切换为旧版模型。
+英文和简体中文的 `auto` 档位默认使用对应旧版模型；日文和繁体中文仍默认使用
+PP-OCRv6（`standard`）。需要时可在 GUI 中手动切换模型版本。

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -806,7 +806,7 @@
     },
     "OcrModelVersionEnglish": {
       "name": "OCR English Model Version",
-      "help": "Choose the English OCR model tier. Lite is lightest and fastest, Standard is balanced, Pro is highest accuracy. Auto uses Standard. alocr_en_v2_6 is the legacy AlOCR English model (ONNX backend only). This affects the English Azur Lane model.",
+      "help": "Choose the English OCR model tier. Lite is lightest and fastest, Standard is balanced, Pro is highest accuracy. Auto uses the legacy alocr_en_v2_6 model. alocr_en_v2_6 is available only with the ONNX backend. This affects the English Azur Lane model.",
       "auto": "Auto Recommended",
       "lite": "Lite",
       "standard": "Standard",
@@ -815,7 +815,7 @@
     },
     "OcrModelVersionChinese": {
       "name": "OCR Chinese Model Version",
-      "help": "Choose the Simplified Chinese OCR model tier. Lite is lightest and fastest, Standard is balanced, Pro is highest accuracy. Auto uses Standard. alocr_cn_v3 is the legacy AlOCR Chinese model (ONNX backend only). This affects cnocr/Chinese models.",
+      "help": "Choose the Simplified Chinese OCR model tier. Lite is lightest and fastest, Standard is balanced, Pro is highest accuracy. Auto uses the legacy alocr_cn_v3 model. alocr_cn_v3 is available only with the ONNX backend. This affects cnocr/Chinese models.",
       "auto": "Auto Recommended",
       "lite": "Lite",
       "standard": "Standard",

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -806,7 +806,7 @@
     },
     "OcrModelVersionEnglish": {
       "name": "OCR 英語モデルバージョン",
-      "help": "英語 OCR モデルの階層を選択します。lite は最軽量で最速、standard はバランス型、pro は最高精度です。auto は standard を使用します。alocr_en_v2_6 は旧版 AlOCR 英語モデル（ONNX バックエンドのみ）です。この項目は英語 Azur Lane モデルに適用されます。",
+      "help": "英語 OCR モデルの階層を選択します。lite は最軽量で最速、standard はバランス型、pro は最高精度です。auto は旧版の alocr_en_v2_6 を使用します。alocr_en_v2_6 は ONNX バックエンドでのみ使用できます。この項目は英語 Azur Lane モデルに適用されます。",
       "auto": "自動推奨",
       "lite": "Lite（軽量）",
       "standard": "Standard（標準）",
@@ -815,7 +815,7 @@
     },
     "OcrModelVersionChinese": {
       "name": "OCR 中国語モデルバージョン",
-      "help": "簡体中国語 OCR モデルの階層を選択します。lite は最軽量で最速、standard はバランス型、pro は最高精度です。auto は standard を使用します。alocr_cn_v3 は旧版 AlOCR 中国語モデル（ONNX バックエンドのみ）です。この項目は cnocr/中国語モデルに適用されます。",
+      "help": "簡体中国語 OCR モデルの階層を選択します。lite は最軽量で最速、standard はバランス型、pro は最高精度です。auto は旧版の alocr_cn_v3 を使用します。alocr_cn_v3 は ONNX バックエンドでのみ使用できます。この項目は cnocr/中国語モデルに適用されます。",
       "auto": "自動推奨",
       "lite": "Lite（軽量）",
       "standard": "Standard（標準）",

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -806,7 +806,7 @@
     },
     "OcrModelVersionEnglish": {
       "name": "OCR英文模型版本",
-      "help": "选择英文 OCR 模型档位。lite 轻量最快，standard 均衡，pro 精度最高。auto 使用 standard。alocr_en_v2_6 为旧版 AlOCR 专用英文模型，仅 ONNX 后端可用。该项影响英文 Azur Lane 模型。",
+      "help": "选择英文 OCR 模型档位。lite 轻量最快，standard 均衡，pro 精度最高。auto 使用旧版 alocr_en_v2_6。alocr_en_v2_6 为旧版 AlOCR 专用英文模型，仅 ONNX 后端可用。该项影响英文 Azur Lane 模型。",
       "auto": "自动推荐",
       "lite": "Lite 轻量",
       "standard": "Standard 标准",
@@ -815,7 +815,7 @@
     },
     "OcrModelVersionChinese": {
       "name": "OCR中文模型版本",
-      "help": "选择简体中文 OCR 模型档位。lite 轻量最快，standard 均衡，pro 精度最高。auto 使用 standard。alocr_cn_v3 为旧版 AlOCR 专用中文模型，仅 ONNX 后端可用。该项影响 cnocr/中文模型。",
+      "help": "选择简体中文 OCR 模型档位。lite 轻量最快，standard 均衡，pro 精度最高。auto 使用旧版 alocr_cn_v3。alocr_cn_v3 为旧版 AlOCR 专用中文模型，仅 ONNX 后端可用。该项影响 cnocr/中文模型。",
       "auto": "自动推荐",
       "lite": "Lite 轻量",
       "standard": "Standard 标准",

--- a/module/config/i18n/zh-MIAO.json
+++ b/module/config/i18n/zh-MIAO.json
@@ -806,7 +806,7 @@
     },
     "OcrModelVersionEnglish": {
       "name": "OCR英文模型版本喵",
-      "help": "选择英文OCR模型档位喵。lite轻量最快喵，standard均衡喵，pro精度最高喵。auto使用standard喵。alocr_en_v2_6为旧版AlOCR专用英文模型喵，仅ONNX后端可用喵。该项影响英文Azur Lane模型。",
+      "help": "选择英文OCR模型档位喵。lite轻量最快喵，standard均衡喵，pro精度最高喵。auto使用旧版alocr_en_v2_6喵。alocr_en_v2_6为旧版AlOCR专用英文模型喵，仅ONNX后端可用喵。该项影响英文Azur Lane模型。",
       "auto": "自动推荐喵",
       "lite": "Lite 轻量喵",
       "standard": "Standard 标准喵",
@@ -815,7 +815,7 @@
     },
     "OcrModelVersionChinese": {
       "name": "OCR中文模型版本喵",
-      "help": "选择简体中文OCR模型档位喵。lite轻量最快喵，standard均衡喵，pro精度最高喵。auto使用standard喵。alocr_cn_v3为旧版AlOCR专用中文模型喵，仅ONNX后端可用喵。该项影响cnocr/中文模型。",
+      "help": "选择简体中文OCR模型档位喵。lite轻量最快喵，standard均衡喵，pro精度最高喵。auto使用旧版alocr_cn_v3喵。alocr_cn_v3为旧版AlOCR专用中文模型喵，仅ONNX后端可用喵。该项影响cnocr/中文模型。",
       "auto": "自动推荐喵",
       "lite": "Lite 轻量喵",
       "standard": "Standard 标准喵",

--- a/module/config/i18n/zh-TW.json
+++ b/module/config/i18n/zh-TW.json
@@ -806,7 +806,7 @@
     },
     "OcrModelVersionEnglish": {
       "name": "OCR 英文模型版本",
-      "help": "選擇英文 OCR 模型檔位。lite 輕量最快，standard 均衡，pro 精度最高。auto 使用 standard。alocr_en_v2_6 為舊版 AlOCR 專用英文模型，僅 ONNX 後端可用。此項影響英文 Azur Lane 模型。",
+      "help": "選擇英文 OCR 模型檔位。lite 輕量最快，standard 均衡，pro 精度最高。auto 使用舊版 alocr_en_v2_6。alocr_en_v2_6 為舊版 AlOCR 專用英文模型，僅 ONNX 後端可用。此項影響英文 Azur Lane 模型。",
       "auto": "自動推薦",
       "lite": "Lite 輕量",
       "standard": "Standard 標準",
@@ -815,7 +815,7 @@
     },
     "OcrModelVersionChinese": {
       "name": "OCR 簡中模型版本",
-      "help": "選擇簡體中文 OCR 模型檔位。lite 輕量最快，standard 均衡，pro 精度最高。auto 使用 standard。alocr_cn_v3 為舊版 AlOCR 專用中文模型，僅 ONNX 後端可用。此項影響 cnocr/中文模型。",
+      "help": "選擇簡體中文 OCR 模型檔位。lite 輕量最快，standard 均衡，pro 精度最高。auto 使用舊版 alocr_cn_v3。alocr_cn_v3 為舊版 AlOCR 專用中文模型，僅 ONNX 後端可用。此項影響 cnocr/中文模型。",
       "auto": "自動推薦",
       "lite": "Lite 輕量",
       "standard": "Standard 標準",

--- a/module/ocr/al_ocr.py
+++ b/module/ocr/al_ocr.py
@@ -133,10 +133,10 @@ ONNX_MODEL_PARAMS = {
 }
 
 DEFAULT_ONNX_MODEL_VERSION = {
-    "azur_lane": "standard",
+    "azur_lane": "alocr_en_v2_6",
     "azur_lane_jp": "standard",
     "ppocr_v6": "standard",
-    "cn": "standard",
+    "cn": "alocr_cn_v3",
     "jp": "standard",
     "tw": "standard",
 }


### PR DESCRIPTION
## Summary by Sourcery

恢复特定语言的旧版模型推荐，用于自动 OCR 识别。

Bug Fixes:
- 恢复用于自动识别英文和简体中文的旧版 OCR 模型默认设置。

Enhancements:
- 让日文和繁体中文的自动识别继续使用标准的 PP-OCRv6 模型。
- 更新 OCR 模型文档，以反映按语言自动选择模型的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore language-specific legacy model recommendations for automatic OCR recognition.

Bug Fixes:
- Restore legacy OCR model defaults for automatic English and Simplified Chinese recognition.

Enhancements:
- Keep Japanese and Traditional Chinese automatic recognition on the standard PP-OCRv6 models.
- Update OCR model documentation to reflect language-specific automatic model selection.

</details>