### PR TITLE
fix(config): 移除配置读写的 stdout 副作用

### DIFF
--- a/module/config/utils.py
+++ b/module/config/utils.py
@@ -98,7 +98,6 @@ def read_file(file):
     Returns:
         dict, list: 解析后的数据。
     """
-    print(f'read: {file}')
     if file.endswith('.json'):
         content = atomic_read_bytes(file)
         if not content:
@@ -113,7 +112,7 @@ def read_file(file):
             data = {}
         return data
     else:
-        print(f'Unsupported config file extension: {file}')
+        logger.warning(f'不支持的配置文件扩展名: {file}')
         return {}
 
 
@@ -125,7 +124,6 @@ def write_file(file, data):
         file (str): 文件路径。
         data (dict, list): 要写入的数据。
     """
-    print(f'write: {file}')
     if file.endswith('.json'):
         content = json.dumps(data, indent=2, ensure_ascii=False, sort_keys=False, default=str)
         atomic_write(file, content)
@@ -138,7 +136,7 @@ def write_file(file, data):
                 data, default_flow_style=False, encoding='utf-8', allow_unicode=True, sort_keys=False)
         atomic_write(file, content)
     else:
-        print(f'Unsupported config file extension: {file}')
+        logger.warning(f'不支持的配置文件扩展名: {file}')
 
 
 def iter_folder(folder, is_dir=False, ext=None):


### PR DESCRIPTION
# 结论

移除配置读写函数对标准输出的直接写入，避免 GUI / launcher 环境下无效 stdout 句柄触发运行时异常，同时把不支持的扩展名提示统一交给 logger。

## 背景

`read_file()` 和 `write_file()` 每次读写配置都会调用 `print()`。在 Windows GUI / launcher 进程中，stdout 可能已经关闭或不是有效控制台句柄，导致配置流程出现 `OSError(22)`，并污染正常运行日志。

## 改动

- 删除 JSON/YAML 配置读写路径中的 `print()` 副作用。
- 不支持的文件扩展名改用 `logger.warning()` 输出。
- 不改变配置解析、序列化、原子写入或返回值行为。

## 未包含

- 不修改 launcher 源码。
- 不修改配置默认值或更新流程。
- 不包含个人 UI、经典主题或部署路径。

## 验证

- `git diff --check upstream/dev..HEAD`：通过。
- `uv run --no-sync ruff check module/config/utils.py --select E9,F63,F7,F82 --ignore F821,F722`：通过。

## 人工确认

建议在 Windows launcher / WebUI 环境执行一次配置读写和启动流程，确认不再出现 stdout 句柄异常，并确认不支持扩展名仍会写入日志。

## 回退

该 PR 只有一个独立提交，可直接 revert，不涉及配置迁移。

## Sourcery 摘要

防止配置 I/O 产生不安全的 stdout 副作用，同时保留现有的解析、序列化和写入行为。

错误修复：
- 移除配置文件读取和写入过程中直接输出到 stdout 的操作，以防在 stdout 句柄无效的 GUI 或启动器环境中出现运行时错误。
- 将不受支持的配置扩展名消息通过日志记录器输出，而不是输出到 stdout。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent configuration I/O from producing unsafe stdout side effects while preserving existing parsing, serialization, and write behavior.

Bug Fixes:
- Remove direct stdout output from configuration file reads and writes to prevent runtime errors in GUI or launcher environments with invalid stdout handles.
- Route unsupported configuration extension messages through the logger instead of stdout.

</details>

错误修复：
- 从配置文件的读写操作中移除对 stdout 的直接输出，以防止在 stdout 句柄无效的 GUI 或启动器环境中产生运行时错误。
- 通过日志记录器（logger）输出不受支持的配置扩展名提示，而不是直接写入 stdout。

<details>
<summary>Original summary in English</summary>



</details>