### PR TITLE
fix(device): 修正 nemu_ipc 触控坐标在 MuMu15 上被二次旋转

### DIFF
--- a/module/device/method/nemu_ipc.py
+++ b/module/device/method/nemu_ipc.py
@@ -241,6 +241,8 @@ class NemuIpcImpl:
         if version is None:
             version = self.detect_version(nemu_folder, instance_id)
         self.version: str = version
+        # 触摸坐标是否需要在本次层旋转，见 _resolve_rotate_xy()
+        self.rotate_xy: bool = self._resolve_rotate_xy(version)
 
         # 尝试从多个路径加载 DLL，实例版本的 SDK 优先
         list_dll = []
@@ -507,15 +509,42 @@ class NemuIpcImpl:
         image = np.ctypeslib.as_array(pixels_pointer.contents).reshape((self.height, self.width, 4))
         return image
 
+    @staticmethod
+    def _resolve_rotate_xy(version: str) -> bool:
+        """判断是否需要把标准 ADB 坐标旋转成 Nemu 显示缓冲坐标。
+
+        MuMu12 的 IPC 直接把坐标注入旋转 90° 的显示缓冲，需要本层做
+        (height - y, x)；MuMu15 的 external_renderer_ipc.dll 内部已经按
+        rotation=90 换算过（调用时 DLL 会打印
+        "after convert, x_point=..., y_point=..."），再旋转一次会让所有点击
+        落到二次旋转后的位置，表现为「想点 A 却触发了 B」。
+
+        Args:
+            version (str): 实例版本，如 '12.0' / '15.0'，未知时为 None。
+
+        Returns:
+            bool: True 表示本层仍需旋转坐标。
+        """
+        try:
+            major = int(str(version).split(".")[0])
+        except (TypeError, ValueError):
+            # 版本未知时保持历史行为，避免影响老版本 MuMu
+            return True
+        return major < 15
+
     def convert_xy(self, x, y):
         """
         将标准 ADB 坐标转换为 Nemu 坐标。
         调用此方法前必须先更新 `self.height`。
 
+        MuMu15 及以后由 DLL 自行处理显示缓冲旋转，此时坐标原样传入。
+
         Returns:
             int, int
         """
         x, y = int(x), int(y)
+        if not self.rotate_xy:
+            return x, y
         x, y = self.height - y, x
         return x, y
 

--- a/tests/test_nemu_ipc_dll.py
+++ b/tests/test_nemu_ipc_dll.py
@@ -195,5 +195,52 @@ class TestDecideChannelOrder(unittest.TestCase):
         self.assertIsNone(NemuIpcImpl._decide_channel_order(raw, frame))
 
 
+class TestTouchCoordinateSpace(unittest.TestCase):
+    """触摸坐标的显示缓冲旋转按模拟器版本区分。
+
+    MuMu12 的 IPC 需要本层把标准坐标旋转成显示缓冲坐标；MuMu15 的
+    external_renderer_ipc.dll 内部已经按 rotation=90 换算过，本层再旋转会让
+    所有点击落到二次旋转后的位置，表现为「想点 A 却触发了 B」。
+    """
+
+    def test_version_gate(self):
+        self.assertFalse(NemuIpcImpl._resolve_rotate_xy('15.0'))
+        self.assertFalse(NemuIpcImpl._resolve_rotate_xy('16.0'))
+        self.assertTrue(NemuIpcImpl._resolve_rotate_xy('12.0'))
+        self.assertTrue(NemuIpcImpl._resolve_rotate_xy('3.8.13'))
+        self.assertTrue(NemuIpcImpl._resolve_rotate_xy(None))
+        self.assertTrue(NemuIpcImpl._resolve_rotate_xy('unknown'))
+
+    def _build(self, version):
+        import ctypes as _ctypes
+
+        root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        folder = os.path.join(root, 'nx_device', version, 'shell', 'sdk')
+        os.makedirs(folder)
+        with open(os.path.join(folder, 'external_renderer_ipc.dll'), 'w') as f:
+            f.write('fake')
+        original = _ctypes.CDLL
+
+        class _FakeLib:
+            pass
+
+        _ctypes.CDLL = lambda path, *a, **k: _FakeLib()
+        try:
+            impl = NemuIpcImpl(nemu_folder=root, instance_id=0, version=version)
+        finally:
+            _ctypes.CDLL = original
+        impl.height = 720
+        return impl
+
+    def test_mumu15_passes_touch_xy_through(self):
+        impl = self._build('15.0')
+        self.assertEqual(impl.convert_xy(17, 241), (17, 241))
+
+    def test_mumu12_rotates_touch_xy(self):
+        impl = self._build('12.0')
+        self.assertEqual(impl.convert_xy(17, 241), (720 - 241, 17))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 问题

