### PR TITLE
fix(island): 修复角色确认卡死并放宽低端设备地图加载等待

### DIFF
--- a/module/island/island.py
+++ b/module/island/island.py
@@ -764,28 +764,55 @@ class Island(SelectCharacter):
         return False
 
     def confirm_selected_character(self, context="岗位派遣"):
-        """确认角色选择，并等待角色选择页切换到下一步。"""
-        if not self.click_selected_character_confirm(context=context):
-            return False
+        """确认角色选择，并等待角色选择页切换到下一步。
 
-        for _ in self.loop(timeout=8, skip_first=False):
+        采用“点击→复检→重试”的状态循环：每次点击后必须确认角色页真正关闭，
+        连续两次点击未生效时仍会继续重试确认按钮（最多 8 次），而不是停止
+        点击导致派遣流程卡死。角色页标题或确认按钮模板在点击后短暂识别不到时，
+        只要之前已确认过角色页仍在，也会按固定间隔继续尝试。
+        """
+        self.interval_clear([SELECT_UI_CONFIRM])
+        retry_timer = Timer(1.5).start()
+        confirm_clicks = 0
+        role_seen = False
+        for _ in self.loop(timeout=20, skip_first=False):
+            in_role_page = self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1)
+            confirm_visible = self.appear(SELECT_UI_CONFIRM)
+            role_seen = role_seen or in_role_page or confirm_visible
+
+            # 已进入已知的下一步：产品选择页
             if self.appear(ISLAND_SELECT_PRODUCT_CHECK, offset=1):
                 return True
+            # 角色页已关闭，且岗位详情/空缺卡已出现
             if (
-                    (self.appear(ISLAND_POST_CHECK, offset=1) or self.appear(ISLAND_POST_VACANT_CHECK, offset=1))
-                    and not self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1)
+                    (self.appear(ISLAND_POST_CHECK, offset=1)
+                     or self.appear(ISLAND_POST_VACANT_CHECK, offset=1))
+                    and not in_role_page
             ):
                 return True
+            # 整个确认流程中从未识别到角色选择页，说明无需确认或已离开
             if (
-                    self.ui_page_appear(page_island_postmanage)
-                    and not self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1)
+                    not role_seen
+                    and self.ui_page_appear(page_island_postmanage)
+                    and not self.is_post_detail_visible()
             ):
                 return True
-            if self.appear(ISLAND_SELECT_CHARACTER_CHECK, offset=1):
-                if self.appear_then_click(SELECT_UI_CONFIRM, interval=1):
-                    continue
 
-        logger.warning(f"[岛屿] {context}确认后未进入下一步")
+            # 未进入任何已知下一步，且曾经看到角色选择页：继续重试确认。
+            # 两次点击仍未生效后，即使按钮/标题模板短暂识别不到，
+            # 也按固定间隔继续点击同一确认区域，避免确认失败后无人再点击。
+            if not role_seen:
+                continue
+            if not retry_timer.reached():
+                continue
+            if in_role_page or confirm_visible or confirm_clicks >= 2:
+                self.device.click(SELECT_UI_CONFIRM)
+                confirm_clicks += 1
+                retry_timer.reset()
+                if confirm_clicks >= 8:
+                    break
+
+        logger.warning(f"[岛屿] {context}确认后未进入下一步（已重试点击 {confirm_clicks} 次）")
         return False
 
     def confirm_selected_character_closed(self, context="角色选择", timeout=8):

--- a/module/island/island.py
+++ b/module/island/island.py
@@ -19,6 +19,12 @@ from module.logger import logger
 import re
 
 ISLAND_MAP_CONFIRM_WAIT = 3
+# 低端设备从岛屿地图跳转目的地时，场景加载可能明显超过 20s，
+# 放宽进入目的地前的等待上限，避免加载稍慢即被误判为失败。
+ISLAND_MAP_DESTINATION_WAIT = 45
+# 目的地确认按钮只允许在点击后前 10s 内补点重试，
+# 防止地图一直停留在确认弹窗时反复点击同一按钮触发 GameTooManyClickError。
+ISLAND_MAP_CONFIRM_RETRY_WAIT = 10
 
 # 岗位产品选择滑动惯性消除安全区域
 SELECT_PRODUCT_INERTIA_STOP = Button(
@@ -464,11 +470,15 @@ class Island(SelectCharacter):
             return False
 
         confirm_wait = Timer(ISLAND_MAP_CONFIRM_WAIT).start()
-        for _ in self.loop(timeout=20, skip_first=False):
+        confirm_retry = Timer(ISLAND_MAP_CONFIRM_RETRY_WAIT).start()
+        for _ in self.loop(timeout=ISLAND_MAP_DESTINATION_WAIT, skip_first=False):
             if self.ui_additional(get_ship=False):
                 continue
 
-            if self.appear_then_click(ISLAND_MAP_CONFIRM, interval=2):
+            # 确认按钮通常会在场景加载开始后消失；若仍可见则在前 10s 内补点，
+            # 超时窗口后不再点击，避免确认弹窗卡住时触发单按钮点击过多保护。
+            if not confirm_retry.reached() and self.appear_then_click(
+                    ISLAND_MAP_CONFIRM, interval=2):
                 confirm_wait.reset()
                 continue
 


### PR DESCRIPTION
Resolves #858
Resolves #851 
### 修复 SELECT_UI_CONFIRM 卡死（282bcc329）
- 重构角色确认为“点击→复检→重试”状态循环，前两次未生效仍按固定间隔重试，最多 8 次
- 确认按钮或角色页标题模板短暂识别不到时不再提前停止
- 重试无进展时记录次数并回退岗位管理，避免 60 秒无操作被误判卡死

### 放宽低端设备地图加载等待（1eb1b7908）
- island_map_goto 目的地进入等待由 20s 放宽至 45s，避免地图加载慢导致珍珠采购/售卖与每日任务反复进图后跳过
- 确认按钮补点限制在前 10s，防止等待拉长后持续点击同一按钮触发 GameTooManyClickError

## Sourcery 总结

通过使角色确认流程可恢复，并适应较慢的地图加载速度，提高岛屿导航的可靠性。

错误修复：
- 通过验证页面转换，并在识别暂时不可靠时重试确认点击，防止岛屿角色确认流程卡住。
- 提高较慢设备上岛屿目的地加载的容错能力，并限制确认按钮的重试次数，以避免因点击过多而失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve island navigation reliability by making character confirmation recoverable and accommodating slower map loading.

Bug Fixes:
- Prevent island character-confirmation flows from getting stuck by validating page transitions and retrying confirmation clicks when recognition is temporarily unreliable.
- Increase island destination-loading tolerance on slower devices and limit confirmation-button retries to avoid excessive-click failures.

</details>