### PR TITLE
feat(webui): 新增启动器信任免密登录，其他浏览器仍需密码

### DIFF
--- a/module/webui/api.py
+++ b/module/webui/api.py
@@ -39,6 +39,14 @@ from module.webui.deploy_settings import (
     set_startup_run,
 )
 from module.webui.launcher import is_local_request, launcher_control
+from module.webui.launcher_trust import (
+    TOKEN_TTL_SECONDS,
+    check_secret,
+    enabled as launcher_trust_enabled,
+    issue_token,
+    validate_token,
+    webui_key,
+)
 from module.webui.lang import t
 
 
@@ -1506,6 +1514,104 @@ async def api_launcher_report(request):
     return JSONResponse(result)
 
 
+# 免密令牌只对回环开放，但仍对"试密钥"做简单限频，避免本机其它进程暴力探测。
+_LAUNCHER_SECRET_FAILURES: list[float] = []
+_LAUNCHER_SECRET_WINDOW = 300  # 秒
+_LAUNCHER_SECRET_MAX_FAILURES = 15
+
+
+def _launcher_secret_try_allowed() -> bool:
+    """最近窗口内错误尝试是否超过阈值。"""
+    now = time.time()
+    while _LAUNCHER_SECRET_FAILURES and now - _LAUNCHER_SECRET_FAILURES[0] > _LAUNCHER_SECRET_WINDOW:
+        _LAUNCHER_SECRET_FAILURES.pop(0)
+    return len(_LAUNCHER_SECRET_FAILURES) < _LAUNCHER_SECRET_MAX_FAILURES
+
+
+def _launcher_secret_failure() -> None:
+    _LAUNCHER_SECRET_FAILURES.append(time.time())
+
+
+async def api_launcher_trusted_login(request):
+    """POST /api/launcher/trusted-login — 启动器以信任密钥换取一次性免密令牌"""
+    if not is_local_request(request):
+        return JSONResponse(
+            {"success": False, "error": "免密通道只允许本机连接"},
+            status_code=403,
+        )
+    if not launcher_trust_enabled():
+        # 未由启动器（带信任密钥）拉起，或未配置 WebUI 密码，免密通道整体关闭。
+        return JSONResponse(
+            {"success": False, "error": "启动器免密通道未启用"},
+            status_code=403,
+        )
+    if not _launcher_secret_try_allowed():
+        return JSONResponse(
+            {"success": False, "error": "尝试次数过多，请稍后再试"},
+            status_code=429,
+        )
+
+    secret = request.headers.get("x-webui-launcher-secret")
+    if not check_secret(secret):
+        _launcher_secret_failure()
+        return JSONResponse(
+            {"success": False, "error": "信任密钥无效"},
+            status_code=403,
+        )
+
+    token = issue_token()
+    if token is None:
+        return JSONResponse(
+            {"success": False, "error": "免密令牌签发失败"},
+            status_code=403,
+        )
+    return JSONResponse(
+        {"success": True, "token": token, "ttl": TOKEN_TTL_SECONDS}
+    )
+
+
+async def launcher_login(request):
+    """GET /launcher-login?token= — 校验令牌后预置本机窗口的登录状态。
+
+    返回与 WebUI 同源的种子页，把当前有效密码写入 localStorage["password"] 并跳回
+    首页；下次会话 login() 命中，无需再输密码。非回环/令牌无效一律拒绝。
+    """
+    if not is_local_request(request):
+        return _launcher_login_denied()
+    token = request.query_params.get("token")
+    if not validate_token(token):
+        return _launcher_login_denied()
+
+    key = webui_key()
+    if not key:
+        # 未配置密码时本就不需要登录，直接回首页。
+        return HTMLResponse(
+            '<!doctype html><script>location.replace("/");</script>',
+            status_code=200,
+        )
+
+    # json.dumps 生成合法 JS 字符串字面量，安全内嵌任意密码。
+    password_literal = json.dumps(str(key))
+    html = (
+        "<!doctype html><html lang=\"zh-CN\"><meta charset=\"utf-8\">"
+        "<title>AzurPilot 免密登录</title>"
+        "<script>"
+        "localStorage.setItem('password', " + password_literal + ");"
+        "location.replace('/');"
+        "</script>"
+        "<body>正在免密登录，请稍候…</body></html>"
+    )
+    return HTMLResponse(html, status_code=200)
+
+
+def _launcher_login_denied():
+    return HTMLResponse(
+        "<!doctype html><html lang=\"zh-CN\"><meta charset=\"utf-8\">"
+        "<title>拒绝访问</title><body>该链接无效或已过期，请从启动器重新打开。</body></html>",
+        status_code=403,
+    )
+
+
 async def api_deploy_settings(request):
     """GET /api/deploy/settings — 查询 deploy.yaml 可视化配置。"""
     if not is_local_request(request):
