### PR TITLE
feat(event): d3三战撤退

### DIFF
--- a/campaign/event_20260908_cn/d3_3.py
+++ b/campaign/event_20260908_cn/d3_3.py
@@ -1,0 +1,59 @@
+"""幽影迷城 D3：仅清除三个塞壬后撤退。"""
+
+from module.logger import logger
+
+from .d3 import Campaign as CampaignBase
+from .d3 import Config as ConfigBase
+
+
+class Config(ConfigBase):
+    # 自动搜索会绕过自定义战斗策略，无法保证只打塞壬和三战撤退。
+    Campaign_UseAutoSearch = False
+
+
+class Campaign(CampaignBase):
+    # 复用 D3 的完整刷新表：开局两个塞壬，第二战后再刷新一个。
+    # 不截断第三战后的普通敌人刷新，否则战斗结算会错误地跳过搜索动画。
+
+    def battle_function(self):
+        """按实时位置清除塞壬，避免全清模式或默认策略攻击普通敌人。
+
+        Pages: in: 地图, out: 地图或关卡选择页。
+
+        Returns:
+            bool: 是否完成了一场战斗；撤退由 CampaignEnd 结束本轮出击。
+        """
+        # 战后敌人移动可能抛出 MapEnemyMoved，下一轮仍必须先检查撤退。
+        if self.battle_count >= 3:
+            logger.info('[D3三战撤退] 已完成三场战斗，撤退')
+            self.withdraw()
+
+        if self.siren_count != self.battle_count:
+            logger.warning('[D3三战撤退] 战斗计数与塞壬计数不一致，撤退')
+            self.withdraw()
+
+        battle_count = self.battle_count
+        # 使用识别和移动追踪后的目标，不假定第三个塞壬的刷新坐标。
+        self.clear_siren()
+        if self.battle_count == battle_count:
+            logger.info('[D3三战撤退] 未完成塞壬战斗，重新扫描刷新目标')
+            self.full_scan(must_scan=self.map.camera_data)
+            self.find_path_initial()
+            self.clear_siren()
+
+        if self.battle_count >= 3:
+            logger.info('[D3三战撤退] 第三场战斗结束，立即撤退')
+            self.withdraw()
+
+        if self.battle_count > battle_count:
+            return True
+
+        # 刷新目标仍未识别或不可达时结束本轮，不用普通敌人凑三战。
+        logger.warning('[D3三战撤退] 未找到可攻击的塞壬，撤退')
+        self.withdraw()
+        return False
+
+    @property
+    def _map_battle(self):
+        """按三场战斗计算出击前的心情消耗。"""
+        return 3

