### PR TITLE
fix(campaign): 修复紧急委托不能刷d3-3的问题

### DIFF
--- a/module/campaign/campaign_event.py
+++ b/module/campaign/campaign_event.py
@@ -312,5 +312,5 @@ class CampaignEvent(CampaignStatus):
         Args:
             name (str): 关卡名称，如 `7-2`、`D3`。
         """
-        regex_main = re.compile(r'\d{1,2}[-_]\d')
-        return bool(regex_main.search(name))
+        regex_main = re.compile(r'^(?:campaign_)?\d{1,2}[-_]\d')
+        return bool(regex_main.match(str(name).strip().lower()))

--- a/module/campaign/run.py
+++ b/module/campaign/run.py
@@ -212,27 +212,33 @@ class CampaignRun(CampaignEvent, ShopStatus):
             str, str: (name, folder)。
         """
         name = to_map_file_name(name)
-        # 支持已适配活动的 D3 三战撤退入口
-        if folder in ['event_20251218_cn', 'event_20260908_cn']:
-            # 将 d3-3 转换为 d3_3 以使用三战撤退逻辑
-            if name == 'd3-3':
-                name = 'd3_3'
-                logger.info('[战役-运行] 关卡名d3-3转换为d3_3 (三战撤退逻辑)')
-            # d3 保持不变，使用标准逻辑
-            elif name == 'd3':
-                logger.info('[战役-运行] 关卡名d3使用标准逻辑')
         # GemsFarming 和 ThreeOilLowCost 自动选择活动或主线章节
         if self.config.task.command in ['GemsFarming', 'ThreeOilLowCost']:
             if self.stage_is_main(name):
                 logger.info(f'Stage name {name} is from campaign_main')
                 folder = 'campaign_main'
             else:
-                folder = self.config.cross_get('GemsFarming.Campaign.Event')
+                event = getattr(self.config, 'Campaign_Event', None)
+                if event and event != 'campaign_main':
+                    folder = event
+                elif folder and folder != 'campaign_main':
+                    pass
+                else:
+                    folder = self.config.cross_get('GemsFarming.Campaign.Event')
                 if folder is not None:
                     logger.info(f'Stage name {name} is from event {folder}')
                 else:
                     logger.warning(f'Cannot get the latest event, fallback to campaign_main')
                     folder = 'campaign_main'
+        # 支持已适配活动的 D3 三战撤退入口
+        if folder in ['event_20251218_cn', 'event_20260908_cn']:
+            # 将 d3-3 / d3_3 转换为 d3_3 以使用三战撤退逻辑
+            if name in ['d3-3', 'd3_3']:
+                name = 'd3_3'
+                logger.info('[战役-运行] 关卡名转换为d3_3 (三战撤退逻辑)')
+            # d3 保持不变，使用标准逻辑
+            elif name == 'd3':
+                logger.info('[战役-运行] 关卡名d3使用标准逻辑')
         # 处理特殊 SP 地图名称
         if folder == 'event_20201126_cn' and name == 'vsp':
             name = 'sp'

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -3002,7 +3002,6 @@
           "event_20260813_cn",
           "event_20260908_cn"
         ],
-        "display": "hide",
         "option_cn": [
           "event_20260908_cn"
         ],

--- a/module/config/argument/override.yaml
+++ b/module/config/argument/override.yaml
@@ -73,8 +73,6 @@ ThreeOilLowCost:
     # SuccessInterval: 0
     # FailureInterval: 0
   Campaign:
-    Event:
-      value: campaign_main
     Mode: normal
     UseClearMode: true
     UseFleetLock: true

--- a/module/config/config_updater.py
+++ b/module/config/config_updater.py
@@ -753,7 +753,7 @@ class ConfigUpdater:
                              keys=f'{task}.Campaign.Event',
                              value=opts[0])
 
-            for task in ['GemsFarming']:
+            for task in GEMS_FARMINGS:
                 opts = deep_get(self.args, keys=f'{task}.Campaign.Event.option_{server}', default=[])
                 if opts and deep_get(new, keys=f'{task}.Campaign.Event', default='campaign_main') not in opts:
                     deep_set(new,

--- a/tests/test_event_20260908_d3_retreat.py
+++ b/tests/test_event_20260908_d3_retreat.py
@@ -154,6 +154,45 @@ class TestD3SirenRetreat(unittest.TestCase):
                 with self.subTest(folder=folder, name=name):
                     self.assertEqual(runner.handle_stage_name(name, folder), (expected, folder))
 
+    def test_stage_is_main(self):
+        self.assertTrue(CampaignRun.stage_is_main('7-2'))
+        self.assertTrue(CampaignRun.stage_is_main('12-4'))
+        self.assertTrue(CampaignRun.stage_is_main('campaign_7_2'))
+        self.assertTrue(CampaignRun.stage_is_main('campaign_12_4'))
+
+        self.assertFalse(CampaignRun.stage_is_main('D3'))
+        self.assertFalse(CampaignRun.stage_is_main('d3'))
+        self.assertFalse(CampaignRun.stage_is_main('D3-3'))
+        self.assertFalse(CampaignRun.stage_is_main('d3-3'))
+        self.assertFalse(CampaignRun.stage_is_main('d3_3'))
+        self.assertFalse(CampaignRun.stage_is_main('sp'))
+        self.assertFalse(CampaignRun.stage_is_main('sp1'))
+
+    def test_gems_farming_and_three_oil_d3_alias(self):
+        for command in ('GemsFarming', 'ThreeOilLowCost'):
+            runner = object.__new__(CampaignRun)
+            runner.config = SimpleNamespace(
+                task=SimpleNamespace(command=command),
+                Campaign_Event='campaign_main',
+                STAGE_LOOP_ALIAS={},
+                cross_get=lambda k: 'event_20260908_cn' if 'Campaign.Event' in k else None,
+            )
+            for name in ('D3-3', 'd3-3', 'd3_3'):
+                with self.subTest(command=command, name=name):
+                    self.assertEqual(
+                        runner.handle_stage_name(name, folder='campaign_main'),
+                        ('d3_3', 'event_20260908_cn'),
+                    )
+
+            self.assertEqual(
+                runner.handle_stage_name('D3', folder='campaign_main'),
+                ('d3', 'event_20260908_cn'),
+            )
+            self.assertEqual(
+                runner.handle_stage_name('7-2', folder='campaign_main'),
+                ('campaign_7_2', 'campaign_main'),
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Sourcery 总结

修复紧急委托对活动 D3-3 的关卡识别与路由，确保其使用正确的活动刷图逻辑。

Bug 修复：
- 修复 GemsFarming 和 ThreeOilLowCost 任务无法正确识别并刷取活动 D3-3 关卡的问题。

功能改进：
- 改进关卡名称与主线关卡的识别，并优化活动关卡配置的选择逻辑。

测试：
- 新增主线关卡识别及活动 D3/D3-3 别名处理的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复紧急委托对活动 D3-3 的关卡识别与路由，确保其使用正确的活动刷图逻辑。

Bug Fixes:
- 修复 GemsFarming 和 ThreeOilLowCost 任务无法正确识别并刷取活动 D3-3 关卡的问题。

Enhancements:
- 改进关卡名称与主线关卡的识别，并优化活动关卡配置的选择逻辑。

Tests:
- 新增主线关卡识别及活动 D3/D3-3 别名处理的测试覆盖。

</details>