@@ -1685,6 +1791,8 @@ api_routes = [
     Route("/api/launcher/startup", api_launcher_startup, methods=["POST"]),
     Route("/api/launcher/stream", api_launcher_stream),
     Route("/api/launcher/report", api_launcher_report, methods=["POST"]),
+    Route("/api/launcher/trusted-login", api_launcher_trusted_login, methods=["POST"]),
+    Route("/launcher-login", launcher_login, methods=["GET"]),
     Route("/api/deploy/settings", api_deploy_settings),
     Route("/api/deploy/settings", api_deploy_settings_save, methods=["POST"]),
     Route("/api/deploy/startup-run", api_deploy_startup_run),

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -7,6 +7,8 @@
 该模块是 WebUI 的顶层入口，被 gui.py 启动时引用。
 """
 
+import os
+
 from hashlib import sha256
 from pathlib import Path
 
@@ -265,6 +267,14 @@ def app():
     lang.LANG = State.deploy_config.Language
     key = args.key if is_webui_password_set(args.key) else State.deploy_config.Password
     key, password_error = ensure_public_webui_password(key)
+    # 由 alas-launcher 以信任密钥拉起时登记免密通道，否则整体关闭。
+    from module.webui.launcher_trust import (
+        TRUST_SECRET_ENV,
+        configure as configure_launcher_trust,
+        enabled as launcher_trust_enabled,
+    )
+
+    configure_launcher_trust(os.environ.get(TRUST_SECRET_ENV), key)
     cdn: str | bool = args.cdn if args.cdn else State.deploy_config.CDN
     runs: List[str] | None = None
     if args.run:
@@ -280,6 +290,7 @@ def app():
     logger.attr("主题", State.deploy_config.Theme)
     logger.attr("语言", lang.LANG)
     logger.attr("密码", is_webui_password_set(key))
+    logger.attr("启动器免密", launcher_trust_enabled())
     logger.attr("CDN", cdn)
     logger.attr("云手机", IS_ON_PHONE_CLOUD)
 

--- a/module/webui/launcher_trust.py
+++ b/module/webui/launcher_trust.py
@@ -1,0 +1,106 @@
+"""启动器信任免密登录的进程内状态与令牌逻辑。
+
+WebUI 若由 alas-launcher 以环境变量 ``ALAS_WEBUI_TRUST_SECRET`` 拉起，
+则对携带匹配密钥的回环请求签发短时令牌，允许其在本机窗口预置
+``localStorage["password"]`` 实现免密进入；其他浏览器不受影响。
+
+信任密钥与用户 WebUI 密码（--key / deploy.yaml Password）解耦：之后修改
+WebUI 密码或由 WebUI 自动生成密码，启动器依旧免密。手动 ``gui.py`` 启动时
+该环境变量缺省，免密通道整体关闭，维持原有登录行为。
+
+本模块只依赖标准库，便于独立单元测试。
+"""
+
+import secrets
+import threading
+import time
+
+#: 启动器注入信任密钥的环境变量名（与 alas-launcher 保持一致）
+TRUST_SECRET_ENV = "ALAS_WEBUI_TRUST_SECRET"
+#: 免密令牌有效期（秒），短时一次性
+TOKEN_TTL_SECONDS = 60
+
+_lock = threading.Lock()
+_secret: str | None = None       #: 启动器信任密钥，None 表示未启用
+_webui_key: str | None = None    #: 当前 WebUI 有效密码
+_tokens: dict[str, float] = {}   #: token -> 过期时间戳
+
+
+def configure(secret, webui_key):
+    """WebUI 工厂启动时调用一次，登记信任密钥与当前有效 WebUI 密码。
+
+    Args:
+        secret: 启动器信任密钥，None/空表示未由启动器拉起。
+        webui_key: 当前生效的 WebUI 密码（可能为 None）。
+    """
+    global _secret, _webui_key
+    with _lock:
+        normalized = str(secret or "").strip() or None
+        _secret = normalized
+        _webui_key = str(webui_key) if webui_key is not None else None
+        # 重新配置时清空残留令牌，避免跨配置重放。
+        _tokens.clear()
+
+
+def _enabled_locked() -> bool:
+    """已持有 ``_lock`` 时的免密可用性判定，供各函数内部复用。
+
+    单独抽出以便 ``enabled()`` 与 ``issue_token()`` 共享同一判定，避免
+    在已持锁时再次获取非重入锁导致死锁。
+    """
+    if not _secret:
+        return False
+    return bool(_webui_key is not None and str(_webui_key).strip())
+
+
+def enabled() -> bool:
+    """免密通道是否可用：既由启动器拉起，又确实配置了 WebUI 密码。"""
+    with _lock:
+        return _enabled_locked()
+
+
+def check_secret(candidate) -> bool:
+    """常数时间比较候选密钥是否与信任密钥一致。"""
+    if candidate is None:
+        return False
+    with _lock:
+        secret = _secret
+    if not secret:
+        return False
+    return secrets.compare_digest(str(candidate), secret)
+
+
+def issue_token():
+    """签发一次性免密令牌，未启用时返回 None。"""
+    with _lock:
+        if not _enabled_locked():
+            return None
+        token = secrets.token_urlsafe(24)
+        _tokens[token] = time.time() + TOKEN_TTL_SECONDS
+        return token
+
+
+def validate_token(token) -> bool:
+    """校验令牌是否存在且未过期，过期令牌会被清理。"""
+    if not token:
+        return False
+    now = time.time()
+    with _lock:
+        expire = _tokens.get(token)
+        if expire is None:
+            return False
+        if now > expire:
+            _tokens.pop(token, None)
+            return False
+    return True
+
+
+def webui_key():
+    """返回当前有效 WebUI 密码，供种子页写入 localStorage。"""
+    with _lock:
+        return _webui_key
+
+
+def _reset():
+    """清空全部状态，仅用于单元测试。"""
+    configure(None, None)

--- a/tests/test_launcher_trust.py
+++ b/tests/test_launcher_trust.py
@@ -1,0 +1,80 @@
+"""launcher_trust（启动器信任免密登录）纯逻辑单元测试。"""
+
+import unittest
+
+from module.webui import launcher_trust
+
+
+class TestLauncherTrust(unittest.TestCase):
+    def setUp(self):
+        launcher_trust._reset()
+
+    def tearDown(self):
+        launcher_trust._reset()
+
+    def test_default_disabled(self):
+        self.assertFalse(launcher_trust.enabled())
+        self.assertIsNone(launcher_trust.issue_token())
+        self.assertFalse(launcher_trust.validate_token("anything"))
+        self.assertFalse(launcher_trust.check_secret("anything"))
+
+    def test_enabled_only_when_secret_and_key(self):
+        launcher_trust.configure("secret", "key")
+        self.assertTrue(launcher_trust.enabled())
+        self.assertEqual(launcher_trust.webui_key(), "key")
+
+        launcher_trust.configure("secret", None)
+        self.assertFalse(launcher_trust.enabled())
+
+        launcher_trust.configure(None, "key")
+        self.assertFalse(launcher_trust.enabled())
+
+        launcher_trust.configure("secret", "   ")
+        self.assertFalse(launcher_trust.enabled())
+
+    def test_check_secret(self):
+        launcher_trust.configure("s3cret", "key")
+        self.assertTrue(launcher_trust.check_secret("s3cret"))
+        self.assertFalse(launcher_trust.check_secret("wrong"))
+        self.assertFalse(launcher_trust.check_secret(None))
+        # 未配置时任何候选都不匹配
+        launcher_trust.configure(None, None)
+        self.assertFalse(launcher_trust.check_secret("s3cret"))
+
+    def test_token_issue_and_validate(self):
+        launcher_trust.configure("s3cret", "key")
+        token = launcher_trust.issue_token()
+        self.assertIsInstance(token, str)
+        self.assertTrue(token)
+        self.assertTrue(launcher_trust.validate_token(token))
+
+        # 错误令牌 / 空令牌一律无效
+        self.assertFalse(launcher_trust.validate_token("forged"))
+        self.assertFalse(launcher_trust.validate_token(""))
+        self.assertFalse(launcher_trust.validate_token(None))
+
+    def test_token_expired(self):
+        launcher_trust.configure("s3cret", "key")
+        token = launcher_trust.issue_token()
+        self.assertTrue(launcher_trust.validate_token(token))
+
+        # 直接让令牌过期，验证会被拒绝并清理
+        launcher_trust._tokens[token] = 0.0
+        self.assertFalse(launcher_trust.validate_token(token))
+        self.assertNotIn(token, launcher_trust._tokens)
+
+    def test_reconfigure_invalidates_old_tokens(self):
+        launcher_trust.configure("s3cret-a", "key")
+        token = launcher_trust.issue_token()
+        self.assertTrue(launcher_trust.validate_token(token))
+
+        launcher_trust.configure("s3cret-b", "key")
+        self.assertFalse(launcher_trust.validate_token(token))
+
+    def test_issue_token_disabled(self):
+        launcher_trust.configure(None, "key")
+        self.assertIsNone(launcher_trust.issue_token())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
启动器每次运行生成随机信任密钥并经环境变量注入 gui.py，WebUI 据此对本机
启动器窗口签发 60s 一次性令牌，窗口经 /launcher-login 预置登录态实现免密；
其它浏览器及手动启动的 WebUI 不受影响，登录门禁维持现状。

## Sourcery 摘要

新增仅限启动器使用的可信登录流程，可在不改变其他位置登录要求的情况下，预先验证本地 WebUI 窗口的身份。

新功能：
- 启用启动器获取短期一次性令牌，以便在其本地 WebUI 窗口中免密码登录。

增强功能：
- 将可信登录限制为仅处理回环请求，并对无效密钥尝试进行速率限制，同时保留其他浏览器和手动启动的 WebUI 实例的密码登录方式。
- 当 WebUI 信任配置发生变化时，使可信登录状态和之前签发的令牌失效。

测试：
- 添加单元测试，覆盖信任通道启用、密钥验证、令牌签发、过期和失效等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a launcher-only trusted login flow that pre-authenticates the local WebUI window without changing login requirements elsewhere.

New Features:
- Enable the launcher to obtain a short-lived one-time token for passwordless login in its local WebUI window.

Enhancements:
- Restrict trusted login to loopback requests and rate-limit invalid secret attempts while preserving password login for other browsers and manually started WebUI instances.
- Invalidate trusted-login state and previously issued tokens when the WebUI trust configuration changes.

Tests:
- Add unit tests covering trust-channel enablement, secret validation, token issuance, expiry, and invalidation.

</details>