### PR TITLE
fix(device): nemu_ipc 通道序校准失败时不再固定为推断值（截图红蓝互换）

### DIFF
--- a/module/device/method/nemu_ipc.py
+++ b/module/device/method/nemu_ipc.py
@@ -300,9 +300,14 @@ class NemuIpcImpl:
         self.connect_id: int = 0
         self.width = 0
         self.height = 0
-        # 截图通道序（'rgba' / 'bgra'），由 screenshot_nemu_ipc 首帧前解析：
-        # 手动配置 > ADB 真值校准 > 按 SDK 架构推断，见 NemuIpc._resolve_channel_order
+        # 截图通道序（'rgba' / 'bgra'），由 screenshot_nemu_ipc 每帧解析：
+        # 手动配置 > 本会话已校准值 > ADB 真值校准 > 上次实测值/架构推断，
+        # 见 NemuIpc._ensure_channel_order
         self.channel_order: str = None
+        # 通道序是否已确认（校准成功或手动指定）；未确认时会带冷却重试：
+        # 启动瞬间常是黑屏加载页，校准会落空，若就此固定成推断值，整程都会红蓝互换
+        self.channel_order_verified: bool = False
+        self.channel_order_last_try: float = 0.0
 
     @staticmethod
     def detect_version(nemu_folder: str, instance_id: int):
@@ -328,39 +333,66 @@ class NemuIpcImpl:
     @property
     def bgra_layout(self) -> bool:
         """
-        nemu_capture_display 返回的像素通道序按 SDK 来源架构区分：
-        新架构（nx_device/<版本> 与 nx_main，MuMu 5.0+ 安装布局）返回
-        BGRA，经典布局（shell/sdk，MuMu 12 3.x/4.x）返回 RGBA。
-        实测 12.0 与 15.0 的 nx_device SDK 均为 BGRA，与版本号无关。
+        按 SDK 来源架构推断通道序，仅在自动校准拿不到结果时兜底。
+
+        历史推断（新架构 nx_device/<版本> 与 nx_main 为 BGRA、经典布局
+        shell/sdk 为 RGBA）出自与校准相同的比对代码，在校准修正 BGR/RGB
+        混用前后结论可能相反——实测 MuMu15.0 的 nx_device SDK 为 RGBA。
+        因此这里只当最后的兜底：能校准时以校准结果为准，校不准还会继续重试。
 
         Returns:
-            bool: 是否为 BGRA 通道序。
+            bool: 推断是否为 BGRA 通道序。
         """
         path = self.ipc_dll.replace('\\', '/')
         return '/nx_device/' in path or '/nx_main/' in path
+
+    # 通道序判定前先降采样：ADB 真值与 IPC 帧之间存在采样间隔，
+    # 动画/撕裂造成的位移不应压过颜色通道特征。
+    CHANNEL_COMPARE_SCALE = 8
+    # 两种解释与真值的差距小于该值（0-255）时视为判不准，交由调用方稍后重试。
+    CHANNEL_DECIDE_MARGIN = 2.0
 
     @staticmethod
     def _decide_channel_order(raw, truth):
         """
         用 ADB screencap 真值帧判定原始捕获的通道序。
 
+        比对前把两侧降采样，真值与原始帧分辨率不一致时先缩放到同一尺寸。
+
         Args:
             raw: nemu_capture_display 的原始帧（4 通道、上下颠倒）。
             truth: ADB screencap 的 RGB 真值帧（RGB 内存，与代码库其余
-                截图一致），尺寸与 raw 一致。
+                截图一致）。
 
         Returns:
-            str: 'rgba' / 'bgra'；画面无特征（如全黑加载页，两种解释
-                均与真值几乎一致）时返回 None。
+            str: 'rgba' / 'bgra'；画面无特征（如全黑加载页）或两种解释
+                差距过小（如灰阶画面）时返回 None。
         """
         def prep(interpretation):
             img = cv2.cvtColor(raw, interpretation)
             cv2.flip(img, 0, dst=img)
             return img
 
