### PR TITLE
Fix: confirm Meowfficer LV.30 OCR result

### DIFF
--- a/module/meowfficer/enhance.py
+++ b/module/meowfficer/enhance.py
@@ -331,17 +331,57 @@ class MeowfficerEnhance(MeowfficerBase):
                 continue
 
     def _meow_get_level(self):
-        """
-        Returns:
-            int: level from 1 to 30. Returns 0 if cannot detect
+    """
+    Returns:
+        int: level from 1 to 30. Returns 0 if cannot detect
 
-        Pages:
-            in: MEOWFFICER_ENHANCE_ENTER
-        """
+    Pages:
+        in: MEOWFFICER_ENHANCE_ENTER
+    """
+    levels = []
+
+    # Wait for the selected Meowfficer information to refresh.
+    self.device.sleep(0.3)
+
+    for attempt in range(3):
+        # Use a fresh screenshot instead of the image captured while
+        # selecting the Meowfficer.
+        self.device.screenshot()
+
         level = OCR_MEOWFFICER_ENHANCE_LEVEL.ocr(self.device.image)
-        if level > 30:
+
+        if 1 <= level <= 30:
+            levels.append(level)
+        else:
             logger.warning(f'[指挥喵-强化] 无效的指挥喵等级: {level}')
-        return level
+
+        # Normal levels do not need additional confirmation.
+        # LV.30 and invalid OCR results are confirmed with fresh frames.
+        if attempt == 0 and 1 <= level < 30:
+            return level
+
+        if attempt < 2:
+            self.device.sleep(0.2)
+
+    # LV.30 may advance EnhanceIndex or disable MeowfficerTrain,
+    # so require three consistent OCR results.
+    if len(levels) == 3 and all(level == 30 for level in levels):
+        return 30
+
+    non_max_levels = [level for level in levels if level < 30]
+    if non_max_levels:
+        if 30 in levels:
+            logger.warning(
+                f'[指挥喵-强化] LV.30 OCR结果不一致: {levels}, '
+                '忽略本次满级判断'
+            )
+        return max(set(non_max_levels), key=non_max_levels.count)
+
+    logger.warning(
+        f'[指挥喵-强化] 无法确认指挥喵等级: {levels}, '
+        '本次不判定为满级'
+    )
+    return 0
 
     def _meow_enhance(self):
         """

--- a/module/meowfficer/enhance.py
+++ b/module/meowfficer/enhance.py
@@ -331,138 +331,58 @@ class MeowfficerEnhance(MeowfficerBase):
                 continue
 
     def _meow_get_level(self):
-    """
-    Returns:
-        int: level from 1 to 30. Returns 0 if cannot detect
-
-    Pages:
-        in: MEOWFFICER_ENHANCE_ENTER
-    """
-    levels = []
-
-    # Wait for the selected Meowfficer information to refresh.
-    self.device.sleep(0.3)
-
-    for attempt in range(3):
-        # Use a fresh screenshot instead of the image captured while
-        # selecting the Meowfficer.
-        self.device.screenshot()
-
-        level = OCR_MEOWFFICER_ENHANCE_LEVEL.ocr(self.device.image)
-
-        if 1 <= level <= 30:
-            levels.append(level)
-        else:
-            logger.warning(f'[指挥喵-强化] 无效的指挥喵等级: {level}')
-
-        # Normal levels do not need additional confirmation.
-        # LV.30 and invalid OCR results are confirmed with fresh frames.
-        if attempt == 0 and 1 <= level < 30:
-            return level
-
-        if attempt < 2:
-            self.device.sleep(0.2)
-
-    # LV.30 may advance EnhanceIndex or disable MeowfficerTrain,
-    # so require three consistent OCR results.
-    if len(levels) == 3 and all(level == 30 for level in levels):
-        return 30
-
-    non_max_levels = [level for level in levels if level < 30]
-    if non_max_levels:
-        if 30 in levels:
-            logger.warning(
-                f'[指挥喵-强化] LV.30 OCR结果不一致: {levels}, '
-                '忽略本次满级判断'
-            )
-        return max(set(non_max_levels), key=non_max_levels.count)
-
-    logger.warning(
-        f'[指挥喵-强化] 无法确认指挥喵等级: {levels}, '
-        '本次不判定为满级'
-    )
-    return 0
-
-    def _meow_enhance(self):
         """
-        Perform meowfficer enhancement operations
-        involving using extraneous meowfficers to
-        donate XP into a meowfficer target
-
         Returns:
-            str:
+            int: level from 1 to 30. Returns 0 if cannot detect
 
         Pages:
