### PR TITLE
fix(tactical): 修复技能满级后未切换到下一个技能

### DIFF
--- a/module/tactical/tactical_class.py
+++ b/module/tactical/tactical_class.py
@@ -420,6 +420,19 @@ class RewardTacticalClass(Dock):
             if not self._tactical_books_get():
                 return False
 
+            # 满级技能不应再选择教材；配置过滤器包含 `first` 回退项时，
+            # 仅检查过滤结果会掩盖满级状态并直接重复开课。
+            if self.config.Tactical_SkillAutoSwitch \
+                    and self._is_current_skill_max(skip_first_screenshot=True):
+                if retry >= MAX_SWITCH_RETRIES:
+                    logger.warning('[战术-选择] 达到技能切换最大重试次数')
+                    break
+                logger.info('[战术-选择] 当前技能已满级，尝试切换到下一个技能')
+                if self._try_switch_to_next_skill():
+                    logger.info('[战术-选择] 已切换到下一个技能，重新进入教材选择')
+                    continue
+                break
+
             self.device.click_record_clear()
             # 确保第一本教材被选中
             # 对于较慢的电脑，选中状态可能已改变
@@ -434,21 +447,9 @@ class RewardTacticalClass(Dock):
             books = BOOK_FILTER.apply(self.books.grids)
             logger.attr('教材排序', ' > '.join([str(book) for book in books]))
 
-            # 如果有可用教材则选择，否则检测是否因为技能已满级
+            # 没有可用教材时取消本次课程。
             if not books:
-                # 无教材可选时，检测是否因为技能已满级（受 SkillAutoSwitch 配置控制）
-                if not self.config.Tactical_SkillAutoSwitch:
-                    break
-                if retry >= MAX_SWITCH_RETRIES:
-                    logger.warning('[战术-选择] 达到技能切换最大重试次数')
-                    break
-                if not self._is_current_skill_max(skip_first_screenshot=True):
-                    break
-                logger.info('[战术-选择] 没有教材因为技能已满级，尝试切换到下一个技能')
-                if not self._try_switch_to_next_skill():
-                    break
-                logger.info('[战术-选择] 已切换到下一个技能，重新进入教材选择')
-                continue
+                break
 
             book = books[0]
             if str(book) != 'first':

--- a/tests/test_tactical_skill_switch.py
+++ b/tests/test_tactical_skill_switch.py
@@ -1,0 +1,68 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from module.map.map_grids import SelectedGrids
+from module.tactical.tactical_class import RewardTacticalClass, SKILL_GRIDS
+
+
+class TestTacticalSkillAutoSwitch(unittest.TestCase):
+    @staticmethod
+    def _handler(max_states):
+        handler = object.__new__(RewardTacticalClass)
+        handler.config = SimpleNamespace(
+            Tactical_SkillAutoSwitch=True,
+            Tactical_TacticalFilter="first",
+        )
+        handler.device = Mock()
+        handler.books = SelectedGrids(
+            [
+                SimpleNamespace(
+                    same_str="unknown",
+                    genre_str="Red",
+                    tier_str="T1",
+                    exp_value=100,
+                )
+            ]
+        )
+        handler._tactical_books_get = Mock(return_value=True)
+        handler._tactical_book_select = Mock()
+        handler._tactical_books_filter_exp = Mock()
+        handler._is_current_skill_max = Mock(side_effect=max_states)
+        handler._try_switch_to_next_skill = Mock(return_value=True)
+        return handler
+
+    def test_switches_before_book_fallback_when_current_skill_is_max(self):
+        handler = self._handler([True, False])
+
+        self.assertTrue(handler._tactical_books_choose())
+
+        handler._try_switch_to_next_skill.assert_called_once_with()
+        handler.device.click.assert_called_once()
+
+    def test_keeps_book_selection_for_non_max_skill(self):
+        handler = self._handler([False])
+
+        self.assertTrue(handler._tactical_books_choose())
+
+        handler._try_switch_to_next_skill.assert_not_called()
+        self.assertEqual(handler._tactical_book_select.call_count, 2)
+        handler._tactical_book_select.assert_called_with(handler.books[0])
+
+    def test_finds_unmaxed_skill_after_maxed_skill(self):
+        handler = object.__new__(RewardTacticalClass)
+        handler.device = Mock(image=object())
+
+        with patch("module.tactical.tactical_class.ExpOnSkillSelect") as ocr:
+            ocr.return_value.ocr.return_value = [
+                "NEXT:MAX",
+                "NEXT:0/100",
+                "NEXT:MAX",
+            ]
+            selected = handler.find_not_full_level_skill()
+
+        self.assertIs(selected, SKILL_GRIDS.buttons[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明

- 修复默认教材过滤器包含 first 回退项时，满级技能被直接重复开课的问题。
- 在教材选择前先检测当前技能是否满级，开启自动切换后切换到同舰船的下一个未满级技能。
- 保留非满级技能原有教材选择逻辑。
- 新增战术学院技能切换回归测试。

## 验证

- uv run python -m unittest discover -s tests（402 tests OK）
- uv run ruff check module/tactical/tactical_class.py tests/test_tactical_skill_switch.py --select E9,F63,F7,F82 --ignore F821,F722
- uv run python -m py_compile module/tactical/tactical_class.py tests/test_tactical_skill_switch.py
- git diff --check

## Sourcery 摘要

通过在选择教材之前检测已达到上限的技能，并切换到下一个可用技能，防止重复开设战术技能课程。

Bug 修复：
- 当默认教材筛选器包含 `first` 回退选项时，防止已达到上限的战术技能再次被选入课程。
- 启用技能自动切换后，在选择教材之前，自动切换到同一艘飞船上下一项尚未达到上限的技能。

测试：
- 添加回归测试，涵盖从已达到上限的技能切换出去，以及为未达到上限的技能保留教材选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent duplicate tactical skill courses by detecting maxed skills before textbook selection and switching to the next available skill.

Bug Fixes:
- Prevent maxed tactical skills from being enrolled again when the default textbook filter includes the `first` fallback option.
- Automatically switch to the next unmaxed skill on the same ship before selecting textbooks when skill auto-switching is enabled.

Tests:
- Add regression coverage for switching away from maxed skills and preserving textbook selection for non-maxed skills.

</details>