### PR TITLE
fix(os): 修复强制收集信标开关配置读取问题

### DIFF
--- a/module/os/tasks/hazard_leveling.py
+++ b/module/os/tasks/hazard_leveling.py
@@ -157,7 +157,7 @@ class OpsiHazard1Leveling(CoinTaskMixin, OSMap):
         if (
             self.config.is_task_enabled("OpsiAshBeacon")
             and not self._ash_fully_collected
-            and self.config.OpsiAshBeacon_EnsureFullyCollected
+            and self.config.cross_get("OpsiAshBeacon.OpsiAshBeacon.EnsureFullyCollected", True)
         ):
             logger.info("[大世界-侵蚀1练级] 余烬信标未收集满，暂时忽略行动力限制")
             self.config.OS_ACTION_POINT_PRESERVE = 0

--- a/module/os/tasks/meowfficer_farming.py
+++ b/module/os/tasks/meowfficer_farming.py
@@ -141,7 +141,7 @@ class OpsiMeowfficerFarming(MeowfficerTargetZoneMixin, CoinTaskMixin, OSMap):
 
         if self.config.is_task_enabled('OpsiAshBeacon') \
                 and not self._ash_fully_collected \
-                and self.config.OpsiAshBeacon_EnsureFullyCollected:
+                and self.config.cross_get("OpsiAshBeacon.OpsiAshBeacon.EnsureFullyCollected", True):
             logger.info('[大世界-耄耋相接] 余烬信标未收集满，暂时忽略行动力限制')
             self.config.OS_ACTION_POINT_PRESERVE = 0
         logger.attr('大世界行动力保留', self.config.OS_ACTION_POINT_PRESERVE)


### PR DESCRIPTION
fix #791

## Summary by Sourcery

Bug Fixes:
- 修复余烬信标强制收集配置读取错误，确保未收集满时能够正确忽略行动力限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复余烬信标强制收集配置读取错误，确保未收集满时能够正确忽略行动力限制。

</details>