### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### AzurLaneAutoScript
 log
 cache/
+.codex
 config/backup/*
 config/*.ini
 !config/template.ini

--- a/module/base/debug_clip.py
+++ b/module/base/debug_clip.py
@@ -1,94 +1,100 @@
-"""大世界战后 debug 录屏（真实游戏画面，scrcpy 设备直录，30fps 实时）。
+"""大世界战后 debug 录屏（设备端 screenrecord 直录，30fps 输出，真实时间戳）。
 
 当前由侵蚀1练级与短猫相接两个任务使用，各自有独立的开关，共用同一套录制实现
 和同一份保留天数设置。
 
 用户要求：录「游戏真实画面」，30fps，**既不加速也不跳帧**。
 
-scrcpy v1.20 的视频流是**不带时间戳的裸 H.264**，直接 `-c copy` + 固定 `-r 30`
-会在源帧率 ≠30 时加速或跳帧。因此本模块采用「解码 → 定时补帧 → 编码」三段式：
+管线：
 
-    裸 H.264 ──ffmpeg 解码──▶ rawvideo 帧 ──按 1/30s 墙钟投喂──▶ libx264 30fps mp4
+    设备端 screenrecord ──SIGINT──▶ 设备上的 mp4 ──adb pull──▶ 本地临时文件 ──ffmpeg──▶ 30fps mp4
 
-三个线程各司其职：
+**为什么不继续用 scrcpy**（2026-09 更换）：旧实现走 scrcpy-server 1.20 的裸 H.264 视频流，
+因为该流不带时间戳，必须自己解码、按 1/30s 墙钟补帧再编码，才能保证播放速度等于真实速度。
+但 scrcpy 1.20 靠 `SurfaceControl.createDisplay()` 镜像画面，而 AOSP 在 Android 14 QPR3 /
+Android 15 上移除了这个隐藏 API（上游直到 scrcpy 2.4 才适配，见 Genymobile/scrcpy#4657）。
+后果是在新模拟器上（例如 MuMu 的安卓 15 实例）握手全部成功、却**一个字节视频都收不到**，
+旧实现只能把它误报成「画面完全静止所以没有帧」，现象就是 clip 目录一个文件都没有。
 
-- `_socket_to_decoder`：把 scrcpy 的 H.264 字节流喂给解码器；
-- `_decode_loop`：把解码出的 rawvideo 帧塞进「只留最新一帧」的队列；
-- `_pace_loop`：每 1/30s 醒来一次，队列里有新帧就用新帧，没有就**复用上一帧**。
+Android 自带的 `screenrecord`（Android 4.4+）没有这个问题：它由系统自己把画面镜像给编码器，
+写出的 mp4 自带真实时间戳，播放速度天然等于真实速度——「不加速」不再需要靠补帧实现，
+也不再依赖任何随安卓版本变动的隐藏接口。代价是设备端会临时存一个高码率文件
+（Android 对 720p60 有约 11Mbps 的下限），所以录完立刻 pull 回来、用 ffmpeg 转成
+30fps CRF 26 的小文件，然后删掉设备上的临时文件。
 
-由此得到两条保证：源帧率高于 30fps 时自动丢帧（取到的总是最新帧），源帧率低于
-30fps 时自动补帧（复用上一帧）。播放速度因此恒等于真实速度——scrcpy 只在屏幕内容
-变化时产帧，游戏加载/静止期间帧率会掉到很低，补帧是「不加速」的关键。早期版本
-缺了这一步，低帧率片段会被压缩成原时长的 1/N。
-
-关于总时长：ffmpeg 的 H.264 解码器有固定的起播预读（实测约 19 帧，probesize /
-analyzeduration / threads 都压不下去），这段帧要等收到 EOF 才会吐出来。因此
-`_pace_loop` 退出前会先 `_drain_decoder()` 把它们补进结尾。即便如此，视频仍会比
-真实时间短「预读帧数 ÷ 源帧率」秒：源 30fps 时约 0.6 秒（6%），60fps 时约 0.3 秒。
-源帧率越低这段越长（5fps 时可达 4 秒），但 scrcpy 在实战画面下不会掉到那么低。
-偏差超过 20% 时 `_keep_record` 会打 warning，不会静默。
-
-用法（由各任务的战后处理代码驱动，推荐用上下文管理器）：
+用法（不变，由各任务的战后处理代码驱动，推荐用上下文管理器）：
 
     with clip_recording(self.config, self.config.OpsiMeowfficerFarming_DebugClip,
                         prefix=CLIP_PREFIX_MEOW):
         ... 重扫地图 / 处理事件 / 强制移动 ...
 
-进入 with 时开录，退出时（含异常路径）保存。每一轮都保留，不管这一轮有没有
-遇到事件，方便逐轮回看实际过程。也可手动 `clip_start()` / `clip_end(keep=...)`
-控制得更细，`keep=False` 用于调用方确实想丢弃某一段的场景。
+进入 with 时开录，退出时（含异常路径）保存。每一轮都保留，不管这一轮有没有遇到事件，
+方便逐轮回看实际过程。也可手动 `clip_start()` / `clip_end(keep=...)` 控制得更细，
+`keep=False` 用于调用方确实想丢弃某一段的场景。
 
 文件输出到 `./log/clips/`，一段一个 mp4，文件名前缀区分任务
 （`eh1_clip_*` = 侵蚀1、`meow_clip_*` = 短猫相接），按 `OpsiGeneral` 里的
 `DebugClipRetentionDays` 保留天数自动清理（0 表示永久保留）。产物无效时
 **不会**留下文件，也不会谎报「已保存」。
 
-文件输出到 `./log/clips/`，一段一个 mp4，按 `DebugClipRetentionDays` 保留天数自动
-清理（0 表示永久保留）。产物无效时**不会**留下文件，也不会谎报「已保存」。
-
-限制：ALAS 自身截图方式若正使用 scrcpy，本模块会跳过并告警（同一 abstract
-socket 无法并存）。scrcpy/ffmpeg 启动失败会优雅降级为不录，不影响游戏逻辑。
+已知限制（都不影响游戏逻辑，失败时优雅降级为不录）：
+- 单段最长 180 秒（screenrecord 的 `--time-limit` 上限），超时会截断并打 warning；
+- 设备端 recorder 启动约 0.5 秒，这一段录不到（旧实现建立 scrcpy 连接也是这个量级）；
+- 本段结束时要做 pull + 转码，占用时间大致是片段长度的 0.15 倍，只发生在收尾；
+- 进程被强杀时设备上会留下临时文件，超过一小时的下次开录会清掉（不长于录像本身的价值）；
+- ALAS 截图方式为 scrcpy 时不再跳过录制（已经不存在 socket 冲突），但设备上会有两路
+  视频编码，截图或录像出现异常时优先怀疑这里。
 """
 
 import contextlib
 import os
-import queue
+import re
 import shutil
-import socket
-import struct
 import subprocess
-import threading
 import time
 
-from adbutils import AdbError, Network
+from adbutils import AdbClient, AdbDevice
 
 from module.logger import logger
 
 DEFAULT_OUTPUT_DIR = "./log/clips"
+# 输出帧率。设备按刷新率（MuMu 实测 47~68fps）录，收尾转码时降到这个帧率
 RECORD_FPS = 30
 # 录像文件名前缀，用于区分是哪个任务录的
 CLIP_PREFIX_EH1 = "eh1_clip_"  # 侵蚀1练级
 CLIP_PREFIX_MEOW = "meow_clip_"  # 短猫相接（耄耋相接）
 CLIP_PREFIXES = (CLIP_PREFIX_EH1, CLIP_PREFIX_MEOW)
-# 录制中途的临时文件前缀；保留旧前缀以便清理历史残留
+# 本地临时文件前缀（转码中途）；保留旧前缀以便清理历史残留
 TMP_PREFIX = "_tmp_clip_"
 TMP_PREFIXES = (TMP_PREFIX, "_tmp_eh1_")
 # 产物小于此字节数视为无效（正常 720p 首帧就在 10KB 以上）
 MIN_VALID_BYTES = 4096
-# 编码落后超过该秒数就不再追赶，直接重新对齐（否则会陷入无休止追赶）
-MAX_LAG = 1.0
-# 收尾时等待解码器吐出剩余帧的上限（秒）。ffmpeg 解码器有固定的起播缓冲，
-# 通常十几帧；超过这个时间就放弃，避免卡住游戏主流程。
-DRAIN_TIMEOUT = 5.0
-# 线程退出 / 子进程退出的等待上限（秒）
-JOIN_TIMEOUT = 8
-DECODER_EXIT_TIMEOUT = 5
-# 编码器要写完 moov atom 才能得到可播放的 mp4，给的时间要宽裕
-ENCODER_EXIT_TIMEOUT = 15
-# 残留临时文件的保留秒数（进程被强杀时留下的）
+# 残留临时文件（本地）的保留秒数
 TMP_MAX_AGE = 3600
 # 清理节流：两次扫描目录至少间隔这么久
 CLEANUP_INTERVAL = 3600
+
+# ------------------------------------------------ 设备端录制参数
+# 设备上的临时目录；用 /data/local/tmp 是因为它一定可写、且能直接 pull
+DEVICE_TMP_DIR = "/data/local/tmp"
+# 请求码率。Android 对 720p60 有 width*height*fps/5 ≈ 11Mbps 的下限，
+# 传更小的值也会被抬高，所以这里只是个声明性的下限
+DEVICE_BITRATE = 4_000_000
+# screenrecord 的单段时长上限（--time-limit 的默认值与最大值都是 180）
+DEVICE_TIME_LIMIT = 180
+# 启动后等待进程存活的时间（秒）：立刻退出说明设备上根本跑不起来。
+# 这里只拦「一行命令都跑不起来」的情况（例如设备没有 nohup），编码器起不来
+# 会在收尾时通过设备端 stderr 报出来，所以不必在这里等太久。
+START_TIMEOUT = 0.6
+# SIGINT 后等待 recorder 写完文件并退出的上限（秒）
+STOP_TIMEOUT = 6.0
+# 轮询设备状态的间隔（秒）。抽成常量是为了让单测不必真的等
+POLL_INTERVAL = 0.2
+# 单条 adb 命令的超时（秒）
+ADB_TIMEOUT = 20
+# 转码超时：按片段长度放宽，但不超过这个上限（秒）
+TRANSCODE_BASE_TIMEOUT = 60.0
+TRANSCODE_MAX_TIMEOUT = 600.0
 
 _ACTIVE = None  # 当前活动的录制会话
 _FFMPEG_CACHE = None  # ffmpeg 探测结果缓存，None 表示尚未探测
@@ -169,6 +175,155 @@ def _even_size(width, height):
         tuple: (偶数宽度, 偶数高度)。
     """
     return width - width % 2, height - height % 2
+
+
+def _adb_device(serial):
+    """取当前实例对应的 adb 设备句柄。
+
+    和 `module.device.connection_attr` 一样从 127.0.0.1 的 adb server 连，
+    端口允许用 ANDROID_ADB_SERVER_PORT 环境变量覆盖。
+
+    Args:
+        serial (str): 设备序列号。
+
+    Returns:
+        AdbDevice: 与 serial 绑定的设备对象。
+    """
+    port = 5037
+    env = os.environ.get("ANDROID_ADB_SERVER_PORT")
+    if env is not None:
+        try:
+            port = int(env)
+        except ValueError:
+            logger.warning(f"[录屏] 无效的环境变量 ANDROID_ADB_SERVER_PORT={env}，使用默认端口")
+    return AdbDevice(AdbClient("127.0.0.1", port), serial)
+
+
+def _parse_pid(text):
+    """从 shell 回显里取出 recorder 的进程号。
+
+    Args:
+        text (str): `echo $!` 的输出。
+
+    Returns:
+        int | None: 解析失败返回 None（例如 nohup 不存在时 shell 报的错）。
+    """
+    for token in str(text).split():
+        if token.isdigit():
+            return int(token)
+    return None
+
+
+def _parse_progress_duration(stdout):
+    """从 ffmpeg `-progress pipe:1` 的输出里取转码后的时长。
+
+    Args:
+        stdout (bytes): ffmpeg 写往 stdout 的进度流。
+
+    Returns:
+        float | None: 时长（秒）；解析不出来返回 None。
+    """
+    text = stdout.decode("utf-8", errors="replace") if stdout else ""
+    seconds = None
+    for line in text.splitlines():
+        if not line.startswith("out_time="):
+            continue
+        try:
+            hour, minute, second = line.split("=", 1)[1].strip().split(":")
+            seconds = int(hour) * 3600 + int(minute) * 60 + float(second)
+        except ValueError:
+            continue
+    return seconds
+
+
+def _stale_device_files(listing, now=None, max_age=TMP_MAX_AGE):
+    """从设备目录列表里挑出过期的临时文件。
+
+    录像文件名里带的是**本机**时间戳（`<前缀>YYYYMMDD_HHMMSS.mp4`），所以可以直接
+    和本机时钟比：只有超过 max_age 的才算残留（进程被强杀留下的）。这样就不会误删
+    别的实例正在录的那一段。
+
+    Args:
+        listing (str): `ls <前缀>*.mp4 <前缀>*.err` 的输出。
+        now (float): 当前时间戳，默认取本机时间。
+        max_age (float): 超过这么多秒视为残留。
+
+    Returns:
+        list: 需要删除的设备端路径。
+    """
+    now = time.time() if now is None else now
+    stale = []
+    for line in str(listing).replace("\r", "\n").split("\n"):
+        path = line.strip()
+        if not path.startswith(f"{DEVICE_TMP_DIR}/") or not path.endswith((".mp4", ".err")):
+            continue
+        # 只认自己的前缀：删的是用户设备上的文件，宁可漏删也不能误删
+        if not os.path.basename(path).startswith(CLIP_PREFIXES):
+            continue
+        match = re.search(r"_(\d{8})_(\d{6})\.(?:mp4|err)$", path)
+        if not match:
+            continue
+        try:
+            stamp = time.mktime(time.strptime(match.group(1) + match.group(2), "%Y%m%d%H%M%S"))
+        except ValueError:
+            continue
+        if now - stamp > max_age:
+            stale.append(path)
+    return stale
+
+
+def _adb_binary():
+    """adb 可执行文件路径。
+
+    优先用 ALAS 已经探测/配置好的那个（adbutils 的全局 adb_path），
+    拿不到再退回 PATH 里的 adb。
+
+    Returns:
+        str | None: 找不到返回 None。
+    """
+    try:
+        import adbutils
+
+        exe = adbutils.adb_path()
+    except Exception:
+        exe = None
+    return exe or shutil.which("adb")
+
+
+def _run_adb_cli(args, timeout=ADB_TIMEOUT):
+    """用 adb 命令行执行一条命令并取回 stdout。
+
+    只用于「必须在设备上留下一个独立进程」的场景（启动 screenrecord），
+    见 `_ScreenRecordClip._launch()` 的说明。
+
+    Args:
+        args (list): adb 子命令，例如 ['shell', 'echo hi']。
+        timeout (float): 超时秒数。
+
+    Returns:
+        str | None: 成功返回 stdout 文本；失败返回 None 并记录原因。
+    """
+    exe = _adb_binary()
+    if not exe:
+        logger.error("[录屏] 找不到 adb 可执行文件，无法执行设备命令")
+        return None
+    cmd = [exe] + list(args)
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            creationflags=subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.error(f"[录屏] 执行 adb 失败: {e}")
+        return None
+    if proc.returncode != 0:
+        reason = proc.stderr.decode("utf-8", errors="replace").strip()
+        logger.error(f"[录屏] adb 返回码 {proc.returncode}: {reason[-400:]}")
+        return None
+    return proc.stdout.decode("utf-8", errors="replace")
 
 
 def cleanup_clips(retention_days, output_dir=DEFAULT_OUTPUT_DIR):
@@ -260,563 +415,356 @@ def cleanup_clips_if_due(config, output_dir=DEFAULT_OUTPUT_DIR):
     return cleanup_clips(days, output_dir)
 
 
-class _ScrcpyClip:
-    """一个基于 scrcpy 设备视频流的 debug 录屏段。"""
+class _ScreenRecordClip:
+    """一个基于设备端 screenrecord 的 debug 录屏段。
 
-    def __init__(self, config, fps=RECORD_FPS, prefix=CLIP_PREFIX_EH1,
-                 width=1280, bitrate_scale=1.0):
+    录制在设备上完成，本类的职责只有三件事：把 recorder 拉起来、按需把它停下来、
+    把产物拉回本地并转码。因此除了 `start()` / `finalize()`，其余方法都是围绕
+    「问设备要信息」展开的，全部失败路径都只记日志、不抛异常。
+    """
+
+    _scrcpy_warned = False  # 截图方式为 scrcpy 的提示只打一次
+
+    def __init__(self, config, fps=RECORD_FPS, prefix=CLIP_PREFIX_EH1):
         self.config = config
         self.fps = fps
         self.prefix = prefix
-        self.width = width
-        self.bitrate_scale = bitrate_scale
         self.output_dir = DEFAULT_OUTPUT_DIR
-        self.tmp_path = None
-        self.dec_log_path = None
-        self.enc_log_path = None
-        self._core = None
-        self.video_socket = None
-        self.control_socket = None
-        self.server_stream = None
+        self.adb = None  # start() 里建立；测试可直接注入假的
+        self.serial = None  # start() 里从配置读取
+        self.remote_path = None  # 设备上的录像文件
+        self.remote_error_path = None  # 设备上 recorder 的 stderr
+        self.pid = None
+        self.size = None  # 传给 screenrecord 的 --size，None 表示让设备自己决定
         self.alive = False
-        self.resolution = (1280, 720)
-        self.frame_size = 1280 * 720 * 3  # 单帧 bgr24 字节数
-        self._dec = None  # ffmpeg: h264 -> rawvideo
-        self._enc = None  # ffmpeg: rawvideo -> mp4
-        self._dec_log = None
-        self._enc_log = None
-        self._socket_thread = None
-        self._decode_thread = None
-        self._pace_thread = None
-        self._frames = queue.Queue(maxsize=1)  # 解码线程 -> 节流线程，只留最新帧
-        self._decoder_done = threading.Event()
-        self._stop = threading.Event()
         self._started_at = None
         self._stopped_at = None
-        self._drain_deadline = float('inf')  # 收尾排空的截止时刻，finalize 里设置
-        self._error = None  # 首个致命错误，仅用于诊断
-        self._frames_decoded = 0
-        self._frames_written = 0
-        self._lags = 0
+        self._error = None
 
-    # ------------------------------------------------ scrcpy 视频流
-    @property
-    def _bitrate(self):
-        # scrcpy 1.20 超过 20Mbps 会回落，保守限制在 20Mbps 内
-        base = max(1, self.width * int(self.width * 9 / 16) * self.fps)
-        bitrate = int(base * 0.20 * self.bitrate_scale)
-        return max(300_000, min(bitrate, 20_000_000))
-
-    def _open_scrcpy(self):
-        """启动 scrcpy-server 并完成握手。
-
-        Raises:
-            Exception: 任意环节失败。失败时已建立的 socket / server 进程会被
-                `_close_scrcpy` 回收（调用方负责），不会泄漏到设备上。
-        """
-        from module.device.method.scrcpy.core import ScrcpyCore
-        from module.device.method.scrcpy.options import ScrcpyOptions
-
-        core = ScrcpyCore(self.config)
-        self._core = core
-        core.adb_push(self.config.SCRCPY_FILEPATH_LOCAL, self.config.SCRCPY_FILEPATH_REMOTE)
-
-        # 显式把帧率传进去，不再临时改写 ScrcpyOptions.frame_rate 这个全局类属性
-        commands = ScrcpyOptions.command_v120(
-            jar_path=self.config.SCRCPY_FILEPATH_REMOTE, frame_rate=self.fps
-        )
-        # scrcpy-server 1.20 参数位置：max_size、bitrate、max_fps
-        commands[6] = str(self.width)
-        commands[7] = str(self._bitrate)
-        commands[8] = str(self.fps)
-
-        server_stream = core.adb.shell(commands, stream=True)
-        self.server_stream = server_stream
-        server_stream.conn.settimeout(3)
-
-        ret = server_stream.read(10)
-        if b"Aborted" in ret:
-            raise RuntimeError("scrcpy-server 启动失败：Aborted")
-        if ret == b"[server] E":
-            ret += self._receive_more(server_stream)
-            raise RuntimeError(ret.decode("utf-8", errors="replace"))
-        ret += self._receive_more(server_stream)
-        if ret:
-            logger.info(f"[录屏] scrcpy-server: {ret.decode('utf-8', errors='replace').strip()}")
-
-        # 握手顺序：video socket -> control socket -> 1 字节占位 -> 64 字节设备名 -> 4 字节分辨率
-        self.video_socket = self._connect_scrcpy_socket(core)
-        if self._recv_exact(self.video_socket, 1) != b"\x00":
-            raise RuntimeError("scrcpy 视频流握手失败")
-        self.control_socket = self._connect_scrcpy_socket(core)
-        device_name = self._recv_exact(self.video_socket, 64).decode(
-            "utf-8", errors="replace"
-        ).rstrip("\x00")
-        if device_name:
-            logger.attr("[录屏] 设备", device_name)
-        resolution = self._recv_exact(self.video_socket, 4)
-        self.resolution = struct.unpack(">HH", resolution)
-        self.video_socket.settimeout(1)
-
-        if self.resolution[0] <= 0 or self.resolution[1] <= 0:
-            raise RuntimeError(f"scrcpy 返回了非法分辨率: {self.resolution}")
-
-        self.alive = True
-        logger.attr("[录屏] 分辨率", self.resolution)
-
-    @staticmethod
-    def _recv_exact(sock, size):
-        """从 socket 上读满 size 字节。
-
-        socket.recv(n) 只保证「最多 n 字节」，小端数据也可能被拆包，必须循环读满。
-
-        Args:
-            sock (socket.socket): 已连接的 socket。
-            size (int): 需要读取的字节数。
-
-        Returns:
-            bytes: 长度恰好为 size 的数据。
-
-        Raises:
-            RuntimeError: 连接在读满之前关闭。
-        """
-        buf = bytearray()
-        while len(buf) < size:
-            chunk = sock.recv(size - len(buf))
-            if not chunk:
-                raise RuntimeError(
-                    f"scrcpy 握手期间连接中断（{len(buf)}/{size} 字节）"
-                )
-            buf += chunk
-        return bytes(buf)
-
-    @staticmethod
-    def _receive_more(server_stream, timeout=0.5):
-        """尽力读取 scrcpy-server 的启动日志（仅用于诊断，读不到不算失败）。
-
-        Args:
-            server_stream: adb shell 流。
-            timeout (float): 单次读取的最长等待。旧实现硬编码 3 秒，服务器没有更多
-                输出时会让每次开录白白多等 3 秒。
-
-        Returns:
-            bytes: 读到的内容，没有则返回 b""。
-        """
-        try:
-            old_timeout = server_stream.conn.gettimeout()
-            server_stream.conn.settimeout(timeout)
-            try:
-                return server_stream.conn.recv(4096)
-            finally:
-                server_stream.conn.settimeout(old_timeout)
-        except Exception:
-            return b""
-
-    def _connect_scrcpy_socket(self, core):
-        """连接 scrcpy 的 abstract socket（video / control 各一条）。
-
-        Args:
-            core (ScrcpyCore): scrcpy 核心对象。
-
-        Returns:
-            socket.socket: 已连接的 socket。
-
-        Raises:
-            RuntimeError: 3 秒内连不上。
-        """
-        deadline = time.time() + 3
-        while time.time() < deadline:
-            try:
-                sock = core.adb.create_connection(Network.LOCAL_ABSTRACT, "scrcpy")
-                sock.settimeout(3)
-                return sock
-            except AdbError:
-                time.sleep(0.1)
-        raise RuntimeError("连接 scrcpy socket 超时")
-
-    # ------------------------------------------------ 生命周期
+    # ------------------------------------------------ 启动
     def start(self):
-        """启动 scrcpy 流 + 解码/编码管线。
+        """拉起设备端 recorder。
 
         Returns:
             bool: 成功返回 True；失败会记录具体原因并返回 False（不影响游戏逻辑）。
         """
-        ffmpeg = _ffmpeg_path()
-        if not ffmpeg:
-            logger.error(
-                "[录屏] 未找到可用的 ffmpeg，debug 录屏无法工作。"
-                "请执行 `uv sync` 安装 imageio-ffmpeg，或自行安装 ffmpeg 并加入 PATH"
-            )
-            return False
-        if str(self.config.Emulator_ScreenshotMethod).lower().startswith("scrcpy"):
-            logger.warning("[录屏] 截图方式为 scrcpy，无法并存第二条视频流，本次跳过录制")
-            return False
         try:
             os.makedirs(self.output_dir, exist_ok=True)
         except OSError as e:
             logger.error(f"[录屏] 创建输出目录失败: {e}")
             return False
 
+        self.serial = str(getattr(self.config, "Emulator_Serial", "") or "")
+        if not self.serial:
+            logger.warning("[录屏] 配置里没有 Emulator_Serial，本次不录制")
+            return False
+        method = str(getattr(self.config, "Emulator_ScreenshotMethod", "") or "")
+        if method.lower().startswith("scrcpy") and not _ScreenRecordClip._scrcpy_warned:
+            # 旧实现会和 scrcpy 截图抢同一个 abstract socket 而必须跳过；
+            # 现在没有 socket 冲突，只是设备上会多一路视频编码，出问题先怀疑这里。
+            # 每轮都提醒会变成噪音，所以一个进程只提醒一次。
+            _ScreenRecordClip._scrcpy_warned = True
+            logger.warning(
+                "[录屏] 当前截图方式为 scrcpy，设备上会同时存在两路视频编码，"
+                "若截图或录像出现异常请临时关掉录像"
+            )
         try:
-            self._open_scrcpy()
+            self.adb = self.adb or _adb_device(self.serial)
         except Exception as e:
-            self._close_scrcpy()
-            logger.error(f"[录屏] scrcpy 启动失败，本次不录制: {e}")
+            logger.error(f"[录屏] 连接 ADB 失败，本次不录制: {e}")
             return False
 
-        raw_width, raw_height = self.resolution
-        enc_width, enc_height = _even_size(raw_width, raw_height)
-        if (enc_width, enc_height) != (raw_width, raw_height):
-            logger.warning(
-                f"[录屏] 设备分辨率 {raw_width}x{raw_height} 含奇数边，"
-                f"H.264 要求宽高为偶数，编码时裁剪为 {enc_width}x{enc_height}"
-            )
-        self.frame_size = raw_width * raw_height * 3  # bgr24
-
         ts = time.strftime("%Y%m%d_%H%M%S")
-        self.tmp_path = os.path.join(self.output_dir, f"{TMP_PREFIX}{ts}.mp4")
-        self.dec_log_path = os.path.join(self.output_dir, f"{TMP_PREFIX}{ts}.dec.log")
-        self.enc_log_path = os.path.join(self.output_dir, f"{TMP_PREFIX}{ts}.enc.log")
+        self.remote_path = f"{DEVICE_TMP_DIR}/{self.prefix}{ts}.mp4"
+        self.remote_error_path = f"{DEVICE_TMP_DIR}/{self.prefix}{ts}.err"
+        self.size = self._device_size()
+        self._remove_stale_device_files()
+        if not self._launch():
+            self._remove_device_files()
+            return False
 
-        # 解码：裸 h264 -> rawvideo bgr24（收到即解，不解封包问题）
-        # probesize/analyzeduration 用最小值：默认的 5 秒分析缓冲会让解码器起播时
-        # 压住十几帧不吐，导致每段录像的开头几秒丢失。
-        dec_cmd = [
-            ffmpeg, "-hide_banner", "-loglevel", "error",
-            "-probesize", "32",
-            "-analyzeduration", "0",
-            "-f", "h264",
-            "-framerate", str(self.fps),
-            "-i", "pipe:0",
+        self._started_at = time.perf_counter()
+        self.alive = True
+        size_desc = f", {self.size}" if self.size else ""
+        logger.info(
+            f"[录屏] 开始录制（设备端 screenrecord{size_desc}，收尾转 {self.fps}fps）: {self.remote_path}"
+        )
+        return True
+
+    def _device_size(self):
+        """读取设备分辨率，作为 screenrecord 的 --size。
+
+        拿不到就让设备自己决定（screenrecord 默认用主显示器的分辨率），
+        这比猜一个尺寸更安全：--size 不被编码器支持时 recorder 会直接失败。
+
+        Returns:
+            str | None: 形如 "1280x720"；读取失败返回 None。
+        """
+        try:
+            window = self.adb.window_size()
+            width, height = _even_size(int(window.width), int(window.height))
+        except Exception as e:
+            logger.warning(f"[录屏] 读取设备分辨率失败，由 screenrecord 自行决定尺寸: {e}")
+            return None
+        if width <= 0 or height <= 0:
+            return None
+        return f"{width}x{height}"
+
+    def _recorder_command(self):
+        """拼出后台启动 screenrecord 的 shell 命令。
+
+        末尾 `echo $!` 回显进程号：收尾时按进程号发 SIGINT，比 `pidof screenrecord`
+        精确（设备上可能同时有别的进程在录屏）。stderr 落到设备上的文件，
+        失败时才有真实原因可报。
+        """
+        size = f"--size {self.size} " if self.size else ""
+        return (
+            f"nohup screenrecord --time-limit {DEVICE_TIME_LIMIT} "
+            f"--bit-rate {DEVICE_BITRATE} {size}{self.remote_path} "
+            f">/dev/null 2>{self.remote_error_path} </dev/null & echo $!"
+        )
+
+    def _launch(self):
+        """启动 recorder，并确认它没有立刻退出。
+
+        这一步刻意绕开 adbutils、直接用 adb 命令行：adbutils 的 shell 会话结束时，
+        设备上的后台子进程会被一起带走（nohup / setsid 都保不住，实测），而
+        screenrecord 必须活到本段结束。其余的前台查询仍然走 adbutils。
+
+        Returns:
+            bool: 成功返回 True。
+        """
+        output = _run_adb_cli(["-s", self.serial, "shell", self._recorder_command()])
+        if output is None:
+            return False
+
+        self.pid = _parse_pid(output)
+        if self.pid is None:
+            logger.error(f"[录屏] 启动 screenrecord 失败，设备未回显进程号: {output!r}")
+            return False
+
+        deadline = time.time() + START_TIMEOUT
+        while time.time() < deadline:
+            if not self._pid_alive():
+                logger.error(
+                    f"[录屏] screenrecord 启动后立刻退出，本段不录制"
+                    f"{self._device_error()}"
+                )
+                return False
+            time.sleep(POLL_INTERVAL)
+        return True
+
+    def _pid_alive(self):
+        """recorder 进程是否还在。"""
+        try:
+            output = self.adb.shell(
+                f"kill -0 {self.pid} 2>/dev/null && echo alive || echo gone"
+            )
+        except Exception:
+            return False
+        return "alive" in str(output)
+
+    def _device_error(self):
+        """读取设备端 recorder 的 stderr，把真实失败原因带给用户。
+
+        Returns:
+            str: 形如「｜设备端: xxx」；没有内容时返回空串。
+        """
+        if not self.remote_error_path:
+            return ""
+        try:
+            text = str(self.adb.shell(f"cat {self.remote_error_path} 2>/dev/null")).strip()
+        except Exception:
+            return ""
+        if not text:
+            return ""
+        return f"｜设备端: {text[-400:]}"
+
+    # ------------------------------------------------ 收尾
+    def _stop_recorder(self):
+        """发 SIGINT 让 recorder 收尾。
+
+        screenrecord 只有在收到中断、写完 moov atom 之后才会得到可播放的 mp4，
+        直接杀进程只会留下一堆无法播放的碎片。
+        """
+        if self.pid is None:
+            return
+        try:
+            # 先确认这个进程号还是 recorder：screenrecord 自己到点退出后，
+            # 进程号可能已经被别的进程复用，不能盲杀
+            self.adb.shell(
+                f"grep -q screenrecord /proc/{self.pid}/cmdline 2>/dev/null"
+                f" && kill -2 {self.pid}"
+            )
+        except Exception as e:
+            self._set_error(f"停止 screenrecord 失败: {e}")
+        stopped = False
+        deadline = time.time() + STOP_TIMEOUT
+        while time.time() < deadline:
+            if not self._pid_alive():
+                stopped = True
+                break
+            time.sleep(POLL_INTERVAL)
+        if not stopped:
+            self._set_error("等待 screenrecord 退出超时，录像可能不完整")
+        self._stopped_at = time.perf_counter()
+
+    def _file_size(self):
+        """设备上录像文件的字节数。
+
+        Returns:
+            int | None: 文件不存在或取不到时返回 None。
+        """
+        try:
+            output = str(self.adb.shell(f"stat -c %s {self.remote_path} 2>/dev/null")).strip()
+        except Exception:
+            return None
+        return int(output) if output.isdigit() else None
+
+    def _remove_device_files(self):
+        """删掉设备上的录像与它的 stderr（可重复调用，失败不抛异常）。"""
+        if not self.remote_path:
+            return
+        try:
+            self.adb.shell(f"rm -f {self.remote_path} {self.remote_error_path}")
+        except Exception as e:
+            logger.warning(f"[录屏] 清理设备上的临时录像失败: {e}")
+
+    def _remove_stale_device_files(self):
+        """清理设备上遗留的录像/err 文件。
+
+        进程被强杀时来不及删，它们会一直占着设备存储，所以每次开录前扫一遍。
+        只删超过 TMP_MAX_AGE 的（按文件名里的时间戳判断），避免误删正在录的那一段。
+        """
+        pattern = " ".join(f"{DEVICE_TMP_DIR}/{p}*" for p in CLIP_PREFIXES)
+        try:
+            listing = self.adb.shell(f"ls {pattern} 2>/dev/null")
+        except Exception as e:
+            logger.warning(f"[录屏] 查询设备上的历史临时文件失败: {e}")
+            return
+        stale = _stale_device_files(listing)
+        if not stale:
+            return
+        try:
+            self.adb.shell(f"rm -f {' '.join(stale)}")
+            logger.info(f"[录屏] 已清理设备上 {len(stale)} 个历史临时文件")
+        except Exception as e:
+            logger.warning(f"[录屏] 清理设备上的历史临时文件失败: {e}")
+
+    def _pull(self, local_path):
+        """把设备上的录像拉到本地。
+
+        Args:
+            local_path (str): 本地目标路径。
+
+        Returns:
+            bool: 成功返回 True。
+        """
+        try:
+            self.adb.sync.pull(self.remote_path, local_path)
+        except Exception as e:
+            self._fail(f"从设备拉取录像失败: {e}")
+            return False
+        return True
+
+    def _transcode(self, src, dst, elapsed):
+        """把设备录像转成 30fps 的小文件。
+
+        设备按刷新率录、码率有下限（720p60 约 11Mbps），直接留下来既大也没必要：
+        转成 30fps CRF 26 之后体积和旧的 scrcpy 管线是一个量级，时间轴仍是真实速度
+        （`-r` 只做抽帧/复制，不改变时长）。没有 ffmpeg 就保留原始文件，只是更大。
+
+        Args:
+            src (str): 拉回来的原始录像。
+            dst (str): 最终产物路径。
+            elapsed (float): 本段实际经过的秒数，用于放宽转码超时。
+
+        Returns:
+            float | None: 转码后的时长（秒）。返回 None 有两种情况：彻底没有产物，
+                或者产物有效但转码没成功（此时留下的是未转码的原始录像）。
+        """
+        ffmpeg = _ffmpeg_path()
+        if not ffmpeg:
+            logger.warning("[录屏] 未找到 ffmpeg，跳过转码，直接保留原始录像（文件会明显更大）")
+            try:
+                os.replace(src, dst)
+            except OSError as e:
+                self._fail(f"保存录像失败: {e}")
+                return None
+            return None
+
+        cmd = [
+            ffmpeg, "-y", "-hide_banner", "-loglevel", "error", "-nostats",
+            "-progress", "pipe:1",
+            "-i", src,
             "-an",
-            "-f", "rawvideo",
-            "-pix_fmt", "bgr24",
-            "pipe:1",
-        ]
-        # 编码：rawvideo -> libx264 mp4（帧由 python 按 1/fps 墙钟投喂）
-        enc_cmd = [
-            ffmpeg, "-y", "-hide_banner", "-loglevel", "error",
-            "-f", "rawvideo",
-            "-vcodec", "rawvideo",
-            "-s", f"{raw_width}x{raw_height}",
-            "-pix_fmt", "bgr24",
+            # 宽高都取偶：yuv420p 的 H.264 不接受奇数边长
+            "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2",
             "-r", str(self.fps),
-            "-i", "pipe:0",
-            "-an",
-        ]
-        if (enc_width, enc_height) != (raw_width, raw_height):
-            enc_cmd += ["-vf", f"crop={enc_width}:{enc_height}:0:0"]
-        enc_cmd += [
             "-c:v", "libx264",
             "-preset", "veryfast",
             "-crf", "26",
             "-pix_fmt", "yuv420p",
             "-movflags", "+faststart",
-            self.tmp_path,
+            dst,
         ]
-
-        # ffmpeg 的 stderr 落盘而不是 DEVNULL：既不会像管道那样写满阻塞，
-        # 又能在失败时把真实原因报给用户。
+        timeout = min(TRANSCODE_MAX_TIMEOUT, TRANSCODE_BASE_TIMEOUT + elapsed * 2)
+        reason = None
         try:
-            self._dec_log = open(self.dec_log_path, "wb")
-            self._enc_log = open(self.enc_log_path, "wb")
-            self._dec = subprocess.Popen(
-                dec_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                stderr=self._dec_log, bufsize=0,
+            proc = subprocess.run(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout
             )
-            self._enc = subprocess.Popen(
-                enc_cmd, stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
-                stderr=self._enc_log, bufsize=0,
-            )
-        except OSError as e:
-            logger.error(f"[录屏] 启动 ffmpeg 失败: {e}")
-            self._close_pipe(self._dec, "stdin")
-            self._wait_proc(self._dec, DECODER_EXIT_TIMEOUT)
-            self._close_log_files()
-            self._close_scrcpy()
-            self._discard()
-            return False
-
-        self._started_at = time.perf_counter()
-        self._socket_thread = threading.Thread(
-            target=self._socket_to_decoder, daemon=True
-        )
-        self._decode_thread = threading.Thread(
-            target=self._decode_loop, daemon=True
-        )
-        self._pace_thread = threading.Thread(
-            target=self._pace_loop, daemon=True
-        )
-        for th in (self._socket_thread, self._decode_thread, self._pace_thread):
-            th.start()
-        logger.info(
-            f"[录屏] 开始录制（真实画面 {self.fps}fps, {raw_width}x{raw_height}）: {self.tmp_path}"
-        )
-        return True
-
-    # ------------------------------------------------ 工作线程
-    def _socket_to_decoder(self):
-        """把 scrcpy 裸 H.264 喂给解码器；EOF/停止/出错时关闭解码器输入。"""
-        # 取局部引用：finalize 会把 self.video_socket 置 None，避免竞态
-        sock = self.video_socket
-        try:
-            while not self._stop.is_set() and self.alive and sock is not None:
-                try:
-                    data = sock.recv(0x10000)
-                except socket.timeout:
-                    continue
-                except (ConnectionError, OSError) as e:
-                    if not self._stop.is_set():
-                        self._set_error(f"scrcpy 视频流中断: {e}")
-                    break
-                if not data:
-                    if not self._stop.is_set():
-                        self._set_error("scrcpy 视频流提前结束")
-                    break
-                try:
-                    self._dec.stdin.write(data)
-                    self._dec.stdin.flush()
-                except Exception as e:
-                    if not self._stop.is_set():
-                        self._set_error(f"写入解码器失败: {e}")
-                    break
-        finally:
-            # 让解码器收到 EOF，把缓冲里的帧吐完再退出
-            self._close_pipe(self._dec, "stdin")
-
-    def _decode_loop(self):
-        """把解码器的 rawvideo 逐帧塞进队列，只保留最新一帧。
-
-        只留最新帧可避免积压：一旦编码跟不上，队列不会无限增长导致视频延迟越来越大。
-        """
-        try:
-            while True:
-                data = self._read_exact(self.frame_size)
-                if data is None:
-                    break
-                self._frames_decoded += 1
-                try:
-                    self._frames.get_nowait()
-                except queue.Empty:
-                    pass
-                try:
-                    self._frames.put_nowait(data)
-                except queue.Full:
-                    pass
-        finally:
-            self._decoder_done.set()
-
-    def _pace_loop(self):
-        """按 1/fps 的墙钟节奏把帧交给编码器（本模块的核心）。
-
-        每个时间点取一次队列：有新帧用新帧，没有就复用上一帧。因此源帧率高于
-        30fps 时自动丢帧、低于 30fps 时自动补帧，**播放速度**恒等于真实速度。
-        （总时长还会受解码器起播预读影响，见模块 docstring。）
-        """
-        interval = 1.0 / self.fps
-        last_frame = None
-        next_t = time.perf_counter()
-        try:
-            while not self._stop.is_set():
-                now = time.perf_counter()
-                if now < next_t:
-                    # 用 Event.wait 而不是 sleep：finalize 时能立刻醒来
-                    self._stop.wait(max(0.001, min(next_t - now, interval)))
-                    continue
-
-                # 取走队列中的最新帧（旧帧直接丢弃）
-                while True:
-                    try:
-                        last_frame = self._frames.get_nowait()
-                    except queue.Empty:
-                        break
-
-                if last_frame is not None:
-                    try:
-                        self._enc.stdin.write(last_frame)
-                        self._enc.stdin.flush()
-                        self._frames_written += 1
-                    except Exception as e:
-                        if not self._stop.is_set():
-                            self._set_error(f"写入编码器失败: {e}")
-                        break
-
-                next_t += interval
-                now = time.perf_counter()
-                if next_t < now and now - next_t > MAX_LAG:
-                    # 落后不超过 MAX_LAG 时靠连续投喂追平（时间轴保持对齐）；
-                    # 超过说明编码根本跟不上，重新对齐并计数，否则会无休止追赶。
-                    self._lags += 1
-                    next_t = now
-
-            self._drain_decoder()
-        finally:
-            self._close_pipe(self._enc, "stdin")
-
-    def _drain_decoder(self):
-        """收尾：把解码器还压着的帧全部写进编码器。
-
-        ffmpeg 解码器有固定的起播缓冲（实测 ~19 帧），这些帧只有在拿到后续帧或
-        收到 EOF 之后才会吐出来。若不管它们，每段录像都会少掉结尾一截。
-        这里只写真实新帧、不再补帧，写完后编码器的时间轴正好补齐。
-        """
-        while True:
-            drained = False
-            while True:
-                try:
-                    frame = self._frames.get_nowait()
-                except queue.Empty:
-                    break
-                try:
-                    self._enc.stdin.write(frame)
-                    self._enc.stdin.flush()
-                    self._frames_written += 1
-                    drained = True
-                except Exception:
-                    return
-
-            if self._decoder_done.is_set() and self._frames.empty():
-                return
-            if self._decode_thread is None:
-                # 没有解码线程在跑（例如只驱动节流线程的场景），不会再有新帧
-                return
-            if time.perf_counter() > self._drain_deadline:
-                self._set_error("收尾时解码器仍未吐出全部帧，录像结尾可能缺失")
-                return
-            if not drained:
-                time.sleep(0.005)
-
-    def _read_exact(self, size):
-        """从解码器 stdout 读满一帧 rawvideo。
-
-        Args:
-            size (int): 单帧字节数。
-
-        Returns:
-            bytes: 完整的一帧；EOF 返回 None；帧不完整（管线断裂）时记录原因并返回 None。
-        """
-        buf = bytearray(size)
-        view = memoryview(buf)
-        got = 0
-        try:
-            while got < size:
-                n = self._dec.stdout.readinto(view[got:])
-                if n is None or n <= 0:
-                    break
-                got += n
-        except Exception as e:
-            self._set_error(f"读取解码器输出失败: {e}")
-            return None
-        if got == 0:
-            return None
-        if got < size:
-            self._set_error(
-                f"解码器输出在帧中途结束（{got}/{size} 字节），本段录像提前终止"
-            )
-            return None
-        return bytes(buf)
-
-    def _close_scrcpy(self):
-        """关闭 scrcpy 相关的 socket 与 server 流（可重复调用）。"""
-        self.alive = False
-        for obj in (self.control_socket, self.video_socket, self.server_stream):
-            if obj is None:
-                continue
+        except (OSError, subprocess.SubprocessError) as e:
+            reason = f"转码失败: {e}"
+            proc = None
+        if proc is not None and proc.returncode != 0:
+            output = proc.stderr.decode("utf-8", errors="replace").strip()
+            reason = f"转码失败（返回码 {proc.returncode}）｜{output[-400:]}"
+        elif proc is not None:
             try:
-                obj.close()
-            except Exception:
-                pass
-        self.control_socket = None
-        self.video_socket = None
-        self.server_stream = None
-
-    # ------------------------------------------------ 收尾
-    @staticmethod
-    def _close_pipe(proc, name):
-        """关闭子进程的 stdin，相当于给 ffmpeg 发 EOF。可重复调用。"""
-        if proc is None:
-            return
-        pipe = getattr(proc, name, None)
-        if pipe is None:
-            return
-        try:
-            pipe.close()
-        except Exception:
-            pass
-
-    @staticmethod
-    def _wait_proc(proc, timeout):
-        """等待子进程退出，超时则强杀。
-
-        Args:
-            proc (subprocess.Popen): 子进程。
-            timeout (float): 等待秒数。
-
-        Returns:
-            bool: 在超时前自行退出返回 True；被强杀返回 False（产物不可信）。
-        """
-        if proc is None:
-            return True
-        try:
-            proc.wait(timeout=timeout)
-            return True
-        except Exception:
-            pass
-        try:
-            proc.terminate()
-        except Exception:
-            pass
-        try:
-            proc.wait(timeout=5)
-        except Exception:
-            pass
-        return False
-
-    def _close_log_files(self):
-        """关闭 ffmpeg stderr 日志文件句柄。"""
-        for log_file in (self._dec_log, self._enc_log):
-            if log_file is None:
-                continue
-            try:
-                log_file.close()
-            except Exception:
-                pass
-        self._dec_log = None
-        self._enc_log = None
-
-    def _set_error(self, reason):
-        """记录首个致命错误（多线程调用，只保留第一条）。"""
-        if self._error is None:
-            self._error = reason
-
-    def _ffmpeg_stderr_tail(self, limit=600):
-        """读取两个 ffmpeg 的错误输出尾部，用于把失败原因暴露给用户。
-
-        Args:
-            limit (int): 每个子进程最多取多少字符。
-
-        Returns:
-            str: 形如「｜编码器: xxx」的拼接文本；没有内容时返回空串。
-        """
-        parts = []
-        for name, path in (("解码器", self.dec_log_path), ("编码器", self.enc_log_path)):
-            if not path:
-                continue
-            try:
-                with open(path, "rb") as f:
-                    f.seek(0, os.SEEK_END)
-                    f.seek(max(0, f.tell() - limit * 4))
-                    data = f.read(limit * 4)
+                if os.path.getsize(dst) >= MIN_VALID_BYTES:
+                    return _parse_progress_duration(proc.stdout)
             except OSError:
-                continue
-            text = data.decode("utf-8", errors="replace").strip()
-            if text:
-                # 取尾部：真正导致失败的那条错误通常在最后
-                parts.append(f"｜{name}: {text[-limit:]}")
-        return "".join(parts)
+                pass
+            reason = "转码产物无效"
 
-    def _remove_file(self, path):
-        """尽力删除一个文件（Windows 上可能被占用，重试几次）。"""
+        # 转码失败也尽量保住原始画面：它本身是有效录像，只是更大、帧率更高
+        logger.error(f"[录屏] {reason}，改为保留未转码的原始录像（文件会明显更大）")
+        try:
+            os.replace(src, dst)
+        except OSError as e:
+            self._fail(f"{reason}，原始录像也无法保留: {e}")
+            return None
+        return None
+
+    def _report(self, path, duration):
+        """汇报保存结果，并把「录像比实际短」这类偏差显式提示出来。"""
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            size = 0
+        desc = f"{duration:.1f}s" if duration else "时长未解析"
+        logger.info(f"[录屏] 已保存: {path} ({size / 1024 / 1024:.1f} MB, 时长 {desc})")
+
+        if duration:
+            if duration >= DEVICE_TIME_LIMIT - 2:
+                logger.warning(
+                    f"[录屏] 本段达到设备端 {DEVICE_TIME_LIMIT} 秒上限，之后的画面没有录到；"
+                    f"需要更长的录像请反馈"
+                )
+            elapsed = 0.0
+            if self._started_at is not None and self._stopped_at is not None:
+                elapsed = max(0.0, self._stopped_at - self._started_at)
+            if elapsed > 10 and duration < elapsed * 0.8:
+                logger.warning(
+                    f"[录屏] 录像时长 {duration:.1f}s 明显短于实际经过的 {elapsed:.1f}s，请留意"
+                )
+        if self._error:
+            logger.warning(f"[录屏] 录制期间出现异常: {self._error}")
+
+    @staticmethod
+    def _remove_file(path):
+        """尽力删除本地文件（Windows 上可能被占用，重试几次）。"""
         if not path:
             return
         for _ in range(3):
@@ -828,74 +776,18 @@ class _ScrcpyClip:
             except OSError:
                 time.sleep(0.2)
 
-    def _discard(self):
-        """删除本次录制的全部临时文件（不保留的片段，或判定为无效的片段）。"""
-        for path in (self.tmp_path, self.dec_log_path, self.enc_log_path):
-            self._remove_file(path)
+    def _set_error(self, reason):
+        """记录首个异常（只保留第一条，便于定位）。"""
+        if self._error is None:
+            self._error = reason
 
     def _fail(self, reason):
         """产物无效时统一报错，绝不谎报「已保存」。"""
-        logger.error(f"[录屏] 本段录像未保存: {reason}{self._ffmpeg_stderr_tail()}")
-
-    def _keep_record(self, encoder_ok, elapsed):
-        """校验并保存本段录像。
-
-        Args:
-            encoder_ok (bool): 编码器是否正常收尾。
-            elapsed (float): 本段实际经过的秒数。
-
-        Returns:
-            str: 最终 mp4 路径；产物无效时返回 None 并记录具体原因。
-        """
-        if self._frames_written <= 0:
-            self._fail(
-                "本段没有捕获到任何画面帧"
-                "（scrcpy 在画面完全静止时不产生帧）"
-            )
-            return None
-        if not self.tmp_path or not os.path.exists(self.tmp_path):
-            self._fail("ffmpeg 没有生成输出文件")
-            return None
-
-        size = os.path.getsize(self.tmp_path)
-        if not encoder_ok:
-            self._fail(f"编码器未能正常收尾，录像不完整（{size} 字节）")
-            return None
-        if size < MIN_VALID_BYTES:
-            self._fail(f"录像文件只有 {size} 字节，判定为无效")
-            return None
-
-        final_path = os.path.join(
-            self.output_dir, f"{self.prefix}{time.strftime('%Y%m%d_%H%M%S')}.mp4"
-        )
-        try:
-            os.replace(self.tmp_path, final_path)
-        except OSError as e:
-            self._fail(f"保存录像失败: {e}")
-            return None
-
-        video_seconds = self._frames_written / self.fps
-        logger.info(
-            f"[录屏] 已保存: {final_path} "
-            f"({size / 1024 / 1024:.1f} MB, 时长 {video_seconds:.1f}s)"
-        )
-        # 旧版在这里是静默的：用户只会拿到一段被压缩时长、看起来「加速」的录像
-        if elapsed > 5 and video_seconds < elapsed * 0.8:
-            logger.warning(
-                f"[录屏] 录像时长 {video_seconds:.1f}s 明显短于实际经过的 {elapsed:.1f}s，"
-                f"画面帧率过低或编码跟不上，这段视频会比真实情况快"
-            )
-        if self._lags:
-            logger.warning(
-                f"[录屏] 录制期间有 {self._lags} 次编码跟不上，视频时间轴可能不连续"
-            )
-        if self._error:
-            logger.warning(f"[录屏] 录制期间出现异常: {self._error}")
-        return final_path
+        logger.error(f"[录屏] 本段录像未保存: {reason}")
 
     # ------------------------------------------------ 对外入口
     def finalize(self, keep):
-        """结束录制：停流、收尾 ffmpeg、校验产物，决定保留还是删除。
+        """结束录制：停流、拉取转码、校验产物，决定保留还是删除。
 
         本函数保证不抛异常（异常也只会退化成「没有产物」），避免调用方的
         finally 里再炸一次。
@@ -904,72 +796,71 @@ class _ScrcpyClip:
             keep (bool): 是否保留本段录像。
 
         Returns:
-            str: 保留且产物有效时返回最终 mp4 路径；丢弃或产物无效时返回 None。
+            str: 保留且产物有效时返回最终 mp4 路径；丢弃或无效时返回 None。
         """
         try:
             return self._finalize(keep)
         except Exception as e:
             logger.error(f"[录屏] 结束录制时发生异常，本段录像丢弃: {e}")
             try:
-                self._stop.set()
-                self._close_scrcpy()
-            except Exception:
-                pass
-            try:
-                self._discard()
+                self._remove_device_files()
             except Exception:
                 pass
             return None
 
     def _finalize(self, keep):
         """finalize 的实际实现。"""
-        self._stop.set()
-        self._stopped_at = time.perf_counter()
-        # 给节流线程留出排空解码器缓冲的时间，超时就不再等
-        self._drain_deadline = self._stopped_at + DRAIN_TIMEOUT
-        self._close_scrcpy()
-        # 主动关闭解码器输入：即使喂帧线程卡在 write 上，解码器也能收到 EOF 而退出
-        self._close_pipe(self._dec, "stdin")
+        self._stop_recorder()
+        self.alive = False
+        try:
+            if not keep:
+                return None
+            elapsed = 0.0
+            if self._started_at is not None and self._stopped_at is not None:
+                elapsed = max(0.0, self._stopped_at - self._started_at)
 
-        for th in (self._socket_thread, self._decode_thread, self._pace_thread):
-            if th is not None:
-                th.join(timeout=JOIN_TIMEOUT)
+            size = self._file_size()
+            if not size:
+                if elapsed < 2:
+                    logger.warning("[录屏] 本段录制时间过短，设备端没有产出录像，本段跳过")
+                else:
+                    self._fail(f"设备端 screenrecord 没有产出录像文件{self._device_error()}")
+                return None
+            if size < MIN_VALID_BYTES:
+                self._fail(
+                    f"设备端录像只有 {size} 字节，判定为无效{self._device_error()}"
+                )
+                return None
 
-        # 线程都停了再关编码器输入，触发它收尾（pace 线程可能已经关过）
-        self._close_pipe(self._enc, "stdin")
+            ts = time.strftime("%Y%m%d_%H%M%S")
+            tmp_path = os.path.join(self.output_dir, f"{TMP_PREFIX}{ts}.mp4")
+            if not self._pull(tmp_path):
+                # 拉取失败时本地可能留下半截文件，不能让它占着目录
+                self._remove_file(tmp_path)
+                return None
 
-        # 编码器必须自己写完 moov atom：硬杀只会得到不可播放的废文件
-        encoder_ok = self._wait_proc(self._enc, ENCODER_EXIT_TIMEOUT)
-        # 解码器已经收到 EOF，正常会立刻退出；被杀不影响已编码的产物
-        self._wait_proc(self._dec, DECODER_EXIT_TIMEOUT)
-        self._close_log_files()
-
-        elapsed = 0.0
-        if self._started_at is not None and self._stopped_at is not None:
-            elapsed = max(0.0, self._stopped_at - self._started_at)
-
-        result = None
-        if keep:
-            result = self._keep_record(encoder_ok, elapsed)
-        if result is None:
-            self._discard()
-        else:
-            # 保存成功：诊断日志已完成使命，录像目录里只应留下 mp4
-            self._remove_file(self.dec_log_path)
-            self._remove_file(self.enc_log_path)
-        return result
+            final_path = os.path.join(self.output_dir, f"{self.prefix}{ts}.mp4")
+            duration = self._transcode(tmp_path, final_path, elapsed)
+            self._remove_file(tmp_path)
+            if not os.path.exists(final_path):
+                return None
+            self._report(final_path, duration)
+            return final_path
+        finally:
+            # 无论成功失败，设备上的临时文件都不能留
+            self._remove_device_files()
 
 
 def clip_start(config, fps=RECORD_FPS, prefix=CLIP_PREFIX_EH1):
     """打开录屏。
 
     Args:
-        config: 当前运行实例的 AzurLaneConfig（含 serial / scrcpy 路径配置）。
-        fps (int): 目标帧率。
+        config: 当前运行实例的 AzurLaneConfig（含 serial 配置）。
+        fps (int): 输出帧率（设备端录制帧率由设备决定，收尾时转成这个帧率）。
         prefix (str): 输出文件名前缀，用于区分是哪个任务录的。
 
     Returns:
-        _ScrcpyClip: 录制句柄；启动失败返回 None。
+        _ScreenRecordClip: 录制句柄；启动失败返回 None。
     """
     global _ACTIVE
     if _ACTIVE is not None:
@@ -978,7 +869,7 @@ def clip_start(config, fps=RECORD_FPS, prefix=CLIP_PREFIX_EH1):
         logger.warning("[录屏] 上一段录制未正常结束，先收尾再开始新的一段")
         _finalize_active(keep=True)
 
-    rec = _ScrcpyClip(config, fps=fps, prefix=prefix)
+    rec = _ScreenRecordClip(config, fps=fps, prefix=prefix)
     if not rec.start():
         return None
     _ACTIVE = rec
@@ -1032,7 +923,7 @@ def clip_recording(config, enabled, prefix=CLIP_PREFIX_EH1):
         prefix (str): 输出文件名前缀，用于区分是哪个任务录的。
 
     Yields:
-        _ScrcpyClip | None: 录制句柄；未开启或启动失败时为 None。
+        _ScreenRecordClip | None: 录制句柄；未开启或启动失败时为 None。
     """
     clip = clip_start(config, prefix=prefix) if enabled else None
     try:

--- a/tests/test_debug_clip.py
+++ b/tests/test_debug_clip.py
@@ -1,16 +1,13 @@
-"""验证 debug 录屏的补帧/丢帧节奏、产物校验与录像清理策略。
+"""验证 debug 录屏的设备端命令、产物校验与录像清理策略。
 
-这些测试不依赖模拟器与真实 ffmpeg：需要子进程的地方用假对象替代，
-节奏相关的测试则直接驱动工作线程，验证「源帧率低时补帧、高时丢帧」。
+这些测试不依赖模拟器和真实 ffmpeg：设备被 `_FakeAdb` 取代，转码用假实现，
+只有纯逻辑（命令拼装、进程号/时长解析、清理规则、会话管理）被真正执行。
 """
 
-import io
 import os
-import queue
 import shutil
 import subprocess
 import tempfile
-import threading
 import time
 import unittest
 from types import SimpleNamespace
@@ -19,38 +16,62 @@ from unittest.mock import patch
 from module.base import debug_clip
 
 
-class _FakeProc:
-    """假的 subprocess.Popen，用于验证等待/强杀逻辑。"""
+class _FakeAdb:
+    """假的 adb 设备：记录 shell 命令，并按命令内容给出预设回复。
 
-    def __init__(self, exits=True):
-        self.exits = exits
-        self.terminated = False
+    只看前台查询（进程存活、文件大小、stderr、清理）；启动 recorder 走的是 adb
+    命令行，由 `_run_adb_cli` 的假实现负责。
+    """
 
-    def wait(self, timeout=None):
-        if self.exits:
-            return 0
-        raise subprocess.TimeoutExpired('cmd', timeout)
+    def __init__(self, pid='4321', file_size=200_000, error_text='',
+                 window=(1280, 720), pull_fails=False, alive=True,
+                 stays_alive=False, ls_listing=''):
+        self.commands = []
+        self.pid = pid
+        self.file_size = file_size
+        self.error_text = error_text
+        self.window = window
+        self.pull_fails = pull_fails
+        self.alive = alive
+        self.stays_alive = stays_alive
+        self.ls_listing = ls_listing
+        self.pulled = []
 
-    def terminate(self):
-        self.terminated = True
+    # ---- 设备接口
+    def shell(self, cmd):
+        self.commands.append(cmd)
+        if cmd.startswith('ls '):
+            return self.ls_listing
+        if cmd.startswith('kill -0'):
+            return 'alive' if self.alive else 'gone'
+        if 'kill -2' in cmd:
+            self.alive = self.stays_alive
+            return ''
+        if 'stat -c %s' in cmd:
+            return '' if self.file_size is None else str(self.file_size)
+        if cmd.startswith('cat '):
+            return self.error_text
+        return ''
+
+    def window_size(self):
+        if self.window is None:
+            raise RuntimeError('wm size failed')
+        return SimpleNamespace(width=self.window[0], height=self.window[1])
+
+    def sync_pull(self, src, dst):
+        if self.pull_fails:
+            raise RuntimeError('pull failed')
+        self.pulled.append((src, dst))
+        with open(dst, 'wb') as f:
+            f.write(b'x' * 20000)
+
+    def command_starting_with(self, prefix):
+        return [c for c in self.commands if c.startswith(prefix)]
 
 
-class _RecordingStdin:
-    """记录编码器收到的每一帧，替代 ffmpeg 的 stdin。"""
-
-    def __init__(self):
-        self.frames = []
-        self.closed = False
-
-    def write(self, data):
-        self.frames.append(data)
-        return len(data)
-
-    def flush(self):
-        pass
-
-    def close(self):
-        self.closed = True
+def make_fake_sync(adb):
+    """给 _FakeAdb 装一个 adbutils 风格的 sync 对象（只用到 pull）。"""
+    return SimpleNamespace(pull=adb.sync_pull)
 
 
 class ClipTestCase(unittest.TestCase):
@@ -66,12 +87,14 @@ class ClipTestCase(unittest.TestCase):
         debug_clip._LAST_CLEANUP = self._saved_cleanup
         shutil.rmtree(self.output_dir, ignore_errors=True)
 
-    def make_clip(self, fps=30):
-        rec = debug_clip._ScrcpyClip(config=None, fps=fps)
+    def make_clip(self, prefix=debug_clip.CLIP_PREFIX_EH1, adb=None):
+        rec = debug_clip._ScreenRecordClip(config=None, prefix=prefix)
         rec.output_dir = self.output_dir
-        rec.tmp_path = os.path.join(self.output_dir, '_tmp_eh1_test.mp4')
-        rec.dec_log_path = os.path.join(self.output_dir, '_tmp_eh1_test.dec.log')
-        rec.enc_log_path = os.path.join(self.output_dir, '_tmp_eh1_test.enc.log')
+        rec.remote_path = '/data/local/tmp/eh1_clip_test.mp4'
+        rec.remote_error_path = '/data/local/tmp/eh1_clip_test.err'
+        if adb is not None:
+            adb.sync = make_fake_sync(adb)
+            rec.adb = adb
         return rec
 
 
@@ -219,246 +242,311 @@ class TestFfmpegProbe(unittest.TestCase):
             self.assertEqual(works.call_count, first_calls)
 
 
-class TestWaitProc(unittest.TestCase):
-    def test_normal_exit(self):
-        proc = _FakeProc(exits=True)
-        self.assertTrue(debug_clip._ScrcpyClip._wait_proc(proc, 1))
-        self.assertFalse(proc.terminated)
+class TestParseHelpers(unittest.TestCase):
+    def test_pid_is_read_from_shell_echo(self):
+        self.assertEqual(debug_clip._parse_pid('4321\n'), 4321)
+        self.assertEqual(debug_clip._parse_pid('  99  '), 99)
 
-    def test_timeout_kills_and_reports_failure(self):
-        proc = _FakeProc(exits=False)
-        self.assertFalse(debug_clip._ScrcpyClip._wait_proc(proc, 0.01))
-        self.assertTrue(proc.terminated)
+    def test_missing_pid_is_detected(self):
+        # 设备没有 nohup 时 shell 只会报错，不会有进程号
+        self.assertIsNone(debug_clip._parse_pid('sh: nohup: not found'))
+        self.assertIsNone(debug_clip._parse_pid(''))
 
-    def test_none_is_ok(self):
-        self.assertTrue(debug_clip._ScrcpyClip._wait_proc(None, 1))
+    def test_progress_duration_is_parsed(self):
+        progress = (
+            b'frame=10\nout_time_us=5170000\nout_time=00:00:05.170000\nprogress=end\n'
+        )
+        self.assertAlmostEqual(debug_clip._parse_progress_duration(progress), 5.17, places=2)
+
+    def test_progress_duration_handles_hours(self):
+        progress = b'out_time=01:02:03.500000\n'
+        self.assertAlmostEqual(
+            debug_clip._parse_progress_duration(progress), 3723.5, places=2
+        )
+
+    def test_broken_progress_is_not_fatal(self):
+        self.assertIsNone(debug_clip._parse_progress_duration(b''))
+        self.assertIsNone(debug_clip._parse_progress_duration(b'out_time=oops\n'))
 
 
-class TestReadExact(ClipTestCase):
-    def make_reader(self, payload):
+class TestStaleDeviceFiles(unittest.TestCase):
+    """设备上的残留只按「文件名时间戳」判断，避免误删正在录的那一段。"""
+
+    def name(self, seconds_ago, ext='.mp4'):
+        stamp = time.strftime('%Y%m%d_%H%M%S', time.localtime(time.time() - seconds_ago))
+        return f'{debug_clip.DEVICE_TMP_DIR}/eh1_clip_{stamp}{ext}'
+
+    def test_fresh_files_are_kept(self):
+        self.assertEqual(debug_clip._stale_device_files(self.name(60)), [])
+
+    def test_old_files_are_collected(self):
+        stale = self.name(2 * 3600)
+        self.assertEqual(debug_clip._stale_device_files(stale), [stale])
+
+    def test_err_files_are_collected_too(self):
+        stale = self.name(2 * 3600, ext='.err')
+        self.assertEqual(debug_clip._stale_device_files(stale), [stale])
+
+    def test_only_our_prefixes_and_temp_dir_are_considered(self):
+        listing = '\n'.join([
+            f'{debug_clip.DEVICE_TMP_DIR}/other_20200101_000000.mp4',
+            '/sdcard/eh1_clip_20200101_000000.mp4',
+            f'{debug_clip.DEVICE_TMP_DIR}/eh1_clip_broken.mp4',
+            '',
+        ])
+        self.assertEqual(debug_clip._stale_device_files(listing), [])
+
+    def test_empty_listing_is_safe(self):
+        self.assertEqual(debug_clip._stale_device_files(''), [])
+        self.assertEqual(debug_clip._stale_device_files(None), [])
+
+
+class TestRecorderCommand(ClipTestCase):
+    def test_command_contains_all_recorder_options(self):
         rec = self.make_clip()
-        rec._dec = SimpleNamespace(stdout=io.BytesIO(payload))
-        return rec
+        rec.size = '1280x720'
+        cmd = rec._recorder_command()
+        self.assertIn('screenrecord', cmd)
+        self.assertIn(f'--time-limit {debug_clip.DEVICE_TIME_LIMIT}', cmd)
+        self.assertIn(f'--bit-rate {debug_clip.DEVICE_BITRATE}', cmd)
+        self.assertIn('--size 1280x720', cmd)
+        self.assertIn(rec.remote_path, cmd)
+        # 后台运行 + 回显进程号（收尾时按进程号发 SIGINT）
+        self.assertIn('&', cmd)
+        self.assertIn('echo $!', cmd)
+        # 设备端的 stderr 要留下来，失败时才有真实原因可报
+        self.assertIn(f'2>{rec.remote_error_path}', cmd)
 
-    def test_returns_complete_frame(self):
-        rec = self.make_reader(b'a' * 32)
-        self.assertEqual(rec._read_exact(32), b'a' * 32)
-        self.assertIsNone(rec._error)
-
-    def test_eof_returns_none_without_error(self):
-        rec = self.make_reader(b'')
-        self.assertIsNone(rec._read_exact(32))
-        self.assertIsNone(rec._error)
-
-    def test_partial_frame_returns_none_and_records_reason(self):
-        rec = self.make_reader(b'a' * 10)
-        self.assertIsNone(rec._read_exact(32))
-        self.assertIn('帧中途结束', rec._error)
-
-    def test_keeps_first_error_only(self):
-        rec = self.make_reader(b'a' * 10)
-        rec._read_exact(32)
-        first = rec._error
-        rec._set_error('后面的错误')
-        self.assertEqual(rec._error, first)
+    def test_size_is_omitted_when_unknown(self):
+        rec = self.make_clip()
+        rec.size = None
+        self.assertNotIn('--size', rec._recorder_command())
 
 
-class TestKeepRecord(ClipTestCase):
-    def write_tmp(self, payload):
-        with open(self.tmp_path, 'wb') as f:
-            f.write(payload)
-
+class TestStart(ClipTestCase):
     def setUp(self):
         super().setUp()
-        self.rec = self.make_clip()
-        self.tmp_path = self.rec.tmp_path
+        self._saved = (debug_clip.START_TIMEOUT, debug_clip.POLL_INTERVAL)
+        debug_clip.START_TIMEOUT = 0.05
+        debug_clip.POLL_INTERVAL = 0.01
 
-    def test_zero_frames_is_rejected(self):
-        self.write_tmp(b'x' * 8000)
-        self.rec._frames_written = 0
-        self.assertIsNone(self.rec._keep_record(True, 10.0))
+    def tearDown(self):
+        debug_clip.START_TIMEOUT, debug_clip.POLL_INTERVAL = self._saved
+        super().tearDown()
 
-    def test_missing_output_file_is_rejected(self):
-        self.rec._frames_written = 300
-        self.assertIsNone(self.rec._keep_record(True, 10.0))
+    def start(self, adb, launch_output='4321\n', serial='127.0.0.1:16384'):
+        rec = debug_clip._ScreenRecordClip(
+            config=SimpleNamespace(Emulator_Serial=serial)
+        )
+        rec.output_dir = self.output_dir
+        adb.sync = make_fake_sync(adb)
+        rec.adb = adb
+        with patch.object(
+            debug_clip, '_run_adb_cli', return_value=launch_output
+        ) as cli:
+            ok = rec.start()
+        return rec, ok, cli
 
-    def test_tiny_file_is_rejected(self):
-        self.write_tmp(b'x' * 100)
-        self.rec._frames_written = 300
-        self.assertIsNone(self.rec._keep_record(True, 10.0))
+    def launched_command(self, cli):
+        """取出真正发给设备的那条 shell 命令。"""
+        args = cli.call_args[0][0]
+        self.assertEqual(args[:3], ['-s', '127.0.0.1:16384', 'shell'])
+        return args[3]
 
-    def test_killed_encoder_is_rejected(self):
-        self.write_tmp(b'x' * 8000)
-        self.rec._frames_written = 300
-        self.assertIsNone(self.rec._keep_record(False, 10.0))
+    def test_start_success_records_device_path_and_pid(self):
+        adb = _FakeAdb()
+        rec, ok, cli = self.start(adb)
+        self.assertTrue(ok)
+        self.assertEqual(rec.pid, 4321)
+        self.assertEqual(rec.size, '1280x720')
+        self.assertTrue(rec.remote_path.startswith(debug_clip.DEVICE_TMP_DIR))
+        self.assertTrue(rec.remote_error_path.endswith('.err'))
+        # 开录前要先问一遍设备上的历史临时文件
+        self.assertTrue(adb.command_starting_with('ls '))
+        # 启动走 adb 命令行（adbutils 的 shell 会连带杀掉后台进程）
+        self.assertIn('screenrecord', self.launched_command(cli))
 
-    def test_valid_record_is_saved(self):
-        self.write_tmp(b'x' * 8000)
-        self.rec._frames_written = 300
-        path = self.rec._keep_record(True, 10.0)
-        self.assertIsNotNone(path)
-        self.assertTrue(os.path.basename(path).startswith(debug_clip.CLIP_PREFIX_EH1))
-        self.assertTrue(os.path.exists(path))
-        self.assertFalse(os.path.exists(self.tmp_path))
+    def test_stale_device_file_is_cleaned_before_recording(self):
+        old = time.strftime('%Y%m%d_%H%M%S', time.localtime(time.time() - 7200))
+        adb = _FakeAdb(ls_listing=f'/data/local/tmp/eh1_clip_{old}.mp4\n')
+        _, ok, _ = self.start(adb)
+        self.assertTrue(ok)
+        removed = adb.command_starting_with('rm -f')
+        self.assertTrue(removed)
+        self.assertIn(f'eh1_clip_{old}.mp4', removed[0])
 
-    def test_custom_prefix_is_used_for_output_name(self):
-        """短猫相接的录像要带自己的前缀，方便和侵蚀一的区分开。"""
-        rec = self.make_clip()
-        rec.prefix = debug_clip.CLIP_PREFIX_MEOW
-        with open(rec.tmp_path, 'wb') as f:
-            f.write(b'x' * 8000)
-        rec._frames_written = 300
-        path = rec._keep_record(True, 10.0)
-        self.assertIsNotNone(path)
-        self.assertTrue(os.path.basename(path).startswith(debug_clip.CLIP_PREFIX_MEOW))
+    def test_start_without_pid_reports_failure(self):
+        adb = _FakeAdb()
+        _, ok, _ = self.start(adb, launch_output='sh: nohup: not found')
+        self.assertFalse(ok)
 
+    def test_start_without_serial_is_skipped(self):
+        adb = _FakeAdb()
+        _, ok, _ = self.start(adb, serial='')
+        self.assertFalse(ok)
 
-class TestFinalizeIsSafe(ClipTestCase):
-    def test_finalize_never_raises_on_broken_internals(self):
-        rec = self.make_clip()
-        rec._dec = object()  # 故意塞一个没有 stdin / wait 的对象
-        rec._enc = object()
-        self.assertIsNone(rec.finalize(keep=False))
-        self.assertIsNone(rec.finalize(keep=True))
+    def test_recorder_dying_immediately_is_reported(self):
+        adb = _FakeAdb(alive=False)  # recorder 起来就崩
+        _, ok, _ = self.start(adb)
+        self.assertFalse(ok)
 
-    def test_finalize_discards_tmp_when_not_kept(self):
-        rec = self.make_clip()
-        with open(rec.tmp_path, 'wb') as f:
-            f.write(b'x' * 8000)
-        rec._frames_written = 300
-        self.assertIsNone(rec.finalize(keep=False))
-        self.assertFalse(os.path.exists(rec.tmp_path))
-
-    def test_finalize_discards_invalid_artifact(self):
-        """产物无效（这里模拟 0 帧）时不能留下文件，更不能谎报已保存。"""
-        rec = self.make_clip()
-        with open(rec.tmp_path, 'wb') as f:
-            f.write(b'x' * 8000)
-        rec._frames_written = 0
-        self.assertIsNone(rec.finalize(keep=True))
-        self.assertFalse(os.path.exists(rec.tmp_path))
-
-    def test_finalize_leaves_only_the_mp4_on_success(self):
-        """录像成功后目录里只能留下 mp4：ffmpeg 的 stderr 日志必须一并清掉。"""
-        rec = self.make_clip()
-        with open(rec.tmp_path, 'wb') as f:
-            f.write(b'x' * 8000)
-        for log_path in (rec.dec_log_path, rec.enc_log_path):
-            with open(log_path, 'wb') as f:
-                f.write(b'ffmpeg noise')
-        rec._frames_written = 300
-
-        path = rec.finalize(keep=True)
-
-        self.assertIsNotNone(path)
-        self.assertTrue(os.path.exists(path))
-        for leftover in (rec.tmp_path, rec.dec_log_path, rec.enc_log_path):
-            self.assertFalse(os.path.exists(leftover), leftover)
+    def test_unknown_device_size_still_starts(self):
+        adb = _FakeAdb(window=None)
+        rec, ok, cli = self.start(adb)
+        self.assertTrue(ok)
+        self.assertIsNone(rec.size)
+        self.assertNotIn('--size', self.launched_command(cli))
 
 
-class TestPaceLoop(ClipTestCase):
-    """验证核心节奏：源帧率低时补帧、高时丢帧，输出时长贴近真实时间。"""
+class TestFinalize(ClipTestCase):
+    def setUp(self):
+        super().setUp()
+        self._saved = (debug_clip.START_TIMEOUT, debug_clip.POLL_INTERVAL)
+        debug_clip.START_TIMEOUT = 0.05
+        debug_clip.POLL_INTERVAL = 0.01
 
-    def start_pace(self, fps=30):
-        rec = self.make_clip(fps=fps)
-        rec._enc = SimpleNamespace(stdin=_RecordingStdin())
-        thread = threading.Thread(target=rec._pace_loop, daemon=True)
-        thread.start()
-        return rec, thread
+    def tearDown(self):
+        debug_clip.START_TIMEOUT, debug_clip.POLL_INTERVAL = self._saved
+        super().tearDown()
 
-    def stop_pace(self, rec, thread):
-        rec._stop.set()
-        thread.join(timeout=3)
-        return rec._enc.stdin
-
-    def test_slow_source_is_padded(self):
-        """源 10fps 持续 0.6 秒：应补帧到约 18 帧，而不是只写 6 帧。"""
-        rec, thread = self.start_pace(fps=30)
-        fed = 0
-        try:
-            for i in range(6):
-                try:
-                    rec._frames.put_nowait(b'frame-%d' % i)
-                except queue.Full:
-                    pass
-                fed += 1
-                time.sleep(0.1)
-        finally:
-            stdin = self.stop_pace(rec, thread)
-
-        self.assertEqual(fed, 6)
-        # 补帧后写入数应远多于源帧数（旧实现只写 6 帧，会导致视频被压缩成 1/3 时长）
-        self.assertGreater(len(stdin.frames), 10)
-        self.assertTrue(stdin.closed)
-
-    def test_fast_source_is_thinned(self):
-        """源 200fps：写入数应受 30fps 节流限制，不能把 60 帧全写进去。"""
-        rec, thread = self.start_pace(fps=30)
-        try:
-            for i in range(60):
-                try:
-                    rec._frames.put_nowait(b'frame-%d' % i)
-                except queue.Full:
-                    pass
-            time.sleep(0.3)
-        finally:
-            stdin = self.stop_pace(rec, thread)
-
-        self.assertGreater(len(stdin.frames), 0)
-        # 0.3 秒最多约 9~10 帧（30fps），远少于投喂的 60 帧
-        self.assertLess(len(stdin.frames), 30)
-
-    def test_written_frames_come_from_source(self):
-        """补帧只能复用真实帧，不得写入空帧或垃圾数据。"""
-        rec, thread = self.start_pace(fps=30)
-        try:
-            source = {b'frame-%d' % i for i in range(5)}
-            for frame in source:
-                try:
-                    rec._frames.put_nowait(frame)
-                except queue.Full:
-                    pass
-                time.sleep(0.05)
-        finally:
-            stdin = self.stop_pace(rec, thread)
-
-        self.assertGreater(len(stdin.frames), 0)
-        self.assertTrue(set(stdin.frames).issubset(source))
-
-
-class TestDrainDecoder(ClipTestCase):
-    """收尾时必须把解码器压着的帧补完，否则每段录像都会短一截。"""
-
-    def make_drain_clip(self):
-        rec = self.make_clip()
-        rec._enc = SimpleNamespace(stdin=_RecordingStdin())
-        rec._frames = queue.Queue()  # 放宽容量，方便一次塞入多帧
+    def started_clip(self, adb=None, prefix=debug_clip.CLIP_PREFIX_EH1):
+        adb = adb or _FakeAdb()
+        rec = self.make_clip(prefix=prefix, adb=adb)
+        rec.pid = int(adb.pid)
+        rec.alive = True
+        adb.alive = True
+        rec._started_at = time.perf_counter() - 12
         return rec
 
-    def test_drains_buffered_frames_until_decoder_done(self):
-        rec = self.make_drain_clip()
-        for i in range(5):
-            rec._frames.put_nowait(b'frame-%d' % i)
-        rec._decoder_done.set()
-        rec._drain_decoder()
-        self.assertEqual(len(rec._enc.stdin.frames), 5)
-        self.assertEqual(rec._frames_written, 5)
+    def test_successful_clip_is_saved_and_device_is_cleaned(self):
+        adb = _FakeAdb()
+        rec = self.started_clip(adb)
+        with patch.object(rec, '_transcode', side_effect=self.fake_transcode):
+            path = rec.finalize(keep=True)
 
-    def test_stops_at_deadline_when_decoder_never_finishes(self):
-        rec = self.make_drain_clip()
-        rec._decode_thread = object()  # 让「没有解码线程」的短路不生效
-        rec._drain_deadline = time.perf_counter() - 1  # 已经过期
-        rec._frames.put_nowait(b'frame-0')
-        rec._drain_decoder()
-        self.assertEqual(len(rec._enc.stdin.frames), 1)
-        self.assertIn('结尾可能缺失', rec._error)
+        self.assertIsNotNone(path)
+        self.assertTrue(os.path.exists(path))
+        self.assertTrue(os.path.basename(path).startswith(debug_clip.CLIP_PREFIX_EH1))
+        # 产物目录里只应留下 mp4，本地临时文件要清掉
+        self.assertEqual(
+            [n for n in os.listdir(self.output_dir) if n.startswith('_tmp')], []
+        )
+        # 设备上的录像与 stderr 都要删掉；SIGINT 前要确认进程还是 recorder
+        stopped = [c for c in adb.commands if 'kill -2' in c]
+        self.assertTrue(stopped)
+        self.assertIn('/proc/', stopped[0])
+        self.assertTrue(adb.command_starting_with('rm -f'))
 
-    def test_returns_immediately_without_decode_thread(self):
-        rec = self.make_drain_clip()
-        rec._drain_deadline = float('inf')
-        started = time.perf_counter()
-        rec._drain_decoder()
-        self.assertLess(time.perf_counter() - started, 0.5)
+    def test_meow_prefix_is_used_for_output_name(self):
+        rec = self.started_clip(prefix=debug_clip.CLIP_PREFIX_MEOW)
+        with patch.object(rec, '_transcode', side_effect=self.fake_transcode):
+            path = rec.finalize(keep=True)
+        self.assertTrue(os.path.basename(path).startswith(debug_clip.CLIP_PREFIX_MEOW))
+
+    def test_discarded_clip_leaves_no_file_and_still_stops_recorder(self):
+        adb = _FakeAdb()
+        rec = self.started_clip(adb)
+        self.assertIsNone(rec.finalize(keep=False))
+        self.assertEqual([n for n in os.listdir(self.output_dir) if n.endswith('.mp4')], [])
+        self.assertTrue([c for c in adb.commands if 'kill -2' in c])
+        self.assertEqual(adb.pulled, [])
+
+    def test_missing_device_file_is_reported_not_faked(self):
+        adb = _FakeAdb(file_size=None, error_text='Fatal: cannot create encoder')
+        rec = self.started_clip(adb)
+        self.assertIsNone(rec.finalize(keep=True))
+        self.assertEqual([n for n in os.listdir(self.output_dir) if n.endswith('.mp4')], [])
+
+    def test_too_small_device_file_is_rejected(self):
+        rec = self.started_clip(_FakeAdb(file_size=100))
+        self.assertIsNone(rec.finalize(keep=True))
+        self.assertEqual([n for n in os.listdir(self.output_dir) if n.endswith('.mp4')], [])
+
+    def test_short_clip_without_recording_is_skipped(self):
+        """录制时间过短时设备端还没写出文件，这属于正常跳过而不是失败。"""
+        rec = self.started_clip(_FakeAdb(file_size=None))
+        rec._started_at = time.perf_counter() - 0.5
+        self.assertIsNone(rec.finalize(keep=True))
+
+    def test_pull_failure_is_reported(self):
+        rec = self.started_clip(_FakeAdb(pull_fails=True))
+        with patch.object(rec, '_transcode', side_effect=self.fake_transcode):
+            self.assertIsNone(rec.finalize(keep=True))
+        self.assertEqual([n for n in os.listdir(self.output_dir) if n.endswith('.mp4')], [])
+
+    def test_finalize_never_raises_on_broken_internals(self):
+        rec = self.make_clip(adb=_FakeAdb())
+        rec.adb = object()  # 故意塞一个没有 shell / sync 的对象
+        self.assertIsNone(rec.finalize(keep=False))
+        self.assertIsNone(rec.finalize(keep=True))
+
+    @staticmethod
+    def fake_transcode(src, dst, elapsed):
+        """替代真实转码：写出目标文件并返回时长。"""
+        with open(dst, 'wb') as f:
+            f.write(b'x' * 20000)
+        return 12.0
+
+
+class TestTranscode(ClipTestCase):
+    def test_transcode_command_targets_realtime_30fps(self):
+        rec = self.make_clip()
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured['cmd'] = cmd
+            with open(cmd[-1], 'wb') as f:
+                f.write(b'x' * 20000)
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=b'out_time=00:00:12.000000\n', stderr=b''
+            )
+
+        with patch.object(debug_clip, '_ffmpeg_path', return_value='/fake/ffmpeg'), \
+                patch.object(debug_clip.subprocess, 'run', side_effect=fake_run):
+            src = os.path.join(self.output_dir, 'src.mp4')
+            with open(src, 'wb') as f:
+                f.write(b'x' * 20000)
+            duration = rec._transcode(src, os.path.join(self.output_dir, 'out.mp4'), 30)
+
+        self.assertAlmostEqual(duration, 12.0, places=2)
+        cmd = captured['cmd']
+        # 抽帧到目标帧率（不改变时长）+ CRF 压缩，避免设备端高码率文件堆积
+        self.assertEqual(cmd[cmd.index('-r') + 1], str(debug_clip.RECORD_FPS))
+        self.assertIn('-crf', cmd)
+        self.assertIn('+faststart', cmd)
+        # yuv420p 不接受奇数边长
+        self.assertIn('scale=trunc(iw/2)*2:trunc(ih/2)*2', cmd)
+
+    def test_transcode_failure_keeps_raw_recording(self):
+        rec = self.make_clip()
+        src = os.path.join(self.output_dir, 'src.mp4')
+        dst = os.path.join(self.output_dir, 'out.mp4')
+        with open(src, 'wb') as f:
+            f.write(b'x' * 20000)
+
+        with patch.object(debug_clip, '_ffmpeg_path', return_value='/fake/ffmpeg'), \
+                patch.object(
+                    debug_clip.subprocess, 'run',
+                    return_value=subprocess.CompletedProcess([], 1, stdout=b'', stderr=b'boom'),
+                ):
+            self.assertIsNone(rec._transcode(src, dst, 30))
+
+        # 转码失败也要保住画面：原始录像比没有强
+        self.assertTrue(os.path.exists(dst))
+        self.assertFalse(os.path.exists(src))
+
+    def test_missing_ffmpeg_keeps_raw_recording(self):
+        rec = self.make_clip()
+        src = os.path.join(self.output_dir, 'src.mp4')
+        dst = os.path.join(self.output_dir, 'out.mp4')
+        with open(src, 'wb') as f:
+            f.write(b'x' * 20000)
+
+        with patch.object(debug_clip, '_ffmpeg_path', return_value=None):
+            self.assertIsNone(rec._transcode(src, dst, 30))
+
+        self.assertTrue(os.path.exists(dst))
+        self.assertFalse(os.path.exists(src))
 
 
 class TestClipSession(unittest.TestCase):
@@ -472,7 +560,7 @@ class TestClipSession(unittest.TestCase):
     def test_stale_session_is_finalized_before_restart(self):
         stale = SimpleNamespace(finalize=lambda keep: '/stale.mp4')
         debug_clip._ACTIVE = stale
-        with patch.object(debug_clip, '_ScrcpyClip') as clip_cls:
+        with patch.object(debug_clip, '_ScreenRecordClip') as clip_cls:
             clip_cls.return_value.start.return_value = False
             self.assertIsNone(debug_clip.clip_start(config=None))
         # 旧会话被收尾、_ACTIVE 被清空，不会永久泄漏导致之后再也录不了
@@ -521,7 +609,7 @@ class TestClipRecordingContext(unittest.TestCase):
         end.assert_called_once_with(keep=True)
 
     def test_start_failure_is_not_fatal(self):
-        """scrcpy/ffmpeg 起不来时录像优雅降级，不影响任务本身。"""
+        """设备上录不了时优雅降级，不影响任务本身。"""
         with patch.object(debug_clip, 'clip_start', return_value=None), \
                 patch.object(debug_clip, 'clip_end') as end:
             with debug_clip.clip_recording(config='cfg', enabled=True) as clip:


### PR DESCRIPTION
## Sourcery 摘要

将调试视频片段录制从基于 scrcpy 的串流迁移到带时间戳的 Android 屏幕录制，以便在较新的 Android 设备上实现更可靠的实时播放。

新功能：
- 将基于 scrcpy 的调试录制替换为设备端 Android screenrecord 录制，并在本地获取 MP4 文件。
- 当 ffmpeg 不可用或转码失败时，回退到原始设备录制，以保留录制内容。

错误修复：
- 避免因不带时间戳的 scrcpy 串流，以及不再支持所需隐藏显示镜像 API 的 Android 版本而导致录制缺失或加速。
- 改进录制失败处理，确保无效或不完整的输出不会被报告为已成功保存。

增强功能：
- 添加设备录制生命周期管理、过期文件清理、时长报告、大小验证，以及针对时间限制和时长差异的明确警告。
- 允许在基于 scrcpy 的截图运行期间同时进行录制，同时警告这两个功能会创建并发的视频编码器。

文档：
- 更新调试录制文档，介绍基于 screenrecord 的处理流程、限制和输出行为。

测试：
- 更新调试录制测试，覆盖设备命令、进程处理、过期文件清理、产物验证、转码回退和会话生命周期行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate debug clip recording from scrcpy streaming to timestamped Android screenrecord capture for more reliable real-time playback on newer Android devices.

New Features:
- Replace scrcpy-based debug recording with Android device-side screenrecord capture and local MP4 retrieval.
- Preserve recordings when ffmpeg is unavailable or transcoding fails by falling back to the original device recording.

Bug Fixes:
- Avoid missing or accelerated recordings caused by timestamp-less scrcpy streams and Android versions that no longer support the required hidden display-mirroring API.
- Improve recording failure handling so invalid or incomplete outputs are not reported as successfully saved.

Enhancements:
- Add device recording lifecycle management, stale-file cleanup, duration reporting, size validation, and explicit warnings for time limits and duration discrepancies.
- Allow recording alongside scrcpy-based screenshots while warning that both features create concurrent video encoders.

Documentation:
- Update debug recording documentation to describe the screenrecord-based pipeline, limitations, and output behavior.

Tests:
- Update debug recording tests to cover device commands, process handling, stale-file cleanup, artifact validation, transcoding fallback, and session lifecycle behavior.

</details>