### PR TITLE
fix(campaign): 修复关卡ocr结果"144"导致不识别的问题

### DIFF
--- a/module/campaign/campaign_ocr.py
+++ b/module/campaign/campaign_ocr.py
@@ -78,8 +78,8 @@ class CampaignOcr(ModuleBase):
         result = re.sub(r'[0-9I]+-[0-9I]+', replace_func, result, count=1)
 
         # 将 '72' 转换为 '7-2'
-        if len(result) == 2 and result[0].isdigit():
-            result = '-'.join(result)
+        if len(result) in [2, 3] and result.isdigit():
+            result = result[:-1] + '-' + result[-1]
 
         result = result.lower()
         return result


### PR DESCRIPTION
Fix #830

## Sourcery 总结

错误修复：
- 通过在最后一位数字前插入阶段分隔符，正确识别两位和三位数的 OCR 结果，包括“144”。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correctly recognize two- and three-digit numeric OCR results, including "144", by inserting the stage separator before the final digit.

</details>