### PR TITLE
feat(tests): 添加校准通道序的回归测试，修正 BGR 与 RGB 比较问题

### DIFF
--- a/module/device/method/nemu_ipc.py
+++ b/module/device/method/nemu_ipc.py
@@ -346,7 +346,8 @@ class NemuIpcImpl:
 
         Args:
             raw: nemu_capture_display 的原始帧（4 通道、上下颠倒）。
-            truth: ADB screencap 的 RGB 真值帧，尺寸与 raw 一致。
+            truth: ADB screencap 的 RGB 真值帧（RGB 内存，与代码库其余
+                截图一致），尺寸与 raw 一致。
 
         Returns:
             str: 'rgba' / 'bgra'；画面无特征（如全黑加载页，两种解释
@@ -725,6 +726,9 @@ class NemuIpc(Platform):
             if truth is None:
                 logger.warning('[设备-NemuIpc] 通道序校准失败: ADB screencap 无输出')
                 return None
+            # imdecode 得到 BGR 内存，_decide_channel_order 按代码库统一的
+            # RGB 内存比较，不转换会让判定恒定取反（红蓝反转，见单元测试）
+            cv2.cvtColor(truth, cv2.COLOR_BGR2RGB, dst=truth)
             raw = impl.screenshot(timeout=2)
             result = NemuIpcImpl._decide_channel_order(raw, truth)
             if result is None:

--- a/tests/test_nemu_ipc_dll.py
+++ b/tests/test_nemu_ipc_dll.py
@@ -13,7 +13,7 @@ import unittest
 import cv2
 import numpy as np
 
-from module.device.method.nemu_ipc import NemuIpcImpl
+from module.device.method.nemu_ipc import NemuIpc, NemuIpcImpl
 
 
 def build_fake_install(root, versions=('12.0',), instance_names=('MuMuPlayer-12.0-0',)):
@@ -193,6 +193,43 @@ class TestDecideChannelOrder(unittest.TestCase):
         frame = np.zeros((64, 64, 3), dtype=np.uint8)
         raw = self._make_raw(frame)
         self.assertIsNone(NemuIpcImpl._decide_channel_order(raw, frame))
+
+
+class TestCalibrateChannelOrder(unittest.TestCase):
+    """校准调用方的真值帧约定回归。
+
+    cv2.imdecode 得到 BGR 内存，而 _decide_channel_order 按代码库统一的
+    RGB 内存比较；调用方漏了 BGR2RGB 时判定恒定取反，nemu_ipc 截图红蓝
+    反转会导致按钮认不出来（2026-09-13 智能调度卡死即由此引起）。
+    这里走真实调用方，只把 ADB 与 IPC 换成假实现。
+    """
+
+    @staticmethod
+    def _png_of(frame):
+        """把 RGB 内存帧编码为 screencap 风格的 PNG 字节。"""
+        bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+        return cv2.imencode('.png', bgr)[1].tobytes()
+
+    def _calibrate(self, frame, raw):
+        class _Host:
+            adb_exec_out = staticmethod(lambda args: self._png_of(frame))
+
+        class _Impl:
+            screenshot = staticmethod(lambda timeout=0: raw)
+
+        return NemuIpc.nemu_ipc_calibrate_channel(_Host, _Impl)
+
+    def test_rgba_raw_detected_as_rgba(self):
+        frame = np.zeros((64, 64, 3), dtype=np.uint8)
+        frame[:, :, 2] = 200  # 蓝色画面
+        raw = cv2.flip(cv2.cvtColor(frame, cv2.COLOR_RGB2RGBA), 0)
+        self.assertEqual(self._calibrate(frame, raw), 'rgba')
+
+    def test_bgra_raw_detected_as_bgra(self):
+        frame = np.zeros((64, 64, 3), dtype=np.uint8)
+        frame[:, :, 0] = 200  # 红色画面
+        raw = cv2.flip(cv2.cvtColor(frame, cv2.COLOR_RGB2BGRA), 0)
+        self.assertEqual(self._calibrate(frame, raw), 'bgra')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Sourcery 摘要

修复 Nemu 通道顺序校准问题，并添加 RGB/BGR 处理的回归测试。

错误修复：
- 修正校准比较逻辑，使 ADB 截图使用预期的 RGB 通道顺序，避免 Nemu 截图中红色和蓝色通道颠倒。

测试：
- 通过实际的校准调用方，添加用于检测 RGBA 和 BGRA 通道顺序的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Nemu channel-order calibration and add regression tests for RGB/BGR handling.

Bug Fixes:
- Correct the calibration comparison so ADB screenshots use the expected RGB channel order, preventing red and blue channel inversion in Nemu screenshots.

Tests:
- Add regression coverage for detecting both RGBA and BGRA channel orders through the real calibration caller.

</details>