### PR TITLE
fix(handler): 避免数据密钥弹窗被误判为低心情

### DIFF
--- a/module/handler/info_handler.py
+++ b/module/handler/info_handler.py
@@ -301,7 +301,7 @@ class InfoHandler(ModuleBase):
             return False
 
         if not self.appear(POPUP_CONFIRM, offset=self._popup_offset) \
-                and not self.appear(POPUP_CANCEL, offset=self._popup_offset, interval=2):
+                or not self.appear(POPUP_CANCEL, offset=self._popup_offset, interval=2):
             return False
 
         if self.appear(USE_DATA_KEY, offset=(20, 20)):
@@ -314,11 +314,14 @@ class InfoHandler(ModuleBase):
                 if self.appear(USE_DATA_KEY, offset=(20, 20), interval=5):
                     self.device.click(USE_DATA_KEY_NOTIFIED)
                     continue
+        else:
+            # 新版战斗准备界面可能使专用模板失配，但作战档案仍明确预期该弹窗。
+            logger.warning('[作战档案] 数据密钥专用模板未命中，按通用弹窗继续确认')
 
+        result = self.handle_popup_confirm('USE_DATA_KEY')
+        if result:
             self.config.USE_DATA_KEY = False  # 成功后重置，因为任务可能在恢复前被停止
