### PR TITLE
fix(webui): 更新器页后台 switch 切页后不再写出幽灵 scope

### DIFF
--- a/module/webui/app_developer_update.py
+++ b/module/webui/app_developer_update.py
@@ -28,10 +28,50 @@ from module.webui.app_types import WebUIMixinBase
 class DeveloperUpdateMixin(WebUIMixinBase):
     """WebUI更新和启动项设置"""
 
+    # 更新器页面的全部 scope 名，供幽灵节点清理复用
+    UPDATER_SCOPES = (
+        "updater_info",
+        "updater_loading",
+        "updater_state",
+        "updater_btn",
+        "updater_table",
+        "updater_detail",
+    )
+
+    @staticmethod
+    def remove_stale_updater_scopes() -> None:
+        """清除落在 content 之外的 updater_* scope 残留。
+
+        后台 switch 任务在页面切走后仍会跑完当前一轮，此时这些 scope 已随
+        content 一起被清空；PyWebIO 的 set_scope(if_exist='blank') 在前端找不到
+        元素时，会把新 scope 追加到调用线程的当前 scope（任务线程只有 ROOT），
+        于是在 #pywebio-scope-ROOT 下留下幽灵节点：既让下次 put_scope 撞名
+        （前端渲染“scope 名称重复”灰条），又作为 ROOT 网格的额外一行把应用
+        外壳挤扁、内容跑到 content 之外。渲染前清理一次，保证本页 DOM 干净。
+
+        Pages: in: page_update
+        """
+        run_js(
+            """
+            (function () {
+                var content = document.getElementById("pywebio-scope-content");
+                if (!content) return;
+                names.forEach(function (name) {
+                    var el = document.getElementById("pywebio-scope-" + name);
+                    if (el && el.parentNode && !content.contains(el)) {
+                        el.parentNode.removeChild(el);
+                    }
+                });
+            })();
+            """,
+            names=list(DeveloperUpdateMixin.UPDATER_SCOPES),
+        )
+
     @use_scope("content", clear=True)
     def dev_update(self) -> None:
         self.init_menu(name="Update")
         self.set_title(t("Gui.MenuDevelop.Update"))
+        self.remove_stale_updater_scopes()
 
         put_scope("updater_info")
         with use_scope("updater_info"):
@@ -52,6 +92,9 @@ class DeveloperUpdateMixin(WebUIMixinBase):
         put_scope("updater_detail")
 
         def update_table():
+            """刷新提交表格；页面已切走时直接放弃，避免写出幽灵 scope。"""
+            if self.page != "Update":
+                return
             with use_scope("updater_table", clear=True):
                 local_commit = updater.get_commit(short_sha1=True)
                 upstream_commit = updater.get_commit(
@@ -70,6 +113,10 @@ class DeveloperUpdateMixin(WebUIMixinBase):
                         t("Gui.Update.Message"),
                     ],
                 )
+            # 两次 get_commit 是 git 子进程，期间用户可能已切页；这里再判一次，
+            # 否则 set_scope 会在 ROOT 下创建幽灵 updater_detail。
+            if self.page != "Update":
+                return
             with use_scope("updater_detail", clear=True):
                 put_text(t("Gui.Update.DetailedHistory"))
                 history = updater.get_commit(
@@ -86,7 +133,8 @@ class DeveloperUpdateMixin(WebUIMixinBase):
                 )
 
         def u(state):
-            if state == -1:
+            # 后台 switch 在本页卸载后仍会跑完当前一轮，必须放弃写 DOM
+            if state == -1 or self.page != "Update":
                 return
             clear("updater_loading")
             clear("updater_state")


### PR DESCRIPTION
## 问题

更新器页（主页 → 更新器）在切页后再次进入时会出现三个互相牵连的异常：

1. 信息卡下方多出一条灰框：`错误: 此scope与已有scope重复!`；
2. 「详细提交历史」标题与提交表被渲染到应用外壳之外（挂在 `#pywebio-scope-ROOT` 下）；
3. 应用外壳（侧栏 + 菜单 + 内容区）被压扁成一小条，窗口下方空出一大片（dev 分支的未验证版本水印让它更显眼）。

## 复现

