### PR TITLE
fix(island): 购买成功弹窗改用模板匹配避免误判连点

### DIFF
--- a/module/island/island.py
+++ b/module/island/island.py
@@ -1015,14 +1015,16 @@ class Island(SelectCharacter):
                 if not self.appear(ISLAND_SHOP_CONFIRM) or not self.appear(ISLAND_SHOPPING_CHECK, offset=(1, 1)):
                     break
                 continue
-            if self.appear(ISLAND_SHOP_GET):
+            # 使用模板检测判断“购买成功”弹窗，商店页大面积浅色背景的平均颜色与弹窗资源接近，
+            # 纯颜色检测会误判并要求反复点击确认按钮。
+            if self.appear(ISLAND_SHOP_GET, offset=(1, 1)):
                 self.device.click(ISLAND_SHOP_CONFIRM)
                 continue
         else:
             logger.warning(f"[岛屿] 确认购买超时: {item_name or item_button}")
             return False
 
-        if self.appear(ISLAND_SHOP_GET):
+        if self.appear(ISLAND_SHOP_GET, offset=(1, 1)):
             self.device.click(ISLAND_SHOP_CONFIRM)
         return True
 
@@ -1241,7 +1243,7 @@ class Island(SelectCharacter):
                 return True
             if self.appear(ISLAND_POST_CHECK, offset=1) or self.appear(ISLAND_POST_VACANT_CHECK, offset=1):
                 return True
-            if self.appear(ISLAND_SHOP_GET):
+            if self.appear(ISLAND_SHOP_GET, offset=(1, 1)):
                 self.device.click(ISLAND_SHOP_CONFIRM)
                 continue
             if self.appear_then_click(back_button, offset=(20, 20), interval=1):

--- a/module/island/island_rancher.py
+++ b/module/island/island_rancher.py
@@ -114,14 +114,14 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
                 self.device.click(ISLAND_SHOP_CONFIRM)
                 self.device.sleep(0.5)
                 continue
-            if self.appear(ISLAND_SHOP_GET):
+            if self.appear(ISLAND_SHOP_GET, offset=(1, 1)):
                 self.device.click(ISLAND_SHOP_CONFIRM)
                 continue
         else:
             logger.warning(f"[岛屿-牧场] 确认磨坊加工超时: {self._item_cn(mill_item)}")
             return False
 
-        if self.appear(ISLAND_SHOP_GET):
+        if self.appear(ISLAND_SHOP_GET, offset=(1, 1)):
             self.device.click(ISLAND_SHOP_CONFIRM)
         return True
 
@@ -245,7 +245,7 @@ class IslandRancher(Island, WarehouseOCR, LoginHandler):
             if self.appear(ISLAND_POST_CHECK, offset=1) or self.appear(ISLAND_POST_VACANT_CHECK, offset=1):
                 self.device.click(POST_CLOSE)
                 continue
-            if self.appear(ISLAND_SHOP_GET):
+            if self.appear(ISLAND_SHOP_GET, offset=(1, 1)):
                 self.device.click(ISLAND_SHOP_CONFIRM)
                 continue
 


### PR DESCRIPTION
- ISLAND_SHOP_GET 资源区域为 284x69 的大面积浅色区域，种子商店页该区域平均色 (217.5,216.7,214.7) 与资源色 (209,210,208) 容差仅 8.5，纯颜色检测恒为命中，导致 back_to_select_product_after_shop() 每帧盲点购买按钮
- 6 处 ISLAND_SHOP_GET 判定统一传入 offset=(1, 1) 改为模板匹配，覆盖island.py 的购买确认/返回产物选择页，以及 island_rancher.py 的磨坊加工
- 失败现场截图上复检：商店页不再误命中，购买成功弹窗仍可正常识别

## Sourcery 摘要

使用模板匹配可靠地识别购买成功对话框，防止在各个岛屿购买流程中发生错误的重复点击。

错误修复：
- 防止在商店页面错误检测到购买成功对话框，避免重复点击确认。

功能增强：
- 统一岛屿购物和磨坊加工流程中的购买成功对话框识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use template matching to reliably recognize purchase-success dialogs and prevent erroneous repeated clicks across island purchasing workflows.

Bug Fixes:
- Prevent false detection of the purchase-success dialog on shop pages, avoiding repeated confirmation clicks.

Enhancements:
- Standardize purchase-success dialog recognition across island shopping and mill-processing flows.

</details>