### PR TITLE
fix(alas): 修复日报线程冲突和初始化竞态

### DIFF
--- a/alas.py
+++ b/alas.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import inflection
 from cached_property import cached_property
 
+import module.config.server as server_config
 from module.base.decorator import del_cached_property
 from module.base.api_client import ApiClient
 from module.base.ssh import clear_ssh_host_key
@@ -101,9 +102,10 @@ class AzurLaneAutoScript:
         self._watchdog_thread = None
         self._watchdog_task_start = 0.0  # 当前任务开始时间（monotonic）
         self._watchdog_task_name = ''    # 当前任务名
-        # 日报服务按需初始化；其运行完全不依赖设备连接。
+        # 日报关闭时不创建线程同步原语、服务或数据库；所有对象均在启用后按需创建。
+        self._daily_summary_enabled = False
         self._daily_summary_service = None
-        self._daily_summary_stop = threading.Event()
+        self._daily_summary_stop = None
         self._daily_summary_thread = None
         self._daily_summary_settings_mtime = None
         self._daily_summary_settings = None
@@ -116,16 +118,60 @@ class AzurLaneAutoScript:
             self._daily_summary_service = DailySummaryService(self.config_name)
         return self._daily_summary_service
 
-    def _check_daily_summary(self):
+    @staticmethod
+    def _daily_summary_settings_from_config(config):
+        """从主线程已加载的配置创建日报专用只读快照。"""
+        return SimpleNamespace(
+            DailySummary_Enable=bool(
+                getattr(config, 'DailySummary_Enable', False)
+            ),
+            DailySummary_TriggerTime=getattr(
+                config, 'DailySummary_TriggerTime', '20:00'
+            ),
+            Emulator_PackageName=getattr(
+                config, 'Emulator_PackageName', 'auto'
+            ),
+            Emulator_ServerName=getattr(
+                config, 'Emulator_ServerName', 'disabled'
+            ),
+            Error_LlmApiKey=getattr(config, 'Error_LlmApiKey', ''),
+            Error_LlmApiBase=getattr(config, 'Error_LlmApiBase', ''),
+            Error_LlmModel=getattr(config, 'Error_LlmModel', ''),
+            Error_OnePushConfig=getattr(config, 'Error_OnePushConfig', ''),
+        )
+
+    @staticmethod
+    def _daily_summary_settings_from_data(data):
+        """仅从配置文件数据创建日报快照，不访问调度器配置对象。"""
+        alas = data.get('Alas') if isinstance(data, dict) else None
+        if not isinstance(alas, dict):
+            alas = {}
+
+        def read(group, key, default):
+            values = alas.get(group)
+            return values.get(key, default) if isinstance(values, dict) else default
+
+        return SimpleNamespace(
+            DailySummary_Enable=bool(read('DailySummary', 'Enable', False)),
+            DailySummary_TriggerTime=read('DailySummary', 'TriggerTime', '20:00'),
+            Emulator_PackageName=read('Emulator', 'PackageName', 'auto'),
+            Emulator_ServerName=read('Emulator', 'ServerName', 'disabled'),
+            Error_LlmApiKey=read('Error', 'LlmApiKey', ''),
+            Error_LlmApiBase=read('Error', 'LlmApiBase', ''),
+            Error_LlmModel=read('Error', 'LlmModel', ''),
+            Error_OnePushConfig=read('Error', 'OnePushConfig', ''),
+        )
+
+    def _check_daily_summary(self, config=None):
         """检查日报，不连接设备，也不影响调度器主流程。"""
         try:
-            config = self._get_daily_summary_settings()
+            if config is None:
+                config = self._get_daily_summary_settings()
             if not bool(getattr(config, 'DailySummary_Enable', False)):
                 return