--- a/module/campaign/run.py
+++ b/module/campaign/run.py
@@ -212,8 +212,8 @@ class CampaignRun(CampaignEvent, ShopStatus):
             str, str: (name, folder)。
         """
         name = to_map_file_name(name)
-        # 处理 event_20251218_cn d3-3 特殊情况
-        if folder == 'event_20251218_cn':
+        # 支持已适配活动的 D3 三战撤退入口
+        if folder in ['event_20251218_cn', 'event_20260908_cn']:
             # 将 d3-3 转换为 d3_3 以使用三战撤退逻辑
             if name == 'd3-3':
                 name = 'd3_3'

--- a/tests/test_event_20260908_d3_retreat.py
+++ b/tests/test_event_20260908_d3_retreat.py
@@ -1,0 +1,159 @@
+"""验证幽影迷城 D3 的分批刷新、目标选择和三战撤退。"""
+
+import copy
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from campaign.event_20260908_cn.d3 import MAP
+from campaign.event_20260908_cn.d3_3 import Campaign, Config
+from module.campaign.run import CampaignRun
+from module.exception import CampaignEnd, MapEnemyMoved
+from module.map.utils import location_ensure
+
+
+class TestD3SirenRetreat(unittest.TestCase):
+    def setUp(self):
+        """复用真实地图和选敌逻辑，仅替换设备交互。"""
+        self.campaign = object.__new__(Campaign)
+        self.campaign.config = Config()
+        self.campaign.config.FLEET_2 = False
+        self.campaign.config.MAP_HAS_FORTRESS = False
+        self.campaign.config.Error_HandleError = True
+        self.campaign.map = copy.deepcopy(MAP)
+        self.campaign.map.reset()
+        self.campaign.map.load_map_data()
+        self.campaign.map.load_spawn_data()
+        self.campaign.map.grid_connection_initial()
+        self.campaign.battle_count = 0
+        self.campaign.siren_count = 0
+        self.location = self.grid('D5').location
+        self.targets = []
+        self.campaign.withdraw = Mock(side_effect=CampaignEnd)
+        self.campaign.full_scan = Mock()
+        self.campaign.find_path_initial = Mock(side_effect=self.update_paths)
+        self.campaign.clear_chosen_enemy = Mock(side_effect=self.finish_combat)
+        self.campaign.battle_default = Mock(side_effect=AssertionError('不应攻击普通敌人'))
+
+    def grid(self, node):
+        return self.campaign.map[location_ensure(node)]
+
+    def update_paths(self):
+        """刷新后使用真实寻路计算可达性。"""
+        self.campaign.map.find_path_initial(self.location, has_ambush=False)
+
+    def spawn_siren(self, node):
+        self.grid(node).is_siren = True
+        self.update_paths()
+
+    def finish_combat(self, grid, expected):
+        """模拟一次已识别目标的战斗结算，不自动创造后续塞壬。"""
+        self.assertTrue(grid.is_siren)
+        self.assertEqual(expected, 'siren')
+        self.targets.append(grid.location)
+        self.location = grid.location
+        grid.wipe_out()
+        self.campaign.battle_count += 1
+        self.campaign.siren_count += 1
+        self.update_paths()
+        return True
+
+    def test_delayed_spawn_can_reuse_a_cleared_grid(self):
+        self.spawn_siren('D2')
+        self.spawn_siren('F2')
+        self.grid('E7').is_enemy = True
+        self.update_paths()
+        self.assertTrue(self.campaign.execute_a_battle())
+        self.assertTrue(self.campaign.execute_a_battle())
+        self.campaign.withdraw.assert_not_called()
+
+        # 第三只尚未被扫描到；验证刷新统计仍要求补齐它。
+        _, missing = self.campaign.map.missing_get(battle_count=2, siren_count=2)
+        self.assertEqual(missing['siren'], 1)
+        first_target = self.targets[0]
+        self.campaign.full_scan.side_effect = lambda **kwargs: self.spawn_siren(first_target)
+        with self.assertRaises(CampaignEnd):
+            self.campaign.execute_a_battle()
+
+        self.assertEqual(self.targets, [first_target, self.targets[1], first_target])
+        self.assertEqual(self.campaign.siren_count, 3)
+        self.campaign.full_scan.assert_called_once_with(must_scan=self.campaign.map.camera_data)
+        self.assertTrue(self.grid('E7').is_enemy)
+
+    def test_moved_siren_uses_current_position(self):
+        # 移动后的塞壬可能离开 MS 刷新格。
+        self.spawn_siren('E4')
+        self.assertTrue(self.campaign.execute_a_battle())
+        self.assertEqual(self.targets, [self.grid('E4').location])
+
+    def test_missing_or_blocked_siren_withdraws_without_normal_combat(self):
+        for blocked in (False, True):
+            with self.subTest(blocked=blocked):
+                self.setUp()
+                self.grid('E7').is_enemy = True
+                if blocked:
+                    self.spawn_siren('E3')
+                    for node in ('D3', 'F3', 'E2', 'E4'):
+                        self.grid(node).is_enemy = True
+                self.update_paths()
+                with self.assertRaises(CampaignEnd):
+                    self.campaign.execute_a_battle()
+                self.assertEqual(self.targets, [])
+                self.campaign.full_scan.assert_called_once()
+
+    def test_stale_target_without_combat_does_not_count_as_a_battle(self):
+        self.spawn_siren('E3')
+        self.campaign.clear_chosen_enemy.side_effect = None
+        self.campaign.clear_chosen_enemy.return_value = True
+        with self.assertRaises(CampaignEnd):
+            self.campaign.execute_a_battle()
+        self.assertEqual(self.campaign.battle_count, 0)
+        self.campaign.full_scan.assert_called_once()
+
+    def test_movement_exception_after_third_battle_cannot_start_fourth(self):
+        self.campaign.battle_count = self.campaign.siren_count = 2
+        self.spawn_siren('E3')
+
+        def finish_with_movement(grid, expected):
+            self.finish_combat(grid, expected)
+            raise MapEnemyMoved
+
+        self.campaign.clear_chosen_enemy.side_effect = finish_with_movement
+        self.assertTrue(self.campaign.execute_a_battle())
+        with self.assertRaises(CampaignEnd):
+            self.campaign.execute_a_battle()
+        self.assertEqual(self.campaign.battle_count, 3)
+        self.campaign.clear_chosen_enemy.assert_called_once()
+
+    def test_clear_all_and_poor_map_modes_still_use_siren_strategy(self):
+        self.campaign.config.MAP_CLEAR_ALL_THIS_TIME = True
+        self.campaign.config.POOR_MAP_DATA = True
+        self.spawn_siren('E3')
+        self.assertTrue(self.campaign.execute_a_battle())
+        self.assertEqual(self.campaign.siren_count, 1)
+
+    def test_unexpected_normal_combat_stops_the_run(self):
+        self.campaign.battle_count = 1
+        with self.assertRaises(CampaignEnd):
+            self.campaign.execute_a_battle()
+        self.campaign.clear_chosen_enemy.assert_not_called()
+
+    def test_all_three_battles_preserve_enemy_searching_settlement(self):
+        for battle_count in range(3):
+            with self.subTest(battle_count=battle_count):
+                self.campaign.battle_count = battle_count
+                self.assertEqual(self.campaign._expected_end('combat_siren'), 'with_searching')
+        self.assertEqual(self.campaign._map_battle, 3)
+        self.assertFalse(self.campaign.config.Campaign_UseAutoSearch)
+
+    def test_stage_alias_preserves_standard_d3(self):
+        runner = object.__new__(CampaignRun)
+        runner.config = SimpleNamespace(task=SimpleNamespace(command='Event'), STAGE_LOOP_ALIAS={})
+        for folder in ('event_20260908_cn', 'event_20251218_cn'):
+            for name, expected in (('D3-3', 'd3_3'), ('d3_3', 'd3_3'), ('d3', 'd3')):
+                with self.subTest(folder=folder, name=name):
+                    self.assertEqual(runner.handle_stage_name(name, folder), (expected, folder))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Sourcery 摘要

支持在本次活动的 D3-3 关卡中可靠地清理三场塞壬战斗并撤退。

新功能：
- 为 20260908 CN 活动添加 D3-3 战役模式，仅以塞壬为目标，并在完成三场战斗后撤退。

错误修复：
- 防止普通敌人、延迟出现或移动后的塞壬、过期目标以及第三场战斗后的移动导致意外战斗或第四场战斗。

增强功能：
- 扩展关卡别名处理，使新活动的 D3-3 入口使用专用的三战撤退逻辑，同时保留标准 D3 行为。

测试：
- 增加对塞壬生成、移动、目标选择、撤退条件、战斗保护机制、结算行为和关卡别名的覆盖测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support reliable three-battle Siren clearing and retreat for the event’s D3-3 stage.

New Features:
- Add a D3-3 campaign mode that targets only Sirens and retreats after three battles for the 20260908 CN event.

Bug Fixes:
- Prevent normal enemies, delayed or moved Sirens, stale targets, and post-third-battle movement from causing unintended combat or a fourth battle.

Enhancements:
- Extend stage alias handling so the new event’s D3-3 entry uses the specialized three-battle retreat logic while preserving standard D3 behavior.

Tests:
- Add coverage for Siren spawning, movement, target selection, retreat conditions, combat safeguards, settlement behavior, and stage aliases.

</details>