-            return self.handle_popup_confirm('USE_DATA_KEY')
-
-        return False
+        return result
 
     def handle_vote_popup(self):
         """

--- a/module/handler/info_handler.py
+++ b/module/handler/info_handler.py
@@ -304,19 +304,16 @@ class InfoHandler(ModuleBase):
                 or not self.appear(POPUP_CANCEL, offset=self._popup_offset, interval=2):
             return False
 
-        if self.appear(USE_DATA_KEY, offset=(20, 20)):
-            # enable USE_DATA_KEY_NOTIFIED
-            for _ in self.loop():
-                enabled = self.image_color_count(
-                    USE_DATA_KEY_NOTIFIED, color=(140, 207, 66), threshold=180, count=10)
-                if enabled:
-                    break
-                if self.appear(USE_DATA_KEY, offset=(20, 20), interval=5):
-                    self.device.click(USE_DATA_KEY_NOTIFIED)
-                    continue
-        else:
+        if not self.appear(USE_DATA_KEY, offset=(20, 20)):
             # 新版战斗准备界面可能使专用模板失配，但作战档案仍明确预期该弹窗。
             logger.warning('[作战档案] 数据密钥专用模板未命中，按通用弹窗继续确认')
+
+        # “今天不再提示”复选框的位置和选中颜色不依赖弹窗内容模板。
+        enabled = self.image_color_count(
+            USE_DATA_KEY_NOTIFIED, color=(140, 207, 66), threshold=180, count=10)
+        if not enabled:
+            self.device.click(USE_DATA_KEY_NOTIFIED)
+            return True
 
         result = self.handle_popup_confirm('USE_DATA_KEY')
         if result:

--- a/tests/test_info_handler.py
+++ b/tests/test_info_handler.py
@@ -1,0 +1,59 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from module.handler.assets import POPUP_CANCEL, POPUP_CONFIRM, USE_DATA_KEY
+from module.handler.info_handler import InfoHandler
+
+
+class TestUseDataKeyPopup(unittest.TestCase):
+    def setUp(self):
+        self.handler = object.__new__(InfoHandler)
+        self.handler.config = SimpleNamespace(USE_DATA_KEY=True)
+        self.handler.handle_popup_confirm = Mock(return_value=True)
+
+    def test_confirm_when_content_template_is_missing(self):
+        """专用模板失配时，作战档案仍应优先确认预期的数据密钥弹窗。"""
+        self.handler.appear = Mock(side_effect=lambda button, **kwargs: {
+            POPUP_CONFIRM: True,
+            POPUP_CANCEL: True,
+            USE_DATA_KEY: False,
+        }.get(button, False))
+
+        result = InfoHandler.handle_use_data_key(self.handler)
+
+        self.assertTrue(result)
+        self.assertFalse(self.handler.config.USE_DATA_KEY)
+        self.handler.handle_popup_confirm.assert_called_once_with('USE_DATA_KEY')
+
+    def test_keep_state_when_generic_popup_is_incomplete(self):
+        """双按钮弹窗未完整出现时，不应提前清除数据密钥预期状态。"""
+        self.handler.appear = Mock(side_effect=lambda button, **kwargs: {
+            POPUP_CONFIRM: False,
+            POPUP_CANCEL: False,
+        }.get(button, False))
+
+        result = InfoHandler.handle_use_data_key(self.handler)
+
+        self.assertFalse(result)
+        self.assertTrue(self.handler.config.USE_DATA_KEY)
+        self.handler.handle_popup_confirm.assert_not_called()
+
+    def test_keep_state_when_confirmation_fails(self):
+        """点击确认未成功时，应保留状态供下一张截图重试。"""
+        self.handler.handle_popup_confirm.return_value = False
+        self.handler.appear = Mock(side_effect=lambda button, **kwargs: {
+            POPUP_CONFIRM: True,
+            POPUP_CANCEL: True,
+            USE_DATA_KEY: False,
+        }.get(button, False))
+
+        result = InfoHandler.handle_use_data_key(self.handler)
+
+        self.assertFalse(result)
+        self.assertTrue(self.handler.config.USE_DATA_KEY)
+        self.handler.handle_popup_confirm.assert_called_once_with('USE_DATA_KEY')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_info_handler.py
+++ b/tests/test_info_handler.py
@@ -2,7 +2,12 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock
 
-from module.handler.assets import POPUP_CANCEL, POPUP_CONFIRM, USE_DATA_KEY
+from module.handler.assets import (
+    POPUP_CANCEL,
+    POPUP_CONFIRM,
+    USE_DATA_KEY,
+    USE_DATA_KEY_NOTIFIED,
+)
 from module.handler.info_handler import InfoHandler
 
 
@@ -10,6 +15,8 @@ class TestUseDataKeyPopup(unittest.TestCase):
     def setUp(self):
         self.handler = object.__new__(InfoHandler)
         self.handler.config = SimpleNamespace(USE_DATA_KEY=True)
+        self.handler.device = Mock()
+        self.handler.image_color_count = Mock(return_value=True)
         self.handler.handle_popup_confirm = Mock(return_value=True)
 
     def test_confirm_when_content_template_is_missing(self):
@@ -37,6 +44,22 @@ class TestUseDataKeyPopup(unittest.TestCase):
 
         self.assertFalse(result)
         self.assertTrue(self.handler.config.USE_DATA_KEY)
+        self.handler.handle_popup_confirm.assert_not_called()
+
+    def test_enable_do_not_remind_when_content_template_is_missing(self):
+        """专用模板失配时，也应先勾选“今天不再提示”。"""
+        self.handler.image_color_count.return_value = False
+        self.handler.appear = Mock(side_effect=lambda button, **kwargs: {
+            POPUP_CONFIRM: True,
+            POPUP_CANCEL: True,
+            USE_DATA_KEY: False,
+        }.get(button, False))
+
+        result = InfoHandler.handle_use_data_key(self.handler)
+
+        self.assertTrue(result)
+        self.assertTrue(self.handler.config.USE_DATA_KEY)
+        self.handler.device.click.assert_called_once_with(USE_DATA_KEY_NOTIFIED)
         self.handler.handle_popup_confirm.assert_not_called()
 
     def test_keep_state_when_confirmation_fails(self):


### PR DESCRIPTION
## 问题说明

在 2026-08-27 战斗界面资源更新（`b64a97e43` / `b8955c4d7`）后的国服环境中，作战档案进入关卡时可能无法命中旧的 `USE_DATA_KEY` 弹窗内容模板。此时弹窗的通用“确认/取消”按钮仍能正常识别。

地图进入流程的处理顺序是：

1. `handle_use_data_key()`
2. `handle_combat_low_emotion()`

当前实现中，`handle_use_data_key()` 除了检测通用双按钮，还强制要求 `USE_DATA_KEY` 内容模板命中；模板失配时返回 `False`。随后低心情处理会调用通用的 `handle_popup_cancel('IGNORE_LOW_EMOTION')`，把同一个数据密钥弹窗当成红脸警告取消。即使仅增加通用确认回退，如果复选框逻辑仍依赖旧内容模板，“今天不再提示”也不会被勾选，之后每次进入关卡都会重复弹窗。

需要特别说明：日志中的 `POPUP_CANCEL_IGNORE_LOW_EMOTION` 只是调用方附加的按钮日志名称，并不表示程序识别到了低心情弹窗内容。

在 `calculate` 且非 `ignore` 模式下，这个误判会继续触发心情保底逻辑：

- 取消数据密钥弹窗；
- 将作战档案舰队心情从真实的 150 清零；
- 把 WarArchives 延迟到下一次服务器刷新；
- 本次作战档案无法开始。

## 复现条件

- 基于 `12c13865a`；
- 国服，1280×720；
- 作战档案有可用数据密钥；
- 心情控制为 `calculate`，未启用忽略红脸；
- 舰队记录心情为 150；
- 新界面中通用确认/取消按钮可命中，但 `USE_DATA_KEY` 内容模板无法命中。

关键失败日志：

```text
[情绪舰队_1] 150
点击 ... @ FLEET_PREPARATION
点击 ... @ POPUP_CANCEL_IGNORE_LOW_EMOTION
[心情-保底] 计算模式下出现红脸弹窗
保存配置 ... WarArchives.Emotion.Fleet1Value=0
延迟任务 WarArchives 到下一次服务器刷新
```

实际画面没有红脸舰船，150 也是真实心情值。

## 修改办法

本 PR 只收敛数据密钥处理，不改变真正低心情弹窗的现有保底行为：

- 要求通用确认、取消按钮完整出现后再处理；
- 当 `USE_DATA_KEY=True` 时，不再把专用内容模板作为确认数据密钥弹窗或处理复选框的硬前提；
- 无论专用内容模板是否命中，都根据固定位置和选中颜色处理“今天不再提示”：未选中时先点击并交还外层截图循环，下一帧确认选中后再确认弹窗；
- 专用模板失配时，按作战档案当前明确预期的通用双按钮弹窗继续确认；
- 仅在确认操作成功后清除 `USE_DATA_KEY` 状态，确认失败则保留状态供下一张截图重试。

## 验证

- 新增 4 个单元测试：
  - 专用内容模板失配时仍确认数据密钥弹窗；
  - 专用内容模板失配时仍先勾选“今天不再提示”；
  - 双按钮未完整出现时不处理、不清状态；
  - 确认失败时保留状态继续重试。
- Ruff 指定检查通过。
- 实机复测成功：心情 150 时正确确认数据密钥弹窗，随后进入 `BATTLE_0`，心情按正常战斗扣减为 148，没有被清零。
- 完整测试运行 303 项；本 PR 新增测试通过。现有 3 项失败已在未修改的 `12c13865a` 上原样复现，与本修改无关。

## Sourcery 总结

确保 data-key 弹窗能够可靠地完成确认，同时不会触发错误的低情绪处理。

错误修复：
- 当专用弹窗内容模板不可用时，避免将 data-key 弹窗误识别为低情绪警告。
- 当通用弹窗不完整或确认失败时，保留 data-key 处理状态。

增强：
- 将专用 data-key 模板视为可选的增强检测条件，同时要求通用弹窗的两个按钮均存在后才能确认。

测试：
- 增加对模板不匹配确认、不完整弹窗和确认失败场景的覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

确保在更新后的战斗界面中可靠地处理 data-key 弹窗，同时避免误触发低情绪恢复。

错误修复：
- 防止将内容模板不匹配的 data-key 弹窗误判为低情绪警告。
- 当弹窗不完整或确认失败时，保留 data-key 处理状态，以便重试。

改进：
- 处理 data-key 弹窗前，要求两个通用弹窗按钮均存在；将专用模板作为识别“不再提醒”控件的可选条件。

测试：
- 增加对缺少 data-key 模板、不完整弹窗、“不再提醒”处理以及确认失败场景的覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保能够可靠地确认 data-key 弹窗，同时避免触发错误的低情绪处理。

Bug 修复：
- 防止将内容模板不匹配的 data-key 弹窗误判为低情绪警告。
- 当通用弹窗不完整或确认失败时，保留 data-key 处理状态。

增强功能：
- 处理 data-key 弹窗前，要求通用弹窗的两个按钮均存在；同时将专用内容模板视为可选，并支持可靠地处理“今天不再提醒”。

测试：
- 增加对模板不匹配、不完整弹窗、复选框处理以及确认失败后重试的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure data-key popups are confirmed reliably without triggering incorrect low-emotion handling.

Bug Fixes:
- Prevent data-key popups with unmatched content templates from being mistaken for low-emotion warnings.
- Preserve data-key handling state when the generic popup is incomplete or confirmation fails.

Enhancements:
- Require both generic popup buttons before processing a data-key popup, while treating the specialized content template as optional and supporting reliable “do not remind today” handling.

Tests:
- Add coverage for template mismatches, incomplete popups, checkbox handling, and failed confirmation retries.

</details>

</details>

</details>