### PR TITLE
fix(combat): 修复过图加载期间红脸弹窗无人处理导致卡死

### DIFF
--- a/module/combat/auto_search_combat.py
+++ b/module/combat/auto_search_combat.py
@@ -259,6 +259,10 @@ class AutoSearchCombat(MapOperation, Combat, CampaignStatus):
                 continue
             if self.handle_vote_popup():
                 continue
+            # 加载期间出现的红脸（低心情）弹窗同样没有任何其他处理器会认，
+            # 不处理会一直等到 GameStuckError。ignore 模式下点「确定」继续出击
+            if self.handle_combat_low_emotion():
+                continue
             # 过图期间弹出的「船坞已满」弹窗没有任何其他处理器会认，
             # 不处理会一直等到 GameStuckError。处理完退役/强化后重新开启
             # 自动搜索，等待游戏自己再次进入战斗加载


### PR DESCRIPTION
进入战斗的加载阶段只处理自动化确认、剧情跳过和投票弹窗，红脸
（低心情）弹窗出现时没有任何处理器会认它，脚本会一直等到
GameStuckError 才重启游戏。issue #890 / #892 虽然关联了 PR #897， 但 PR #897 处理的是「船坞已满」弹窗，与心情弹窗无关。

补上 handle_combat_low_emotion()：配置了「无视红脸出击」时点掉弹窗
继续出击并置位 GEMS_EMOTION_TRIGGERED，使战斗结束后的换船流程
能够正常触发。

## Sourcery 摘要

错误修复：
- 在战斗加载期间处理低士气战斗弹窗，以便配置的忽略模式可以将其关闭，防止自动化流程卡住。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle low-morale combat popups during battle loading so configured ignore mode can dismiss them and prevent the automation from getting stuck.

</details>