### PR TITLE
fix(debug_clip): 录像成功后不再残留 ffmpeg 日志文件

### DIFF
--- a/module/base/debug_clip.py
+++ b/module/base/debug_clip.py
@@ -815,19 +815,23 @@ class _ScrcpyClip:
                 parts.append(f"｜{name}: {text[-limit:]}")
         return "".join(parts)
 
+    def _remove_file(self, path):
+        """尽力删除一个文件（Windows 上可能被占用，重试几次）。"""
+        if not path:
+            return
+        for _ in range(3):
+            try:
+                os.remove(path)
+                break
+            except FileNotFoundError:
+                break
+            except OSError:
+                time.sleep(0.2)
+
     def _discard(self):
-        """删除本次录制的临时产物（不保留的片段，或判定为无效的片段）。"""
+        """删除本次录制的全部临时文件（不保留的片段，或判定为无效的片段）。"""
         for path in (self.tmp_path, self.dec_log_path, self.enc_log_path):
-            if not path:
-                continue
-            for _ in range(3):
-                try:
-                    os.remove(path)
-                    break
-                except FileNotFoundError:
-                    break
-                except OSError:
-                    time.sleep(0.2)
+            self._remove_file(path)
 
     def _fail(self, reason):
         """产物无效时统一报错，绝不谎报「已保存」。"""
@@ -949,6 +953,10 @@ class _ScrcpyClip:
             result = self._keep_record(encoder_ok, elapsed)
         if result is None:
             self._discard()
+        else:
+            # 保存成功：诊断日志已完成使命，录像目录里只应留下 mp4
+            self._remove_file(self.dec_log_path)
+            self._remove_file(self.enc_log_path)
         return result
 
 

--- a/tests/test_debug_clip.py
+++ b/tests/test_debug_clip.py
@@ -338,6 +338,23 @@ class TestFinalizeIsSafe(ClipTestCase):
         self.assertIsNone(rec.finalize(keep=True))
         self.assertFalse(os.path.exists(rec.tmp_path))
 
+    def test_finalize_leaves_only_the_mp4_on_success(self):
+        """录像成功后目录里只能留下 mp4：ffmpeg 的 stderr 日志必须一并清掉。"""
+        rec = self.make_clip()
+        with open(rec.tmp_path, 'wb') as f:
+            f.write(b'x' * 8000)
+        for log_path in (rec.dec_log_path, rec.enc_log_path):
+            with open(log_path, 'wb') as f:
+                f.write(b'ffmpeg noise')
+        rec._frames_written = 300
+
+        path = rec.finalize(keep=True)
+
+        self.assertIsNotNone(path)
+        self.assertTrue(os.path.exists(path))
+        for leftover in (rec.tmp_path, rec.dec_log_path, rec.enc_log_path):
+            self.assertFalse(os.path.exists(leftover), leftover)
+
 
 class TestPaceLoop(ClipTestCase):
     """验证核心节奏：源帧率低时补帧、高时丢帧，输出时长贴近真实时间。"""


### PR DESCRIPTION
上一版把 ffmpeg 的 stderr 从 DEVNULL 改成落盘日志（用于定位录像失败原因），但 清理逻辑 _discard() 只在「产物无效 / 不保留」分支被调用——录制成功走的是另一条
分支，两个 .log 就永远留在 log/clips/ 里，和视频混在一起。

现象是每成功录一段就多出两个 0 字节的 _tmp_clip_*.dec.log / .enc.log，用户在 录像目录里看到 log 文件会以为出了问题。

改为：保存成功后单独清掉这两个日志文件；顺带把删除逻辑抽成 _remove_file() 供
两处复用。新增回归测试，断言成功路径下目录里只剩下 mp4。

## Sourcery 总结

清理成功录制后的 ffmpeg 日志，防止保存的片段旁出现多余的日志文件。

错误修复：
- 在片段成功完成最终处理后删除 ffmpeg 诊断日志文件，确保录制目录中仅保留保存的 MP4 文件。
- 添加回归测试，确保成功录制后临时视频文件和 ffmpeg 日志文件均不存在。

增强功能：
- 集中处理文件删除重试逻辑，以便在各个清理路径中复用。

测试：
- 添加成功路径测试，验证完成最终处理后仅保留 MP4 文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up ffmpeg logs after successful recordings to prevent stray log files from appearing alongside saved clips.

Bug Fixes:
- Remove ffmpeg diagnostic log files after successful clip finalization so recording directories retain only the saved MP4.
- Add regression coverage ensuring temporary video and ffmpeg log files are absent after a successful recording.

Enhancements:
- Centralize retrying file deletion for reuse across cleanup paths.

Tests:
- Add a success-path test verifying that only the MP4 remains after finalization.

</details>