MuMu15 + `nemu_ipc` 触控时，所有点击都落到「二次旋转」后的位置，表现是脚本点 A 却触发了 B：

- 配置 `ScreenshotMethod = nemu_ipc`、`ControlMethod = nemu_ipc`；
- 脚本在主页执行 `ui_goto(page_reward)`，日志显示 `点击 (17, 241) @ MAIN_GOTO_REWARD_WHITE`，但游戏弹出的是「花费 50 购买 800 石油」，页面永远切不过去，于是每 5 秒反复点击同一按钮。

## 根因

`NemuIpcImpl.convert_xy()` 会把标准 ADB 坐标旋转成显示缓冲坐标：

```python
x, y = self.height - y, x      # (17, 241) -> (479, 17)
```

但 MuMu15 的 `external_renderer_ipc.dll` 在 `nemu_input_event_touch_down()` 内部**已经**按 `rotation=90` 做过同样的换算（调用时 DLL 自己会打印）：

```text
x: 17, y: 241, width: 1280, height: 720, rotation: 90.000000, product_major: 0
after convert, x_point: 479, y_point: 17
```

本层再转一次，进入模拟器的就是二次旋转后的坐标（T∘T），落点与预期无关。MuMu12 的 IPC 不做这个换算，所以老版本需要本层旋转。

## 改动

- 新增 `NemuIpcImpl._resolve_rotate_xy(version)`，`__init__` 里解析为 `self.rotate_xy`；
- `convert_xy()` 按实例版本判断：MuMu12 及更早保持原有旋转，**MuMu15 及以上原样传入由 DLL 处理**，版本未知时保持历史行为；
- `tests/test_nemu_ipc_dll.py` 补 3 个用例（版本判定 + 两种坐标空间）。

## 验证

1. `python -m unittest tests.test_nemu_ipc_dll` → 14 项通过（含新增 3 项）。
2. 真机（MuMu15.0，显示缓冲 1280x720）用 `NemuIpcImpl.down()/up()` 直接点「手册」按钮 `(75, 110)`：
   - 修复前（走 `convert_xy`，注入 `(610, 75)`）：手册面板不出现，只触发了看板娘的触摸台词；
   - 修复后（原样注入）：**手册面板正常弹出**。
3. DLL 自证：上面那两行 `rotation: 90.000000` / `after convert` 就是 MuMu15 的 `external_renderer_ipc.dll` 打印的。

## 备注

- 与 `2e0cd8090`（取消 nemu_ipc 控制强制联动）、`f937fa28b`（nemu_ipc 不再参与自动选择）是互补关系：那两个提交让用户可以**避开** nemu_ipc 触控，本 PR 修掉坐标换算本身，让**选择使用** nemu_ipc 的用户也能点得准。
- 受影响的用户临时规避：截图方式 + 控制方式一起改成非 nemu_ipc（如 `auto` + `MaaTouch`）。
- 若想要更稳的判定，可以像新加的「通道序自动校准」那样，用一次探测点击对比 DLL 打印的换算与预期落点来自动决定是否本层旋转，而不是硬编码版本号；本 PR 先做最小改动。

## Summary by Sourcery

根据 MuMu 版本调整 nemu_ipc 触控坐标转换，避免 MuMu15 的重复旋转并保持旧版本兼容。

Bug Fixes:
- 修正 MuMu15 及以上版本 nemu_ipc 触控坐标被重复旋转导致点击落点错误的问题。

Enhancements:
- 根据模拟器版本选择触控坐标转换策略，保留 MuMu12 及更早版本的兼容行为，并在版本未知时沿用历史行为。

Tests:
- 新增触控坐标空间和版本判定测试，覆盖 MuMu12、MuMu15 及未知版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

根据 MuMu 版本调整 nemu_ipc 触控坐标转换，避免 MuMu15 的重复旋转并保持旧版本兼容。

Bug Fixes:
- 修正 MuMu15 及以上版本 nemu_ipc 触控坐标被重复旋转导致点击落点错误的问题。

Enhancements:
- 根据模拟器版本选择触控坐标转换策略，保留 MuMu12 及更早版本的兼容行为，并在版本未知时沿用历史行为。

Tests:
- 新增触控坐标空间和版本判定测试，覆盖 MuMu12、MuMu15 及未知版本。

</details>