1. 进入 主页，点击菜单 **更新器**（页面末尾会注册 `Switch_updater_refresh`，一次刷新要跑 3 个 `updater.get_commit()`，即 3 个 git 子进程，约 1~3 秒）；
2. 在这 2~3 秒内切到别的页面（回主页或点远程控制都行）；
3. 再回到 **更新器** —— 灰条 + 提交表跑出外壳 + 下方大片空白。

## 根因

- `update_table()` 由后台 switch 任务调用；切页时 `TaskHandler.remove_pending_task()` 只是把任务从列表里移除，**正在执行的那一轮 `task.send()` 无法中断**，会继续跑完。
- 此时 `updater_*` 这些 scope 已随 `@use_scope("content", clear=True)` 的 `blank` 从 DOM 清空，`use_scope("updater_detail", clear=True)` 发出的 `set_scope(..., if_exist="blank")` 在前端找不到元素，于是走回退分支把新建的 div 追加到**调用线程的当前 scope**；而 PyWebIO 的 `scope_stack` 按 task_id（即线程）记录，任务线程里只有 `ROOT`，于是幽灵节点被挂到 `#pywebio-scope-ROOT` 下。
- 下次进入本页时，`put_scope("updater_detail")` 生成的元素在 `AfterCurrentOutputWidgetShow` 回调里发现 `$("#pywebio-scope-updater_detail").length !== 0`，于是**不设置 id**、`empty()` 之后塞入 `duplicated_scope_name` 文案 ⇒ 灰条；随后 `put_table()` 按 id 落进 ROOT 上的幽灵节点 ⇒ 内容跑到外壳之外。
- 幽灵节点还成为 `#pywebio-scope-ROOT`（`height:100vh; grid-template-rows: auto 1fr`，本来只为 `header` + `contents` 两行设计）的隐式第三行，把 `1fr` 行 `#pywebio-scope-contents` 压缩 ⇒ 窗口下方那一大片空白。

## 改动

- `u()` 与 `update_table()` 增加 `self.page != "Update"` 守卫：页面已切走时立即放弃写 DOM；两次 `get_commit()`（git 子进程）之间也再判一次；
- `dev_update()` 渲染前调用 `remove_stale_updater_scopes()`，清掉落在 `content` 之外的 `updater_*` 幽灵节点（防御历史遗留，切页竞态仍有极小窗口）。

## 验证

- `python -m py_compile module/webui/app_developer_update.py` 通过；
- 用假 PyWebIO 会话 + 前端语义模拟器（复刻 `AfterCurrentOutputWidgetShow` 触发时机、`set_scope` 回退创建、`output_ctl` 的 clear/blank/loose 语义）重放「渲染 → 切页 → 僵尸任务再跑一轮 → 重进页面」：修复前 ROOT 下多出 `updater_table` / `updater_detail` 两个幽灵节点并产生重复 scope 告警，修复后**告警 0、无幽灵节点**，DOM 全部落在 `content` 内；
- 清理脚本用 Node + 最小 DOM 桩单测：`content` 之外的节点被删除、卡片内 `updater_info` 保留、无关节点（`menu`）不受影响 → PASS；
- 手工验证：更新器 → 2 秒内点主页 → 回更新器，修复前必现，修复后不再复现。

## 附加建议（可另开 issue）

`Updater.get_commit()` 每次刷新要 spawn 3 个 git 子进程，僵尸窗口 ~2.7s 就是由此而来；按 `(revision, n, short_sha1)` 缓存后可降到毫秒级，即使守卫有竞态也造不出幽灵节点。

## Sourcery 总结

防止更新器页面刷新竞争在切换页面后留下幽灵作用域并破坏 WebUI 布局。

Bug 修复：
- 防止用户离开更新器页面后，后台更新器刷新任务仍写入作用域，从而消除重复作用域警告、脱离 shell 的渲染问题，以及返回页面时的布局崩溃。
- 在渲染更新器页面之前，移除内容容器外残留的过时更新器作用域元素。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent updater page refresh races from leaving ghost scopes and corrupting the WebUI layout after switching pages.

Bug Fixes:
- Prevent background updater refresh tasks from writing scopes after the user leaves the updater page, eliminating duplicate-scope warnings, out-of-shell rendering, and layout collapse when returning to the page.
- Remove stale updater scope elements left outside the content container before rendering the updater page.

</details>