-            # 自动包名仅在 Device 初始化后才会可靠地写入运行时服务器。
-            current_server = None
-            if 'device' in self.__dict__:
-                current_server = getattr(self.config, 'SERVER', None)
+            current_server = (
+                server_config.server if 'device' in self.__dict__ else None
+            )
             self._get_daily_summary_service().check_due(
                 config,
                 current_server=current_server,
@@ -140,7 +186,7 @@ class AzurLaneAutoScript:
             config_path = filepath_config(self.config_name)
             modified_at = os.stat(config_path).st_mtime_ns
         except OSError:
-            return self.config
+            return self._daily_summary_settings or self._daily_summary_settings_from_data({})
 
         if (
             self._daily_summary_settings is not None
@@ -148,89 +194,106 @@ class AzurLaneAutoScript:
         ):
             return self._daily_summary_settings
 
-        config = self.config
         try:
             with open(config_path, encoding='utf-8') as file:
                 data = json.load(file)
         except (OSError, json.JSONDecodeError):
-            logger.warning('[日报] 读取最新配置失败，继续使用当前配置')
-            return config
+            logger.warning('[日报] 读取最新配置失败，继续使用日报配置快照')
+            return self._daily_summary_settings or self._daily_summary_settings_from_data({})
 
-        alas = data.get('Alas') if isinstance(data, dict) else None
-        if not isinstance(alas, dict):
-            return config
-
-        def read(group, key, default):
-            values = alas.get(group)
-            return values.get(key, default) if isinstance(values, dict) else default
-
-        self._daily_summary_settings = SimpleNamespace(
-            DailySummary_Enable=read(
-                'DailySummary', 'Enable', getattr(config, 'DailySummary_Enable', False)
-            ),
-            DailySummary_TriggerTime=read(
-                'DailySummary', 'TriggerTime',
-                getattr(config, 'DailySummary_TriggerTime', '20:00'),
-            ),
-            Emulator_PackageName=read(
-                'Emulator', 'PackageName',
-                getattr(config, 'Emulator_PackageName', 'auto'),
-            ),
-            Emulator_ServerName=read(
-                'Emulator', 'ServerName',
-                getattr(config, 'Emulator_ServerName', 'disabled'),
-            ),
-            Error_LlmApiKey=read(
-                'Error', 'LlmApiKey', getattr(config, 'Error_LlmApiKey', '')
-            ),
-            Error_LlmApiBase=read(
-                'Error', 'LlmApiBase', getattr(config, 'Error_LlmApiBase', '')
-            ),
-            Error_LlmModel=read(
-                'Error', 'LlmModel', getattr(config, 'Error_LlmModel', '')
-            ),
-            Error_OnePushConfig=read(
-                'Error', 'OnePushConfig', getattr(config, 'Error_OnePushConfig', '')
-            ),
-        )
+        self._daily_summary_settings = self._daily_summary_settings_from_data(data)
         self._daily_summary_settings_mtime = modified_at
         return self._daily_summary_settings
 
     def _daily_summary_loop(self):
         """独立检查日报时间，避免长任务或服务器等待错过触发时刻。"""
-        while not self._daily_summary_stop.is_set():
-            self._check_daily_summary()
-            self._daily_summary_stop.wait(DAILY_SUMMARY_CHECK_INTERVAL)
+        stop_event = self._daily_summary_stop
+        if stop_event is None:
+            return
+        try:
+            while not stop_event.is_set():
+                config = self._get_daily_summary_settings()
+                if not bool(getattr(config, 'DailySummary_Enable', False)):
+                    self._daily_summary_enabled = False
+                    logger.info('[日报] 功能已关闭，停止独立定时检查')
+                    return
+                self._check_daily_summary(config)
+                stop_event.wait(DAILY_SUMMARY_CHECK_INTERVAL)
+        finally:
+            if self._daily_summary_thread is threading.current_thread():
+                self._daily_summary_stop = None
+                self._daily_summary_thread = None
 
-    def _start_daily_summary_scheduler(self):
+    def _start_daily_summary_scheduler(self, config=None):
         """启动不依赖游戏任务的日报定时检查线程。"""
+        # 只使用调用方已经持有的配置；绝不通过 self.config 触发懒加载。
+        if config is None or not bool(
+            getattr(config, 'DailySummary_Enable', False)
+        ):
+            return False
         if (
             self._daily_summary_thread is not None
             and self._daily_summary_thread.is_alive()
         ):
-            return
-        self._daily_summary_stop.clear()
-        self._daily_summary_thread = threading.Thread(
+            return True
+        settings = self._daily_summary_settings_from_config(config)
+        try:
+            settings_mtime = os.stat(
+                filepath_config(self.config_name)
+            ).st_mtime_ns
+        except OSError:
+            settings_mtime = None
+
+        # 在线程启动前由主线程完成服务初始化，避免定时线程和任务线程同时创建服务。
+        try:
+            self._get_daily_summary_service()
+        except Exception as error:
+            logger.warning(f'[日报] 初始化失败，未启动定时检查: {type(error).__name__}')
+            return False
+
+        stop_event = threading.Event()
+        thread = threading.Thread(
             target=self._daily_summary_loop,
             daemon=True,
             name=f'daily-summary-scheduler-{self.config_name}',
         )
-        self._daily_summary_thread.start()
+        self._daily_summary_settings = settings
+        self._daily_summary_settings_mtime = settings_mtime
+        self._daily_summary_stop = stop_event
+        self._daily_summary_thread = thread
+        self._daily_summary_enabled = True
+        try:
+            thread.start()
+        except Exception as error:
+            self._daily_summary_enabled = False
+            self._daily_summary_stop = None
+            self._daily_summary_thread = None
+            logger.warning(f'[日报] 定时检查启动失败: {type(error).__name__}')
+            return False
         logger.info('[日报] 独立定时检查已启动')
+        return True
 
     def _stop_daily_summary_scheduler(self):
         """停止日报定时检查线程。"""
-        self._daily_summary_stop.set()
-        if self._daily_summary_thread is not None:
-            self._daily_summary_thread.join(timeout=5)
-            self._daily_summary_thread = None
+        stop_event = self._daily_summary_stop
+        thread = self._daily_summary_thread
+        if stop_event is None and thread is None:
+            return False
+        if stop_event is not None:
+            stop_event.set()
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=5)
+        self._daily_summary_enabled = False
+        self._daily_summary_stop = None
+        self._daily_summary_thread = None
         logger.info('[日报] 独立定时检查已停止')
+        return True
 
     def _record_daily_summary_task_start(self, task: str):
         """为启用日报的实例记录任务开始，不向调度器传播存储错误。"""
+        if not self._daily_summary_enabled:
+            return None
         try:
-            if not bool(getattr(self.config, 'DailySummary_Enable', False)):
-                return None
             return self._get_daily_summary_service().store.record_task_start(
                 self.config_name, task, current_time()
             )
@@ -1760,9 +1823,10 @@ class AzurLaneAutoScript:
 
         from module.config.utils import is_oobe_needed
 
-        # 先加载配置，再启动不依赖设备和任务执行的日报时钟。
-        _ = self.config
-        self._start_daily_summary_scheduler()
+        # 调度器本身需要先加载配置；日报关闭时不创建任何附加线程或服务。
+        config = self.config
+        if config.DailySummary_Enable:
+            self._start_daily_summary_scheduler(config)
 
         # 启动看门狗：守护线程在任务执行期间监测日志心跳，若主线程长时间
         # 无日志输出（如卡死在 u2 HTTP 调用或 ADB shell 中），则强制杀死
@@ -1839,7 +1903,9 @@ class AzurLaneAutoScript:
                 self._watchdog_task_start = time.monotonic()
                 self._watchdog_task_name = task
                 task_started_at = current_time()
-                daily_summary_run_id = self._record_daily_summary_task_start(task)
+                daily_summary_run_id = None
+                if self._daily_summary_enabled:
+                    daily_summary_run_id = self._record_daily_summary_task_start(task)
                 success = None
                 try:
                     success = self.run(inflection.underscore(task))

--- a/tests/test_daily_summary_service.py
+++ b/tests/test_daily_summary_service.py
@@ -355,22 +355,24 @@ class TestDailySummaryService(unittest.TestCase):
         script = AzurLaneAutoScript.__new__(AzurLaneAutoScript)
         script.config_name = 'alpha'
         script.failure_record = {'Commission': 2}
-        script.__dict__['config'] = summary_config()
+        script._daily_summary_settings = summary_config()
+        script._daily_summary_settings_mtime = None
         service = Mock()
         script.__dict__['_daily_summary_service'] = service
 
         with patch('alas.current_time', return_value=datetime(2026, 8, 21, 20, 2)):
-            script._check_daily_summary()
+            script._check_daily_summary(script._daily_summary_settings)
             service.check_due.side_effect = RuntimeError('日报故障')
-            script._check_daily_summary()
+            script._check_daily_summary(script._daily_summary_settings)
 
         self.assertEqual(2, service.check_due.call_count)
+        self.assertIsNone(service.check_due.call_args.kwargs['current_server'])
         self.assertNotIn('device', script.__dict__)
+        self.assertNotIn('config', script.__dict__)
         self.assertEqual({'Commission': 2}, script.failure_record)
 
-        script.__dict__['config'] = summary_config(DailySummary_Enable=False)
         script.__dict__['_daily_summary_service'] = None
-        script._check_daily_summary()
+        script._check_daily_summary(summary_config(DailySummary_Enable=False))
         self.assertIsNone(script._daily_summary_service)
 
     def test_independent_daily_summary_loop_checks_without_task_completion(self):
@@ -378,26 +380,65 @@ class TestDailySummaryService(unittest.TestCase):
         script._daily_summary_stop = Mock()
         script._daily_summary_stop.is_set.side_effect = [False, True]
         script._daily_summary_stop.wait.return_value = False
+        script._daily_summary_thread = None
+        script._daily_summary_enabled = True
+        script._get_daily_summary_settings = Mock(return_value=summary_config())
         script._check_daily_summary = Mock()
 
         script._daily_summary_loop()
 
-        script._check_daily_summary.assert_called_once_with()
+        script._check_daily_summary.assert_called_once_with(
+            script._get_daily_summary_settings.return_value
+        )
         self.assertNotIn('device', script.__dict__)
 
     def test_independent_daily_summary_scheduler_starts_a_daemon_thread(self):
         script = AzurLaneAutoScript.__new__(AzurLaneAutoScript)
         script.config_name = 'alpha'
-        script._daily_summary_stop = Mock()
+        script._daily_summary_enabled = False
+        script._daily_summary_stop = None
         script._daily_summary_thread = None
+        script._daily_summary_settings_mtime = None
+        script._daily_summary_settings = None
+        script._get_daily_summary_service = Mock()
         with patch('alas.threading.Thread') as thread:
-            script._start_daily_summary_scheduler()
+            started = script._start_daily_summary_scheduler(summary_config())
 
+        self.assertTrue(started)
+        script._get_daily_summary_service.assert_called_once_with()
         thread.assert_called_once()
         self.assertIs(thread.call_args.kwargs['target'].__self__, script)
         self.assertEqual('_daily_summary_loop', thread.call_args.kwargs['target'].__name__)
         self.assertTrue(thread.call_args.kwargs['daemon'])
         thread.return_value.start.assert_called_once_with()
+
+    def test_disabled_daily_summary_creates_no_thread_service_or_config(self):
+        script = AzurLaneAutoScript.__new__(AzurLaneAutoScript)
+        script.config_name = 'alpha'
+        script._daily_summary_enabled = False
+        script._daily_summary_service = None
+        script._daily_summary_stop = None
+        script._daily_summary_thread = None
+        script._daily_summary_settings_mtime = None
+        script._daily_summary_settings = None
+        script._get_daily_summary_service = Mock()
+
+        with (
+            patch('alas.threading.Event') as event,
+            patch('alas.threading.Thread') as thread,
+        ):
+            started = script._start_daily_summary_scheduler(
+                summary_config(DailySummary_Enable=False)
+            )
+
+        self.assertFalse(started)
+        script._get_daily_summary_service.assert_not_called()
+        event.assert_not_called()
+        thread.assert_not_called()
+        self.assertIsNone(script._daily_summary_service)
+        self.assertIsNone(script._daily_summary_stop)
+        self.assertIsNone(script._daily_summary_settings)
+        self.assertNotIn('config', script.__dict__)
 
     def test_daily_scheduler_reads_latest_saved_settings_without_reloading_task_config(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -419,9 +460,8 @@ class TestDailySummaryService(unittest.TestCase):
             )
             script = AzurLaneAutoScript.__new__(AzurLaneAutoScript)
             script.config_name = 'alpha'
-            script.__dict__['config'] = summary_config(DailySummary_Enable=False)
             script._daily_summary_settings_mtime = None
-            script._daily_summary_settings = None
+            script._daily_summary_settings = summary_config()
             service = Mock()
             script.__dict__['_daily_summary_service'] = service
 
@@ -436,7 +476,7 @@ class TestDailySummaryService(unittest.TestCase):
         self.assertTrue(settings.DailySummary_Enable)
         self.assertEqual('00:10', settings.DailySummary_TriggerTime)
         self.assertEqual('cn_android-0', settings.Emulator_ServerName)
-        self.assertFalse(script.config.DailySummary_Enable)
+        self.assertNotIn('config', script.__dict__)
 
 
 class TestDailySummaryNotify(unittest.TestCase):


### PR DESCRIPTION
fix #842

## Sourcery 摘要

修复每日摘要调度竞态问题，并确保仅在功能启用时进行初始化。

错误修复：
- 通过确保安全地创建和管理配置、服务及同步状态，防止每日摘要线程冲突和初始化竞态。

改进：
- 通过配置快照和感知生命周期的线程管理，将每日摘要调度与任务调度器隔离。
- 避免从每日摘要工作线程加载调度器配置或设备状态，并在功能禁用时停止该工作线程。

测试：
- 扩展每日摘要测试，覆盖功能禁用行为、线程启动、配置隔离以及无设备检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix daily summary scheduling races and ensure the feature initializes only when enabled.

Bug Fixes:
- Prevent daily summary thread conflicts and initialization races by ensuring configuration, service, and synchronization state are created and managed safely.

Enhancements:
- Isolate daily summary scheduling from the task scheduler through configuration snapshots and lifecycle-aware thread management.
- Avoid loading scheduler configuration or device state from the daily summary worker, and stop the worker when the feature is disabled.

Tests:
- Expand daily summary tests to cover disabled-feature behavior, thread startup, configuration isolation, and device-free checks.

</details>