### PR TITLE
Fix camera coordinate divergence and grid calculation errors

### DIFF
--- a/module/map/camera.py
+++ b/module/map/camera.py
@@ -401,7 +401,25 @@ class Camera(MapOperation):
 
             if len(record) > 0:
                 # 即使两条边缘可见也要滑动，以避免一些尴尬的相机位置。
+                prev_homo = self.view.backend.homo_loca
                 self.map_swipe((x, y))
+                cur_homo = self.view.backend.homo_loca
+                if prev_homo is not None and cur_homo is not None:
+                    delta = np.subtract(cur_homo, prev_homo)
+                    base = self.view.swipe_base
+                    # 滑动后地图在对应轴上位移不足半格（地图小于视野或已到达边缘，
+                    # 游戏不再滚动），停止该轴滑动并撤销死推算的相机位移，
+                    # 避免相机坐标持续发散导致无限滑动
+                    if x != 0 and abs(delta[0]) < base[0] / 2:
+                        logger.info('[地图-摄像机] 地图横向已到达边缘，停止横向滑动')
+                        x_swipe = 0
+                        if not (self.view.left_edge or self.view.right_edge):
+                            self.camera = (self.camera[0] - x, self.camera[1])
+                    if y != 0 and abs(delta[1]) < base[1] / 2:
+                        logger.info('[地图-摄像机] 地图纵向已到达边缘，停止纵向滑动')
+                        y_swipe = 0
+                        if not (self.view.upper_edge or self.view.lower_edge):
+                            self.camera = (self.camera[0], self.camera[1] - y)
 
             record.append((x, y))
 

--- a/module/os/map.py
+++ b/module/os/map.py
@@ -1258,6 +1258,13 @@ class OSMap(OSFleet, Map, GlobeCamera, StorageHandler, StrategicSearchHandler):
             self.view.predict()
             self.view.show()
 
+            # 摄像机漂移（视野中找不到当前舰队，如全图扫描后相机停留在扫描位置）时，
+            # 回退换算会以摄像机中心当作舰队位置，可能点到错误的格子。
+            # 先换队重新对焦提高换算准确性；对焦失败也继续走回退换算：
+            # 点错后舰队移动会带动相机跟队解除漂移，未触发事件还有全图扫描兜底
+            if self.view.select(is_current_fleet=True).count == 0:
+                self._os_camera_recover_to_fleet()
+
             try:
                 grid = self.convert_radar_to_local(grid)
             except KeyError:


### PR DESCRIPTION
## Sourcery 总结

防止摄像机漂移导致无限边缘滑动和错误的地图网格计算。

错误修复：
- 防止地图滑动到边缘或不再产生有效移动时摄像机坐标发生偏移。
- 检测到摄像机漂移时，在转换雷达坐标之前重新将摄像机聚焦到当前舰队，从而提高网格定位的准确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent camera drift from causing endless edge swipes and incorrect map-grid calculations.

Bug Fixes:
- Prevent camera coordinates from diverging when map swipes reach an edge or no longer produce meaningful movement.
- Improve grid targeting accuracy by refocusing the camera on the current fleet before converting radar coordinates when camera drift is detected.

</details>