### PR TITLE
perf(scheduler): 优化部分情况下结束调度器的逻辑

### DIFF
--- a/module/webui/app_overview.py
+++ b/module/webui/app_overview.py
@@ -89,7 +89,9 @@ class OverviewMixin(WebUIMixinBase):
         switch_scheduler = BinarySwitchButton(
             label_on=t("Gui.Button.Stop"),
             label_off=t("Gui.Button.Start"),
-            onclick_on=lambda: self.alas.stop_by_user(),
+            onclick_on=lambda: self.alas.stop_by_user(
+                self.alas_config.Optimization_WhenSchedulerStopped
+            ),
             onclick_off=self._alas_start,
             get_state=lambda: self.alas.alive,
             color_on="off",
@@ -310,7 +312,9 @@ class OverviewMixin(WebUIMixinBase):
         switch_scheduler = BinarySwitchButton(
             label_on=t("Gui.Button.Stop"),
             label_off=t("Gui.Button.Start"),
-            onclick_on=lambda: self.alas.stop_by_user(),
+            onclick_on=lambda: self.alas.stop_by_user(
+                self.alas_config.Optimization_WhenSchedulerStopped
+            ),
             onclick_off=lambda: self.alas.start(task),
             get_state=lambda: self.alas.alive,
             color_on="off",

--- a/module/webui/process_manager.py
+++ b/module/webui/process_manager.py
@@ -49,6 +49,8 @@ from module.webui.worker_registry import (
     unregister_worker,
 )
 
+_STOP_ACTION_UNSET = object()
+
 
 class ProcessManager:
     _processes: Dict[str, "ProcessManager"] = {}
@@ -182,12 +184,22 @@ class ProcessManager:
             logger.warning(f"[{self.config_name}] worker 未完全停止")
         return stopped
 
-    def stop_by_user(self) -> bool:
+    def stop_by_user(self, action: object = _STOP_ACTION_UNSET) -> bool:
         """停止 worker 后执行用户配置的收尾动作。
 
         该入口仅供 WebUI 的停止按钮使用。更新、WebUI 清理和 MCP 仍调用
         ``stop()``，从而避免非用户停止意外关闭游戏或模拟器。
+
+        ``stay_there`` 直接复用最初的强制停止路径，不启动收尾进程，确保
+        停止行为和响应速度与未引入停止后动作前完全一致。未传入动作时保留
+        旧调用行为，由独立收尾进程重新读取配置。
         """
+        if action is not _STOP_ACTION_UNSET:
+            from module.webui.scheduler_stop import normalize_stop_action
+
+            if normalize_stop_action(action) == "stay_there":
+                return self.stop()
+
         with self._get_lifecycle_lock(self.config_name):
             stopped, should_run_action = self._stop_worker_locked()
             if stopped and should_run_action:

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -401,7 +401,32 @@ class TestProcessManagerRegistry(unittest.TestCase):
         process.join.assert_called_once_with(timeout=0)
         self.assertIsNone(manager._process)
 
+    def test_stop_by_user_stay_there_uses_original_stop_path(self):
+        manager = ProcessManager.get_manager("alas")
+
+        with (
+            patch.object(manager, "stop", return_value=True) as stop,
+            patch.object(manager, "_stop_worker_locked") as stop_worker,
+            patch.object(manager, "_run_manual_stop_action_locked") as action,
+        ):
+            self.assertTrue(manager.stop_by_user("stay_there"))
+
+        stop.assert_called_once_with()
+        stop_worker.assert_not_called()
+        action.assert_not_called()
+
     def test_stop_by_user_runs_action_after_confirmed_worker_stop(self):
+        manager = ProcessManager.get_manager("alas")
+
+        with (
+            patch.object(manager, "_stop_worker_locked", return_value=(True, True)),
+            patch.object(manager, "_run_manual_stop_action_locked") as action,
+        ):
+            self.assertTrue(manager.stop_by_user("goto_main"))
+
+        action.assert_called_once_with()
+
+    def test_stop_by_user_without_action_keeps_legacy_config_resolution(self):
         manager = ProcessManager.get_manager("alas")
 
         with (
@@ -419,7 +444,7 @@ class TestProcessManagerRegistry(unittest.TestCase):
             patch.object(manager, "_stop_worker_locked", return_value=(False, True)),
             patch.object(manager, "_run_manual_stop_action_locked") as action,
         ):
-            self.assertFalse(manager.stop_by_user())
+            self.assertFalse(manager.stop_by_user("close_game"))
 
         action.assert_not_called()
 
@@ -430,7 +455,7 @@ class TestProcessManagerRegistry(unittest.TestCase):
             patch.object(manager, "_stop_worker_locked", return_value=(True, False)),
             patch.object(manager, "_run_manual_stop_action_locked") as action,
         ):
-            self.assertTrue(manager.stop_by_user())
+            self.assertTrue(manager.stop_by_user("close_emulator"))
 
         action.assert_not_called()
 


### PR DESCRIPTION
## Summary by Sourcery

通过应用来自 WebUI 的已配置停止动作来优化调度器关闭处理，并在不需要后续操作时跳过不必要的后续处理。

Bug Fixes:
- 确保调度器的“原地停止”动作使用原始的“立即停止”路径，而不会触发任何后续动作。

Enhancements:
- 允许 WebUI 在停止调度器时直接传递已配置的后停止动作，同时为未显式指定动作的调用方保留原有行为。

Tests:
- 增加对显式停止动作、旧版配置解析以及优化后的“原地停止”路径的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize scheduler shutdown handling by applying the configured stop action from the WebUI and bypassing unnecessary follow-up processing when no post-stop action is needed.

Bug Fixes:
- Ensure the scheduler's stay-in-place stop action uses the original immediate stop path without launching follow-up actions.

Enhancements:
- Allow the WebUI to pass the configured post-stop action directly when stopping the scheduler while preserving legacy behavior for callers without an explicit action.

Tests:
- Add coverage for explicit stop actions, legacy configuration resolution, and the optimized stay-in-place stop path.

</details>