-            in: page_meowfficer
-            out: page_meowfficer
+            in: MEOWFFICER_ENHANCE_ENTER
         """
-        logger.hr('指挥喵强化', level=1)
-        logger.attr('强化索引', self.config.MeowfficerTrain_EnhanceIndex)
+        levels = []
 
-        # Base Cases
-        # - Config at least > 0 but less than or equal to 12
-        # - Coins at least > 1000
-        if not (1 <= self.config.MeowfficerTrain_EnhanceIndex <= 12):
-            logger.warning(f'[指挥喵-强化] 强化索引={self.config.MeowfficerTrain_EnhanceIndex} '
-                           f'is out of bounds. Please limit to 1~12, skip')
-            return 'invalid'
+        # Wait for the selected Meowfficer information to refresh.
+        self.device.sleep(0.3)
 
-        coins = MEOWFFICER_COINS.ocr(self.device.image)
-        if coins < 1000:
-            logger.info(f'[指挥喵-强化] 物资 ({coins}) < 1000, 物资不足无法完成 '
-                        f'enhancement, skip')
-            return 'coin_limit'
+        for attempt in range(3):
+            # Use a fresh screenshot instead of the image captured while
+            # selecting the Meowfficer.
+            self.device.screenshot()
 
-        for _ in range(2):
-            # Select target meowfficer
-            # for enhancement
-            self._meow_select()
+            level = OCR_MEOWFFICER_ENHANCE_LEVEL.ocr(self.device.image)
 
-            if self._meow_get_level() >= 30:
-                logger.info('[指挥喵-强化] 当前指挥喵已满级')
-                return 'leveled_max'
-
-            # Transition to MEOWFFICER_FEED after
-            # selection; broken up due to significant
-            # delayed behavior of meow_additional
-            if self.meow_enhance_enter():
-                break
+            if 1 <= level <= 30:
+                levels.append(level)
             else:
-                # Retreat from an existing battle
-                self.ui_goto_campaign()
-                self.ui_goto(page_meowfficer)
-                continue
+                logger.warning(f'[指挥喵-强化] 无效的指挥喵等级: {level}')
 
-        # Initiate feed sequence; loop until exhaust all
-        # - Select Feed
-        # - Confirm/Cancel Feed
-        # - Confirm Enhancement
-        # - Check remaining coins after enhancement
-        while 1:
-            logger.hr('强化一次', level=2)
-            if not self.meow_feed_enter():
-                # Exit back into page_meowfficer
-                self.ui_click(MEOWFFICER_GOTO_DORMMENU, check_button=MEOWFFICER_ENHANCE_ENTER,
-                              appear_button=MEOWFFICER_ENHANCE_CONFIRM, offset=None, skip_first_screenshot=True)
-                # Re-enter page_meowfficer
-                self.ui_goto_main()
-                self.ui_goto(page_meowfficer)
-                return 'in_battle'
-            if not self.meow_feed_select():
-                break
-            self.meow_enhance_confirm()
+            # Normal levels do not need additional confirmation.
+            # LV.30 and invalid OCR results are confirmed with fresh frames.
+            if attempt == 0 and 1 <= level < 30:
+                return level
 
-            coins = MEOWFFICER_COINS.ocr(self.device.image)
-            if coins < 1000:
-                logger.info(f'[指挥喵-强化] 剩余物资 ({coins}) < 1000, 物资不足以进行下次 '
-                            f'enhancement, skip')
-                break
+            if attempt < 2:
+                self.device.sleep(0.2)
 
-        # Exit back into page_meowfficer
-        self.ui_click(MEOWFFICER_GOTO_DORMMENU, check_button=MEOWFFICER_ENHANCE_ENTER,
-                      appear_button=MEOWFFICER_ENHANCE_CONFIRM, offset=None, skip_first_screenshot=True)
-        return 'success'
+        # LV.30 may advance EnhanceIndex or disable MeowfficerTrain,
+        # so require three consistent OCR results.
+        if len(levels) == 3 and all(level == 30 for level in levels):
+            return 30
 
+        non_max_levels = [level for level in levels if level < 30]
+        if non_max_levels:
+            if 30 in levels:
+                logger.warning(
+                    f'[指挥喵-强化] LV.30 OCR结果不一致: {levels}, '
+                    '忽略本次满级判断'
+                )
+            return max(set(non_max_levels), key=non_max_levels.count)
+
+        logger.warning(
+            f'[指挥喵-强化] 无法确认指挥喵等级: {levels}, '
+            '本次不判定为满级'
+        )
+        return 0
+        
     def meow_enhance(self):
         """
         A wrapper of _meow_enhance()


### PR DESCRIPTION
## Problem

`MeowfficerEnhance._meow_get_level()` currently reads the Meowfficer level from the existing screenshot only once.

The existing image may have been captured while selecting the target Meowfficer, before the level display has completely refreshed.

A single incorrect LV.30 OCR result is especially problematic because `_meow_enhance()` immediately treats `level >= 30` as `leveled_max`.

When `MeowfficerTrain_EnhanceIndex` is already 12, this may also disable Meowfficer training.

There is another edge case where OCR values greater than 30 are logged as invalid but are still returned, so they also satisfy `level >= 30`.

## Observed behavior

I observed the following results for the same enhance index:

- 02:57 - OCR level: 22
- 05:58 - OCR level: 22
- 09:07 - OCR level: 30
- Meowfficer training was immediately disabled after the LV.30 result

The log at the time of the issue was:

```text
[强化索引] 12
[OCR_MEOWFFICER_ENHANCE_LEVEL] 30
[指挥喵-强化] 当前指挥喵已满级
[指挥喵-强化] 第12只指挥喵达到30级，禁用指挥喵训练
[配置] 保存配置 ./config\alas.json, Meowfficer.MeowfficerTrain.Enable=False

## 由 Sourcery 提供的摘要

在应用“满级训练”决策之前，先验证 Meowfficer 等级识别结果。

Bug 修复：
- 防止短暂或无效的 Meowfficer OCR 识别结果错误地将 Meowfficer 标记为 30 级并禁用训练。

增强：
- 刷新已选中的 Meowfficer 视图，并在多张截图中确认 30 级结果，同时解决来自有效但未满级状态下的不一致识别结果。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在应用满级训练决策之前，验证 Meowfficer 等级读数。

错误修复：
- 防止瞬时或无效的 Meowfficer OCR 结果被错误地识别为 30 级并禁用训练。

改进：
- 刷新所选 Meowfficer 视图，并要求 OCR 结果保持一致后再确认 30 级，同时保留有效的较低等级读数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate Meowfficer level readings before applying max-level training decisions.

Bug Fixes:
- Prevent transient or invalid Meowfficer OCR results from incorrectly marking a Meowfficer as level 30 and disabling training.

Enhancements:
- Refresh the selected Meowfficer view and require consistent OCR results to confirm level 30 while preserving valid lower-level readings.

</details>

</details>