### PR TITLE
feat(gems_farming): 新增紧急委托索敌配置与放开潜艇限制

### DIFF
--- a/config/template.json
+++ b/config/template.json
@@ -532,7 +532,7 @@
       "Fleet": 0,
       "Mode": "do_not_use",
       "AutoSearchMode": "sub_standby",
-      "DistanceToBoss": "use_open_ocean_support",
+      "DistanceToBoss": "2_grid_to_boss",
       "AdvancedConfig": "# 弹药数\nammo: 7\n\n# 远洋支援数\nsupport: 1\n\n# 松鲷的狩猎范围\nrange:\n  - \"ONONOOO\"\n  - \"ONNNNOO\"\n  - \"NNNNNNO\"\n  - \"ONNHNNN\"\n  - \"NNNNNNO\"\n  - \"ONOONOO\"\n  - \"OOOOOOO\"\n\n# 规则\nrules:\n  battle_0: # 所有战斗\n    type: hunt  # 出击类型为狩猎\n    condition:  # 出击条件\n      ammo: \">2\"  # 弹药数大于2\n      enemy:  # 敌人类型为\n        - \"2C\"  # 中航\n        - \"3T\"  # 大运\n        - \"0E\"  # 未知敌人\n      in_range: true  # 在狩猎范围里\n    move: false # 不移动\n  battle_2: # 第二场战斗\n    type: call  # 出击类型为召唤\n    condition:  # 出击条件\n      ammo: \">=2\" # 弹药数大于等于2\n      support: \"!=0\" # 远洋支援数不等于0\n      enemy:  # 敌人类型为\n        - \"3*\"  # 所有大型舰队\n      in_range: false  # 不要求在狩猎范围里\n    move: false # 不移动\n  battle_-1:  # 最后一场战斗\n    type: call  # 出击类型为召唤\n    # 这里没写条件所以是必定出击\n    support: true # 远洋支援\n    move: true # 移动\n"
     },
     "Emotion": {
@@ -549,6 +549,9 @@
       "Fleet2Recover": "not_in_dormitory",
       "Fleet2Oath": false,
       "Fleet2Onsen": false
+    },
+    "EnemyPriority": {
+      "EnemyScaleBalanceWeight": "S1_enemy_first"
     },
     "Storage": {
       "Storage": {}
@@ -621,7 +624,7 @@
       "Fleet": 0,
       "Mode": "do_not_use",
       "AutoSearchMode": "sub_standby",
-      "DistanceToBoss": "use_open_ocean_support",
+      "DistanceToBoss": "2_grid_to_boss",
       "AdvancedConfig": "# 弹药数\nammo: 7\n\n# 远洋支援数\nsupport: 1\n\n# 松鲷的狩猎范围\nrange:\n  - \"ONONOOO\"\n  - \"ONNNNOO\"\n  - \"NNNNNNO\"\n  - \"ONNHNNN\"\n  - \"NNNNNNO\"\n  - \"ONOONOO\"\n  - \"OOOOOOO\"\n\n# 规则\nrules:\n  battle_0: # 所有战斗\n    type: hunt  # 出击类型为狩猎\n    condition:  # 出击条件\n      ammo: \">2\"  # 弹药数大于2\n      enemy:  # 敌人类型为\n        - \"2C\"  # 中航\n        - \"3T\"  # 大运\n        - \"0E\"  # 未知敌人\n      in_range: true  # 在狩猎范围里\n    move: false # 不移动\n  battle_2: # 第二场战斗\n    type: call  # 出击类型为召唤\n    condition:  # 出击条件\n      ammo: \">=2\" # 弹药数大于等于2\n      support: \"!=0\" # 远洋支援数不等于0\n      enemy:  # 敌人类型为\n        - \"3*\"  # 所有大型舰队\n      in_range: false  # 不要求在狩猎范围里\n    move: false # 不移动\n  battle_-1:  # 最后一场战斗\n    type: call  # 出击类型为召唤\n    # 这里没写条件所以是必定出击\n    support: true # 远洋支援\n    move: true # 移动\n"
     },
     "Emotion": {
@@ -638,6 +641,9 @@
       "Fleet2Recover": "not_in_dormitory",
       "Fleet2Oath": false,
       "Fleet2Onsen": false
+    },
+    "EnemyPriority": {
+      "EnemyScaleBalanceWeight": "S1_enemy_first"
     },
     "Storage": {
       "Storage": {}

--- a/module/campaign/gems_farming.py
+++ b/module/campaign/gems_farming.py
@@ -309,7 +309,7 @@ class GemsFarming(CampaignRun, FleetEquipment, GemsEquipmentHandler, Retirement)
 
         在父类 load_campaign() 基础上，将 Campaign 替换为继承了
         GemsCampaignOverride 的子类，注入 GemsEmotion 情绪管理。
-        根据是否更换先锋舰船设置情绪管理模式。
+        根据是否更换先锋舰船设置情绪管理模式，索敌优先级保持任务配置。
 
         Args:
             name (str): 地图文件名。
@@ -327,7 +327,6 @@ class GemsFarming(CampaignRun, FleetEquipment, GemsEquipmentHandler, Retirement)
         self.campaign = GemsCampaign(device=self.campaign.device, config=self.campaign.config)
         if self.change_vanguard:
             self.campaign.config.override(Emotion_Mode='ignore_calculate')
-            self.campaign.config.override(EnemyPriority_EnemyScaleBalanceWeight='S1_enemy_first')
         else:
             self.campaign.config.override(Emotion_Mode='ignore')
 

--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -2723,9 +2723,12 @@
         "value": "do_not_use",
         "option": [
           "do_not_use",
-          "hunt_only"
-        ],
-        "display": "display"
+          "hunt_only",
+          "boss_only",
+          "hunt_and_boss",
+          "every_combat",
+          "advanced"
+        ]
       },
       "AutoSearchMode": {
         "type": "select",
@@ -2733,19 +2736,17 @@
         "option": [
           "sub_standby",
           "sub_auto_call"
-        ],
-        "display": "hide"
+        ]
       },
       "DistanceToBoss": {
         "type": "select",
-        "value": "use_open_ocean_support",
+        "value": "2_grid_to_boss",
         "option": [
           "to_boss_position",
           "1_grid_to_boss",
           "2_grid_to_boss",
           "use_open_ocean_support"
-        ],
-        "display": "hide"
+        ]
       },
       "AdvancedConfig": {
         "type": "textarea",
@@ -2844,6 +2845,17 @@
       "Fleet2Onsen": {
         "type": "checkbox",
         "value": false
+      }
+    },
+    "EnemyPriority": {
+      "EnemyScaleBalanceWeight": {
+        "type": "select",
+        "value": "S1_enemy_first",
+        "option": [
+          "default_mode",
+          "S3_enemy_first",
+          "S1_enemy_first"
+        ]
       }
     },
     "Storage": {
@@ -3247,9 +3259,12 @@
         "value": "do_not_use",
         "option": [
           "do_not_use",
-          "hunt_only"
-        ],
-        "display": "display"
+          "hunt_only",
+          "boss_only",
+          "hunt_and_boss",
+          "every_combat",
+          "advanced"
+        ]
       },
       "AutoSearchMode": {
         "type": "select",
@@ -3257,19 +3272,17 @@
         "option": [
           "sub_standby",
           "sub_auto_call"
-        ],
-        "display": "hide"
+        ]
       },
       "DistanceToBoss": {
         "type": "select",
-        "value": "use_open_ocean_support",
+        "value": "2_grid_to_boss",
         "option": [
           "to_boss_position",
           "1_grid_to_boss",
           "2_grid_to_boss",
           "use_open_ocean_support"
-        ],
-        "display": "hide"
+        ]
       },
       "AdvancedConfig": {
         "type": "textarea",
@@ -3367,6 +3380,17 @@
       "Fleet2Onsen": {
         "type": "checkbox",
         "value": false
+      }
+    },
+    "EnemyPriority": {
+      "EnemyScaleBalanceWeight": {
+        "type": "select",
+        "value": "S1_enemy_first",
+        "option": [
+          "default_mode",
+          "S3_enemy_first",
+          "S1_enemy_first"
+        ]
       }
     },
     "Storage": {

--- a/module/config/argument/default.yaml
+++ b/module/config/argument/default.yaml
@@ -6,6 +6,13 @@
 
 # ==================== Farm ====================
 
+GemsFarming:
+  EnemyPriority:
+    EnemyScaleBalanceWeight: S1_enemy_first
+ThreeOilLowCost:
+  EnemyPriority:
+    EnemyScaleBalanceWeight: S1_enemy_first
+
 # ==================== Event ====================
 
 EventA:
@@ -32,9 +39,6 @@ EventD:
 # ==================== DailyMission ====================
 
 # ==================== Opsi ====================
-ThreeOilLowCost:
-  Scheduler:
-    Enable: false
 OpsiCrossMonth:
   Scheduler:
     Sensitive: true

--- a/module/config/argument/override.yaml
+++ b/module/config/argument/override.yaml
@@ -54,14 +54,6 @@ GemsFarming:
     Fleet2Control: prevent_red_face
     Fleet2Recover: not_in_dormitory
     Fleet2Oath: false
-  Submarine:
-    Mode:
-      display: display
-      value: do_not_use
-      option: [do_not_use, hunt_only]
-    AutoSearchMode: sub_standby
-    DistanceToBoss: use_open_ocean_support
-
 
 ThreeOilLowCost:
   Scheduler:
@@ -97,13 +89,6 @@ ThreeOilLowCost:
     Fleet2Control: prevent_red_face
     Fleet2Recover: not_in_dormitory
     Fleet2Oath: false
-  Submarine:
-    Mode:
-      display: display
-      value: do_not_use
-      option: [do_not_use, hunt_only]
-    AutoSearchMode: sub_standby
-    DistanceToBoss: use_open_ocean_support
 
 Ambush11:
   Campaign:

--- a/module/config/argument/task.yaml
+++ b/module/config/argument/task.yaml
@@ -60,6 +60,7 @@ Farm:
       - Fleet
       - Submarine
       - Emotion
+      - EnemyPriority
     ThreeOilLowCost:
       - Scheduler
       - GemsFarming
@@ -68,6 +69,7 @@ Farm:
       - Fleet
       - Submarine
       - Emotion
+      - EnemyPriority
     Ambush11:
       - Scheduler
       - GemsFarming

--- a/tests/test_farming_combat_config.py
+++ b/tests/test_farming_combat_config.py
@@ -1,0 +1,117 @@
+"""验证低耗任务的配置更新、战役加载及潜艇与索敌接入。"""
+
+import copy
+import itertools
+import unittest
+from unittest.mock import Mock
+
+from module.campaign.gems_farming import GemsFarming
+from module.config.config import AzurLaneConfig, name_to_function
+from module.config.utils import read_file
+
+
+TASKS = ('GemsFarming', 'ThreeOilLowCost')
+PRIORITIES = ('default_mode', 'S1_enemy_first', 'S3_enemy_first')
+
+
+def make_config(task, **groups):
+    """使用真实更新和绑定流程，全程在内存中操作配置。"""
+    config = AzurLaneConfig('template')
+    config.auto_update = False
+    config.data = config.config_update({task: groups})
+    config.bind(task)
+    config.task = name_to_function(task)
+    return config
+
+
+class TestFarmingCombatConfig(unittest.TestCase):
+    def test_submarine_options_are_editable_and_survive_reload(self):
+        """覆盖所有解锁选项，防止界面可选但加载后被隐藏覆盖值重置。"""
+        args = read_file('module/config/argument/args.json')
+        reference = args['Main']['Submarine']
+        for task in TASKS:
+            for name, definition in reference.items():
+                with self.subTest(task=task, name=name):
+                    actual = args[task]['Submarine'][name]
+                    self.assertNotIn(actual.get('display'), ('hide', 'disabled'))
+                    self.assertEqual(actual.get('option'), definition.get('option'))
+            combinations = itertools.product(
+                reference['Mode']['option'], reference['AutoSearchMode']['option'],
+                reference['DistanceToBoss']['option'],
+            )
+            for mode, auto, distance in combinations:
+                with self.subTest(task=task, mode=mode, auto=auto, distance=distance):
+                    values = dict(Fleet=2, Mode=mode, AutoSearchMode=auto, DistanceToBoss=distance)
+                    config = make_config(task, Submarine=values)
+                    config.data = config.config_update(config.data)
+                    config.bind(task)
+                    for name, value in values.items():
+                        self.assertEqual(getattr(config, f'Submarine_{name}'), value)
+
+    def test_old_config_gets_priority_without_changing_submarine_defaults(self):
+        """旧配置补齐索敌选项，并保留原有潜艇行为和任务边界。"""
+        for task in TASKS:
+            config = make_config(task, Submarine={'Fleet': 1, 'Mode': 'hunt_only'})
+            self.assertEqual(config.EnemyPriority_EnemyScaleBalanceWeight, 'default_mode')
+            self.assertEqual(config.bound['EnemyPriority_EnemyScaleBalanceWeight'],
+                             f'{task}.EnemyPriority.EnemyScaleBalanceWeight')
+            self.assertEqual(config.Submarine_Mode, 'hunt_only')
+            self.assertEqual(config.Submarine_AutoSearchMode, 'sub_standby')
+            self.assertEqual(config.Submarine_DistanceToBoss, 'use_open_ocean_support')
+        config = make_config('Ambush11', Submarine={'AutoSearchMode': 'sub_auto_call'})
+        self.assertEqual(config.Submarine_AutoSearchMode, 'sub_standby')
+
+    def load_campaign(self, task, priority='default_mode', vanguard='disabled', **submarine):
+        config = make_config(
+            task, EnemyPriority={'EnemyScaleBalanceWeight': priority},
+            GemsFarming={'ChangeVanguard': vanguard}, Submarine=submarine,
+        )
+        runner = GemsFarming(config=config, device=Mock())
+        runner.load_campaign('campaign_2_1')
+        return runner.campaign
+
+    def test_priority_reaches_target_selection_with_or_without_ship_changes(self):
+        """经任务加载后使用真实地图选敌，避免只验证配置字段。"""
+        for task, priority, vanguard in itertools.product(TASKS, PRIORITIES, ('disabled', 'ship_equip')):
+            with self.subTest(task=task, priority=priority, vanguard=vanguard):
+                campaign = self.load_campaign(task, priority, vanguard)
+                self.assertEqual(campaign.config.EnemyPriority_EnemyScaleBalanceWeight, priority)
+                campaign.map = copy.deepcopy(campaign.MAP)
+                campaign.map.reset()
+                campaign.config.override(MAP_CLEAR_ALL_THIS_TIME=False, MAP_HAS_MOVABLE_NORMAL_ENEMY=False)
+                for scale in (1, 2, 3):
+                    grid = campaign.map[(scale - 1, 0)]
+                    grid.is_enemy = True
+                    grid.cost = 1
+                    grid.enemy_scale = scale
+                    grid.enemy_genre = 'Light'
+                    grid.weight = 0 if scale == 2 else 10
+                campaign.clear_chosen_enemy = Mock()
+                expected = {'default_mode': 2, 'S1_enemy_first': 1, 'S3_enemy_first': 3}[priority]
+                self.assertTrue(campaign.clear_enemy())
+                self.assertEqual(campaign.clear_chosen_enemy.call_args.args[0].enemy_scale, expected)
+                self.assertTrue(campaign.clear_filter_enemy('2L > 1L > 3L', preserve=0))
+                self.assertEqual(campaign.clear_chosen_enemy.call_args.args[0].enemy_scale, expected)
+
+    def test_submarine_modes_reach_campaign_handlers(self):
+        """验证 Boss 召唤、高级规则及自律方案使用任务中的实际配置。"""
+        for task in TASKS:
+            for mode in ('boss_only', 'hunt_and_boss'):
+                campaign = self.load_campaign(task, Fleet=1, Mode=mode)
+                self.assertEqual(campaign._submarine_mode('combat'), 'do_not_use')
+                self.assertEqual(campaign._submarine_mode('combat_boss'), 'every_combat')
+            campaign = self.load_campaign(task, Fleet=1, Mode='advanced', AutoSearchMode='sub_auto_call')
+            campaign.map_is_auto_search = False
+            campaign.submarine_advanced_reset()
+            self.assertIsNotNone(campaign.submarine_advanced)
+            campaign.map_is_auto_search = True
+            campaign.submarine_advanced_reset()
+            self.assertIsNone(campaign.submarine_advanced)
+            campaign.fleet_preparation_sidebar_ensure = Mock()
+            campaign.auto_search_setting_ensure = Mock(return_value=True)
+            self.assertTrue(campaign.handle_auto_search_setting())
+            campaign.auto_search_setting_ensure.assert_any_call('sub_auto_call')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Sourcery 总结

在保留现有配置兼容性的同时，为 farming 任务启用可配置的敌方目标选择和潜艇行为。

新功能：
- 为 GemsFarming 和 ThreeOilLowCost 任务添加可配置的敌方目标优先级。
- 为 farming 任务公开潜艇行为选项，不再强制使用固定的潜艇限制。

错误修复：
- 加载 farming 战役和重新加载现有配置时，保留任务专属的敌方优先级和潜艇设置。

测试：
- 增加对 farming 配置迁移、敌方选择优先级，以及潜艇战斗和自动搜索行为的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable configurable enemy targeting and submarine behavior for farming tasks while preserving existing configuration compatibility.

New Features:
- Add configurable enemy-targeting priority for GemsFarming and ThreeOilLowCost tasks.
- Expose submarine behavior options for farming tasks instead of forcing fixed submarine restrictions.

Bug Fixes:
- Preserve task-specific enemy-priority and submarine settings when loading farming campaigns and reloading existing configurations.

Tests:
- Add coverage for farming configuration migration, enemy selection priorities, and submarine combat and auto-search behavior.

</details>