-        d_rgba = float(np.mean(cv2.absdiff(prep(cv2.COLOR_RGBA2RGB), truth)))
-        d_bgra = float(np.mean(cv2.absdiff(prep(cv2.COLOR_BGRA2RGB), truth)))
+        def shrink(img):
+            height, width = img.shape[:2]
+            scale = NemuIpcImpl.CHANNEL_COMPARE_SCALE
+            return cv2.resize(
+                img, (max(1, width // scale), max(1, height // scale)),
+                interpolation=cv2.INTER_AREA)
+
+        raw_rgba = prep(cv2.COLOR_RGBA2RGB)
+        if truth.shape[:2] != raw_rgba.shape[:2]:
+            truth = cv2.resize(
+                truth, (raw_rgba.shape[1], raw_rgba.shape[0]),
+                interpolation=cv2.INTER_AREA)
+        i_rgba, i_bgra = shrink(raw_rgba), shrink(prep(cv2.COLOR_BGRA2RGB))
+        truth = shrink(truth)
+
+        d_rgba = float(np.mean(cv2.absdiff(i_rgba, truth)))
+        d_bgra = float(np.mean(cv2.absdiff(i_bgra, truth)))
         if d_rgba < 3 and d_bgra < 3:
+            return None
+        if abs(d_rgba - d_bgra) < NemuIpcImpl.CHANNEL_DECIDE_MARGIN:
             return None
         return 'rgba' if d_rgba <= d_bgra else 'bgra'
 
@@ -722,38 +754,82 @@ class NemuIpc(Platform):
             logger.warning(f'[设备-NemuIpc] 通道序校准失败: {e}')
             return None
 
-    def _resolve_channel_order(self, impl) -> str:
-        """
-        确定截图通道序：手动配置 > ADB 真值校准（auto）> 按 SDK 架构推断。
+    # 未校准时的重试间隔（秒）。启动瞬间常是黑屏加载页，校准会落空；
+    # 若只做一次就沿用推断值，整个会话都会红蓝互换，因此带冷却重试。
+    CHANNEL_RECALIBRATE_INTERVAL = 2.0
 
-        auto 校准成功时把实测值写入配置（Emulator.NemuIpcChannelDetected）
-        持久化，供用户查看；配置文件随 MuMu 更新后再次启动自动重新校准。
+    def _fallback_channel_order(self, impl) -> str:
+        """
+        校准尚未成功时使用的临时通道序。
+
+        优先复用上次会话校准成功并持久化的实测值
+        （Emulator.NemuIpcChannelDetected），其次才按 SDK 架构推断；两者都只是
+        过渡值，_ensure_channel_order() 会继续重试校准。
+
+        Args:
+            impl (NemuIpcImpl): 已连接的 IPC 实例。
+
+        Returns:
+            str: 'rgba' / 'bgra'
+        """
+        detected = str(getattr(self.config, 'Emulator_NemuIpcChannelDetected', '') or '')
+        if detected in ('rgba', 'bgra'):
+            return detected
+        return 'bgra' if impl.bgra_layout else 'rgba'
+
+    def _ensure_channel_order(self, impl) -> str:
+        """
+        确定本次截图使用的通道序。
+
+        优先级：手动配置 > 本会话已校准值 > ADB 真值校准 > 上次实测值/架构推断。
+        未确认（未校准）时按 CHANNEL_RECALIBRATE_INTERVAL 冷却重试，避免加载页
+        黑屏等无特征画面让校准落空后整程用错通道序；校准成功时把实测值写入配置
+        （Emulator.NemuIpcChannelDetected）持久化，供下次兜底并供用户查看。
+
+        Args:
+            impl (NemuIpcImpl): 已连接的 IPC 实例。
+
+        Returns:
+            str: 'rgba' / 'bgra'
         """
         order = str(self.config.Emulator_NemuIpcChannel or 'auto')
         if order in ('rgba', 'bgra'):
-            logger.info(f'[设备-NemuIpc] 通道序使用手动配置: {order}')
+            if impl.channel_order != order:
+                logger.info(f'[设备-NemuIpc] 通道序使用手动配置: {order}')
+            impl.channel_order = order
+            impl.channel_order_verified = True
             return order
 
-        detected = self.nemu_ipc_calibrate_channel(impl)
-        if detected:
-            try:
-                self.config.Emulator_NemuIpcChannelDetected = detected
-            except Exception as e:
-                logger.warning(f'[设备-NemuIpc] 校准结果写入配置失败: {e}')
-            logger.attr('NemuIpc 通道序', f'{detected}（自动校准）')
-            return detected
+        if impl.channel_order_verified:
+            return impl.channel_order
 
-        fallback = 'bgra' if impl.bgra_layout else 'rgba'
-        logger.info(f'[设备-NemuIpc] 通道序回退为按 SDK 架构推断: {fallback}')
-        return fallback
+        now = time.time()
+        if now - impl.channel_order_last_try >= self.CHANNEL_RECALIBRATE_INTERVAL:
+            impl.channel_order_last_try = now
+            detected = self.nemu_ipc_calibrate_channel(impl)
+            if detected:
+                impl.channel_order = detected
+                impl.channel_order_verified = True
+                try:
+                    self.config.Emulator_NemuIpcChannelDetected = detected
+                except Exception as e:
+                    logger.warning(f'[设备-NemuIpc] 校准结果写入配置失败: {e}')
+                logger.attr('NemuIpc 通道序', f'{detected}（自动校准）')
+                return detected
+            if impl.channel_order is None:
+                impl.channel_order = self._fallback_channel_order(impl)
+                logger.warning(
+                    f'[设备-NemuIpc] 通道序尚未校准，暂用 {impl.channel_order}，'
+                    f'{self.CHANNEL_RECALIBRATE_INTERVAL:g}s 后重试'
+                )
+        return impl.channel_order
 
     def screenshot_nemu_ipc(self):
         impl = self.nemu_ipc
-        if impl.channel_order is None:
-            impl.channel_order = self._resolve_channel_order(impl)
+        channel_order = self._ensure_channel_order(impl)
 
         image = impl.screenshot()
-        if impl.channel_order == 'bgra':
+        if channel_order == 'bgra':
             image = cv2.cvtColor(image, cv2.COLOR_BGRA2RGB)
         else:
             image = cv2.cvtColor(image, cv2.COLOR_RGBA2RGB)

--- a/module/device/method/nemu_ipc.py
+++ b/module/device/method/nemu_ipc.py
@@ -346,7 +346,8 @@ class NemuIpcImpl:
 
         Args:
             raw: nemu_capture_display 的原始帧（4 通道、上下颠倒）。
-            truth: ADB screencap 的 RGB 真值帧，尺寸与 raw 一致。
+            truth: ADB screencap 的 RGB 真值帧（RGB 内存，与代码库其余
+                截图一致），尺寸与 raw 一致。
 
         Returns:
             str: 'rgba' / 'bgra'；画面无特征（如全黑加载页，两种解释
@@ -725,6 +726,9 @@ class NemuIpc(Platform):
             if truth is None:
                 logger.warning('[设备-NemuIpc] 通道序校准失败: ADB screencap 无输出')
                 return None
+            # imdecode 得到 BGR 内存，_decide_channel_order 按代码库统一的
+            # RGB 内存比较，不转换会让判定恒定取反（红蓝反转，见单元测试）
+            cv2.cvtColor(truth, cv2.COLOR_BGR2RGB, dst=truth)
             raw = impl.screenshot(timeout=2)
             result = NemuIpcImpl._decide_channel_order(raw, truth)
             if result is None:

--- a/tests/test_nemu_ipc_dll.py
+++ b/tests/test_nemu_ipc_dll.py
@@ -13,7 +13,7 @@ import unittest
 import cv2
 import numpy as np
 
-from module.device.method.nemu_ipc import NemuIpcImpl
+from module.device.method.nemu_ipc import NemuIpc, NemuIpcImpl
 
 
 def build_fake_install(root, versions=('12.0',), instance_names=('MuMuPlayer-12.0-0',)):
@@ -193,6 +193,43 @@ class TestDecideChannelOrder(unittest.TestCase):
         frame = np.zeros((64, 64, 3), dtype=np.uint8)
         raw = self._make_raw(frame)
         self.assertIsNone(NemuIpcImpl._decide_channel_order(raw, frame))
+
+
+class TestCalibrateChannelOrder(unittest.TestCase):
+    """校准调用方的真值帧约定回归。
+
+    cv2.imdecode 得到 BGR 内存，而 _decide_channel_order 按代码库统一的
+    RGB 内存比较；调用方漏了 BGR2RGB 时判定恒定取反，nemu_ipc 截图红蓝
+    反转会导致按钮认不出来（2026-09-13 智能调度卡死即由此引起）。
+    这里走真实调用方，只把 ADB 与 IPC 换成假实现。
+    """
+
+    @staticmethod
+    def _png_of(frame):
+        """把 RGB 内存帧编码为 screencap 风格的 PNG 字节。"""
+        bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+        return cv2.imencode('.png', bgr)[1].tobytes()
+
+    def _calibrate(self, frame, raw):
+        class _Host:
+            adb_exec_out = staticmethod(lambda args: self._png_of(frame))
+
+        class _Impl:
+            screenshot = staticmethod(lambda timeout=0: raw)
+
+        return NemuIpc.nemu_ipc_calibrate_channel(_Host, _Impl)
+
+    def test_rgba_raw_detected_as_rgba(self):
+        frame = np.zeros((64, 64, 3), dtype=np.uint8)
+        frame[:, :, 2] = 200  # 蓝色画面
+        raw = cv2.flip(cv2.cvtColor(frame, cv2.COLOR_RGB2RGBA), 0)
+        self.assertEqual(self._calibrate(frame, raw), 'rgba')
+
+    def test_bgra_raw_detected_as_bgra(self):
+        frame = np.zeros((64, 64, 3), dtype=np.uint8)
+        frame[:, :, 0] = 200  # 红色画面
+        raw = cv2.flip(cv2.cvtColor(frame, cv2.COLOR_RGB2BGRA), 0)
+        self.assertEqual(self._calibrate(frame, raw), 'bgra')
 
 
 if __name__ == '__main__':

--- a/tests/test_nemu_ipc_dll.py
+++ b/tests/test_nemu_ipc_dll.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 import cv2
 import numpy as np
@@ -230,6 +231,100 @@ class TestCalibrateChannelOrder(unittest.TestCase):
         frame[:, :, 0] = 200  # 红色画面
         raw = cv2.flip(cv2.cvtColor(frame, cv2.COLOR_RGB2BGRA), 0)
         self.assertEqual(self._calibrate(frame, raw), 'bgra')
+
+
+class TestDecideChannelOrderRobustness(unittest.TestCase):
+    """判定要对采样间隔内的画面变化与分辨率差保持鲁棒，
+    并在红蓝接近时承认判不出来，交给调用方稍后重试。
+    """
+
+    @staticmethod
+    def _frames(frame):
+        """由 RGB 画面构造 nemu 原始帧（RGBA、上下颠倒）。"""
+        return cv2.flip(cv2.cvtColor(frame, cv2.COLOR_RGB2RGBA), 0), frame
+
+    def test_shifted_truth_still_decides(self):
+        """真值帧与原始帧相差半帧画面（动画）时仍能判定通道序。"""
+        frame = np.zeros((128, 128, 3), dtype=np.uint8)
+        frame[:64, :, 2] = 200  # 上半蓝
+        frame[64:, :, 0] = 200  # 下半红
+        raw, truth = self._frames(frame)
+        shifted = np.roll(truth, 8, axis=0)  # 模拟两个采样之间的位移
+        self.assertEqual(NemuIpcImpl._decide_channel_order(raw, shifted), 'rgba')
+
+    def test_truth_resolution_mismatch_is_resized(self):
+        """ADB 真值与 IPC 缓冲分辨率不一致时应缩放后比较，而不是抛异常。"""
+        frame = np.zeros((128, 128, 3), dtype=np.uint8)
+        frame[:, :, 2] = 200  # 纯蓝
+        raw, truth = self._frames(frame)
+        smaller = cv2.resize(truth, (64, 64), interpolation=cv2.INTER_AREA)
+        self.assertEqual(NemuIpcImpl._decide_channel_order(raw, smaller), 'rgba')
+
+    def test_nearly_symmetric_color_is_inconclusive(self):
+        """红蓝接近的画面（灰阶/单色 UI）判不出通道序，应返回 None。"""
+        frame = np.zeros((64, 64, 3), dtype=np.uint8)
+        frame[:, :, 0] = 100
+        frame[:, :, 1] = 60
+        frame[:, :, 2] = 101
+        raw, truth = self._frames(frame)
+        self.assertIsNone(NemuIpcImpl._decide_channel_order(raw, truth))
+
+
+class TestEnsureChannelOrder(unittest.TestCase):
+    """未校准时的临时值选择与冷却重试。
+
+    启动瞬间多为黑屏加载页，校准会返回 None；若就此固定成按 SDK 路径的
+    推断值，整个会话都会红蓝互换（实测 MuMu15.0 nx_device 为 RGBA，而推断
+    会说 BGRA），所以要能拿到上次实测值并在稍后自动纠正。
+    """
+
+    class _Config:
+        def __init__(self, manual='auto', detected=''):
+            self.Emulator_NemuIpcChannel = manual
+            self.Emulator_NemuIpcChannelDetected = detected
+
+    class _Impl:
+        def __init__(self, bgra_layout=True):
+            self.bgra_layout = bgra_layout
+            self.channel_order = None
+            self.channel_order_verified = False
+            self.channel_order_last_try = 0.0
+
+    class _Host(NemuIpc):
+        def __init__(self, config, results):
+            self.config = config
+            self.results = list(results)
+            self.calls = 0
+
+        def nemu_ipc_calibrate_channel(self, impl):
+            self.calls += 1
+            return self.results.pop(0) if self.results else None
+
+    def test_manual_config_wins_and_skips_calibration(self):
+        config = self._Config(manual='bgra', detected='rgba')
+        host = self._Host(config, ['rgba'])
+        impl = self._Impl()
+        self.assertEqual(NemuIpc._ensure_channel_order(host, impl), 'bgra')
+        self.assertEqual(host.calls, 0)
+        self.assertTrue(impl.channel_order_verified)
+
+    def test_fallback_prefers_last_measured_value(self):
+        config = self._Config(manual='auto', detected='rgba')
+        host = self._Host(config, [None])  # 校准失败（如黑屏）
+        impl = self._Impl(bgra_layout=True)  # 路径推断会说 bgra
+        self.assertEqual(NemuIpc._ensure_channel_order(host, impl), 'rgba')
+        self.assertFalse(impl.channel_order_verified)
+
+    def test_retry_corrects_after_featureless_start(self):
+        config = self._Config(manual='auto', detected='')
+        host = self._Host(config, [None, 'rgba'])
+        impl = self._Impl(bgra_layout=True)
+        with mock.patch.object(NemuIpc, 'CHANNEL_RECALIBRATE_INTERVAL', 0.0):
+            self.assertEqual(NemuIpc._ensure_channel_order(host, impl), 'bgra')
+            self.assertEqual(NemuIpc._ensure_channel_order(host, impl), 'rgba')
+        self.assertTrue(impl.channel_order_verified)
+        self.assertEqual(config.Emulator_NemuIpcChannelDetected, 'rgba')
+        self.assertEqual(host.calls, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 背景

#930 已经修掉了校准真值的 BGR/RGB 混用，`_decide_channel_order()` 由此能得出正确结论。
但通道序的确定仍只在「启动时校准成功」这一条路上可靠，另一条路会把整程带偏：

- 启动瞬间通常是黑屏加载页，两种解释都接近真值 ⇒ `_decide_channel_order()` 返回 None；
- 此时原实现直接固定成「按 SDK 架构推断」（nx_device ⇒ **BGRA**），而实测 MuMu15.0 的
  nx_device SDK 是 **RGBA**（见验证）；
- 之后 `impl.channel_order` 不再变化 ⇒ **整个会话的截图红蓝互换**，所有颜色类判定
  （`Button.appear_on`、Navbar/Switch 活跃色、进度条…）都会失真，而且不会报错。

## 改动（`module/device/method/nemu_ipc.py`）

1. `_resolve_channel_order()` → `_ensure_channel_order()`：未确认（未校准）时按
   `CHANNEL_RECALIBRATE_INTERVAL`（2s）**冷却重试**，校准成功即覆盖并写回
   `Emulator.NemuIpcChannelDetected`；手动配置仍最高优先级且不触发校准。
2. 新增 `_fallback_channel_order()`：未校准时的临时值**优先复用上次实测值**
   （`NemuIpcChannelDetected`），最后才用 SDK 路径推断，不再是纯猜测。
3. `_decide_channel_order()`：
   - 比对前**降采样 1/8**——ADB 真值与 IPC 帧之间存在采样间隔，动画/撕裂的位移
     不应压过颜色通道特征；
   - 真值分辨率与原始帧不一致时先缩放（此前会直接抛异常，被调用方的 try/except
     吞掉后校准被永久跳过）；
   - 两种解释差距小于 `CHANNEL_DECIDE_MARGIN`（2.0）时返回 None——判不准就交给
     重试，而不是赌一个。
4. `bgra_layout` 文档更新：注明它只是最后的兜底，且历史结论（nx_device 为 BGRA）
   出自与校准相同的比对代码，实测 MuMu15.0 为 RGBA。

## 验证

1. `python -m unittest tests.test_nemu_ipc_dll` → **19 项通过**（新增 6 项：位移/分辨率
   不一致仍能判定、灰阶判不准、未校准时用实测值兜底、冷却后重试纠正、手动配置优先）。
2. 真机（MuMu15.0 + 1280x720，nx_device/15.0 SDK）用仓库实现跑 `_ensure_channel_order()`：

   ```text
   判定 = rgba | verified = True | 写入配置 = rgba
   复核  d_rgba=2.63  d_bgra=16.45  => 真值 rgba（ADB 真值比对）
   ```

3. 全量单测 554 项：失败/错误与上游基线（stash 后同环境重跑）**完全一致**
   （worker registry / commission planner / farming combat config 等既存问题），
   nemu_ipc 相关无新增失败。

## 备注

- 与 #929（触控坐标二次旋转）同源但不同处：触控那条已由 `767fa3f2d` 修掉，本 PR 收尾
  截图通道序这条链路（#929 已关闭）。
- 复现/验证手法可复用：以 ADB screencap 为真值，对同一时刻的 IPC 帧施加候选变换后比
  差值，取最小者。

## Sourcery 摘要

使 Nemu IPC 通道顺序检测具备可重试性并基于证据进行判断，从而确保在不同模拟器启动状态和 SDK 变体下截图颜色保持正确。

Bug 修复：
- 防止在启动校准结果不明确时，Nemu IPC 截图持续锁定到错误的推断通道顺序，避免红蓝颜色长期颠倒。
- 基于 RGB 真值帧修正通道顺序校准，并增强其对帧位移、分辨率差异和图像歧义的处理能力。

增强功能：
- 在冷却时间后重试自动通道顺序校准，复用上次已验证的顺序作为回退方案，并持久化新验证的结果，同时保留手动配置的优先级。

文档：
- 明确说明，基于 SDK 的 BGRA 检测仅作为最终回退方案，可能无法反映实际的通道顺序。

测试：
- 增加针对校准颜色转换、帧偏移、分辨率不匹配、图像信息不足、回退选择和重试修正的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Nemu IPC channel-order detection retryable and evidence-based so screenshot colors remain correct across emulator startup and SDK variants.

Bug Fixes:
- Prevent Nemu IPC screenshots from remaining locked to an incorrect inferred channel order when startup calibration is inconclusive, avoiding persistent red/blue color swaps.
- Correct channel-order calibration against RGB truth frames and make it robust to frame displacement, resolution differences, and ambiguous imagery.

Enhancements:
- Retry automatic channel-order calibration after a cooldown, reuse the last verified order as a fallback, and persist newly verified results while preserving manual configuration priority.

Documentation:
- Clarify that SDK-based BGRA detection is only a final fallback and may not reflect the actual channel order.

Tests:
- Add regression coverage for calibration color conversion, frame shifts, resolution mismatches, inconclusive images, fallback selection, and retry correction.

</details>